### PR TITLE
feat: add prediction market profiles

### DIFF
--- a/apps/web/src/app/api/cron/markets-tick/route.ts
+++ b/apps/web/src/app/api/cron/markets-tick/route.ts
@@ -74,6 +74,7 @@ import {
   type DailyTopicContext,
   dailyTopicService,
   deriveTopicFromText,
+  getPredictionMarketInitialization,
   isEligibleActor,
   mapGranularToDbTimeframe,
   normalizeTopicDate,
@@ -113,12 +114,6 @@ export const dynamic = 'force-dynamic';
  * Consistent with QuestionManager defaults.
  */
 const DEFAULT_SCENARIO_ID = 1;
-
-/**
- * Default initial liquidity for new markets (in base units).
- * This determines the initial AMM pool depth.
- */
-const DEFAULT_INITIAL_LIQUIDITY = 20000;
 
 /**
  * Default time budget for tick execution in milliseconds.
@@ -1996,10 +1991,16 @@ async function createMarketForTimeframe(
         wallet: MOCK_WALLET,
         fees: SYSTEM_MARKET_FEES,
       });
+      const marketInitialization = getPredictionMarketInitialization({
+        marketId: questionId,
+        question: questionData.text,
+        endDate: resolutionDate,
+      });
 
       market = await marketService.ensureMarketExists({
         marketId: questionId,
-        initialLiquidity: DEFAULT_INITIAL_LIQUIDITY,
+        initialLiquidity: marketInitialization.initialLiquidity,
+        initialYesProbability: marketInitialization.initialYesProbability,
         description: questionData.resolutionCriteria,
         gameId: gameState.id,
         dayNumber: gameState.currentDay,
@@ -2517,10 +2518,16 @@ async function createSubMarket(
         wallet: MOCK_WALLET,
         fees: SYSTEM_MARKET_FEES,
       });
+      const marketInitialization = getPredictionMarketInitialization({
+        marketId: questionId,
+        question: questionData.text,
+        endDate: resolutionDate,
+      });
 
       await marketService.ensureMarketExists({
         marketId: questionId,
-        initialLiquidity: DEFAULT_INITIAL_LIQUIDITY,
+        initialLiquidity: marketInitialization.initialLiquidity,
+        initialYesProbability: marketInitialization.initialYesProbability,
         description: questionData.resolutionCriteria,
         gameId: gameState.id,
         dayNumber: gameState.currentDay,

--- a/packages/core/markets/prediction/PredictionMarketService.ts
+++ b/packages/core/markets/prediction/PredictionMarketService.ts
@@ -50,6 +50,7 @@ export class PredictionMarketService {
   async ensureMarketExists(input: {
     marketId: string;
     initialLiquidity?: number;
+    initialYesProbability?: number;
     description?: string | null;
     gameId?: string | null;
     dayNumber?: number | null;
@@ -68,6 +69,7 @@ export class PredictionMarketService {
         description: input.description,
         gameId: input.gameId,
         dayNumber: input.dayNumber,
+        initialYesProbability: input.initialYesProbability,
       }
     );
   }

--- a/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
+++ b/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
@@ -17,6 +17,7 @@ import type {
   PredictionSide,
   QuestionRecord,
 } from '../../types';
+import { PredictionPricing } from '../../pricing';
 
 type NewMarket = InferInsertModel<typeof markets>;
 type NewPosition = InferInsertModel<typeof positions>;
@@ -192,18 +193,22 @@ export class PredictionDbAdapter implements PredictionDbPort {
       description?: string | null;
       gameId?: string | null;
       dayNumber?: number | null;
+      initialYesProbability?: number;
     }
   ): Promise<PredictionMarketRecord> {
     const now = new Date();
-    const liquidityHalf = initialLiquidity / 2;
+    const { yesShares, noShares } = PredictionPricing.initializeMarket(
+      initialLiquidity,
+      options?.initialYesProbability ?? 0.5
+    );
     const data: NewMarket = {
       id: question.id,
       question: question.text,
       description: options?.description ?? null,
       gameId: options?.gameId ?? 'continuous',
       dayNumber: options?.dayNumber ?? null,
-      yesShares: String(liquidityHalf),
-      noShares: String(liquidityHalf),
+      yesShares: String(yesShares),
+      noShares: String(noShares),
       liquidity: String(initialLiquidity),
       resolved: false,
       resolution: null,

--- a/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
+++ b/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
@@ -9,6 +9,7 @@ import {
 import { generateSnowflakeId } from '@babylon/shared';
 import type { InferInsertModel } from 'drizzle-orm';
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
+import { PredictionPricing } from '../../pricing';
 import type {
   PredictionDbPort,
   PredictionMarketRecord,
@@ -17,7 +18,6 @@ import type {
   PredictionSide,
   QuestionRecord,
 } from '../../types';
-import { PredictionPricing } from '../../pricing';
 
 type NewMarket = InferInsertModel<typeof markets>;
 type NewPosition = InferInsertModel<typeof positions>;

--- a/packages/core/markets/prediction/pricing.ts
+++ b/packages/core/markets/prediction/pricing.ts
@@ -68,11 +68,11 @@ export class PredictionPricing {
   /**
    * Initialize a market with configurable starting probability and liquidity.
    */
-  static initializeMarket(
-    initialLiquidity = 10_000,
-    yesProbability = 0.5
-  ) {
-    const clampedYesProbability = Math.max(0.05, Math.min(0.95, yesProbability));
+  static initializeMarket(initialLiquidity = 10_000, yesProbability = 0.5) {
+    const clampedYesProbability = Math.max(
+      0.05,
+      Math.min(0.95, yesProbability)
+    );
     const noShares = Math.max(1, initialLiquidity * clampedYesProbability);
     const yesShares = Math.max(1, initialLiquidity - noShares);
     return { yesShares, noShares };

--- a/packages/core/markets/prediction/pricing.ts
+++ b/packages/core/markets/prediction/pricing.ts
@@ -66,14 +66,14 @@ export class PredictionPricing {
   }
 
   /**
-   * Initialize a market with symmetric liquidity.
+   * Initialize a market with configurable starting probability and liquidity.
    */
   static initializeMarket(
     initialLiquidity = 10_000,
     yesProbability = 0.5
   ) {
     const clampedYesProbability = Math.max(0.05, Math.min(0.95, yesProbability));
-    const noShares = initialLiquidity * clampedYesProbability;
+    const noShares = Math.max(1, initialLiquidity * clampedYesProbability);
     const yesShares = Math.max(1, initialLiquidity - noShares);
     return { yesShares, noShares };
   }

--- a/packages/core/markets/prediction/pricing.ts
+++ b/packages/core/markets/prediction/pricing.ts
@@ -68,9 +68,14 @@ export class PredictionPricing {
   /**
    * Initialize a market with symmetric liquidity.
    */
-  static initializeMarket(initialLiquidity = 10_000) {
-    const half = initialLiquidity / 2;
-    return { yesShares: half, noShares: half };
+  static initializeMarket(
+    initialLiquidity = 10_000,
+    yesProbability = 0.5
+  ) {
+    const clampedYesProbability = Math.max(0.05, Math.min(0.95, yesProbability));
+    const noShares = initialLiquidity * clampedYesProbability;
+    const yesShares = Math.max(1, initialLiquidity - noShares);
+    return { yesShares, noShares };
   }
 
   static calculateBuy(

--- a/packages/core/markets/prediction/types.ts
+++ b/packages/core/markets/prediction/types.ts
@@ -89,6 +89,7 @@ export interface PredictionDbPort {
       description?: string | null;
       gameId?: string | null;
       dayNumber?: number | null;
+      initialYesProbability?: number;
     }
   ): Promise<PredictionMarketRecord>;
   updateMarketState(

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -93,6 +93,7 @@ import {
   filterIncoherent as filterIncoherentBase,
   validateCoherence,
 } from './services/content-grounding-validator';
+import { buildPredictionMarketProfile } from './services/prediction-market-profiles';
 
 /**
  * Wrapper around filterIncoherent that logs when items are filtered out.
@@ -1417,8 +1418,6 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
     const scenarioId = 1;
     const now = new Date();
     const currentTopic = await dailyTopicService.ensureTopicForDate(now);
-    const initialLiquidity = 20000;
-
     const marketService = new CorePredictionMarketService({
       db: new CorePredictionDbAdapter(),
       // Not used for market creation, but required by the service deps type
@@ -1533,11 +1532,17 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
         questionResults,
         'Question insert returned empty'
       );
+      const marketProfile = buildPredictionMarketProfile({
+        marketId: question.id,
+        question: question.text,
+        endDate: resolutionDate,
+      });
 
       // Ensure market exists via core service (keeps creation logic portable)
       const market = await marketService.ensureMarketExists({
         marketId: question.id,
-        initialLiquidity,
+        initialLiquidity: marketProfile.initialLiquidity,
+        initialYesProbability: marketProfile.initialYesProbability,
         description: questionData.resolutionCriteria,
       });
 
@@ -1548,6 +1553,7 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
           questionNumber: question.questionNumber,
           resolutionDate: resolutionDate.toISOString(),
           daysUntilResolution,
+          initialLiquidity: marketProfile.initialLiquidity,
           marketEndDate: market.endDate.toISOString(),
         },
         'QuestionManager'

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -93,7 +93,7 @@ import {
   filterIncoherent as filterIncoherentBase,
   validateCoherence,
 } from './services/content-grounding-validator';
-import { buildPredictionMarketProfile } from './services/prediction-market-profiles';
+import { getPredictionMarketInitialization } from './services/prediction-market-profiles';
 
 /**
  * Wrapper around filterIncoherent that logs when items are filtered out.
@@ -1532,7 +1532,7 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
         questionResults,
         'Question insert returned empty'
       );
-      const marketProfile = buildPredictionMarketProfile({
+      const marketInitialization = getPredictionMarketInitialization({
         marketId: question.id,
         question: question.text,
         endDate: resolutionDate,
@@ -1541,8 +1541,8 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
       // Ensure market exists via core service (keeps creation logic portable)
       const market = await marketService.ensureMarketExists({
         marketId: question.id,
-        initialLiquidity: marketProfile.initialLiquidity,
-        initialYesProbability: marketProfile.initialYesProbability,
+        initialLiquidity: marketInitialization.initialLiquidity,
+        initialYesProbability: marketInitialization.initialYesProbability,
         description: questionData.resolutionCriteria,
       });
 
@@ -1553,7 +1553,7 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
           questionNumber: question.questionNumber,
           resolutionDate: resolutionDate.toISOString(),
           daysUntilResolution,
-          initialLiquidity: marketProfile.initialLiquidity,
+          initialLiquidity: marketInitialization.initialLiquidity,
           marketEndDate: market.endDate.toISOString(),
         },
         'QuestionManager'

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -64,12 +64,12 @@ export * from './event-market-linker'; // BAB-5: Event-market connection
 export * from './event-market-pipeline';
 export * from './market-metrics-service'; // BAB-5: Metrics-based question generation
 export * from './market-mover-agent';
-export * from './prediction-market-profiles';
 export * from './market-timeframes'; // Multi-timeframe market system
 export * from './onchain-market-service';
 export * from './onchain-perp-read-model';
 export * from './onchain-perp-service';
 export * from './perp-price-impact-port';
+export * from './prediction-market-profiles';
 export * from './price-update-service';
 export * from './signal-extraction-service';
 export * from './sub-market-service'; // Sub-market spawning

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -64,6 +64,7 @@ export * from './event-market-linker'; // BAB-5: Event-market connection
 export * from './event-market-pipeline';
 export * from './market-metrics-service'; // BAB-5: Metrics-based question generation
 export * from './market-mover-agent';
+export * from './prediction-market-profiles';
 export * from './market-timeframes'; // Multi-timeframe market system
 export * from './onchain-market-service';
 export * from './onchain-perp-read-model';

--- a/packages/engine/src/services/prediction-auto-amm-helpers.test.ts
+++ b/packages/engine/src/services/prediction-auto-amm-helpers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test';
+import { calculateAutoAmmTargetNudge } from './prediction-auto-amm-helpers';
+
+describe('prediction-auto-amm-helpers', () => {
+  it('reverts underpriced YES markets back toward 50/50 in neutral regime', () => {
+    const targetNudge = calculateAutoAmmTargetNudge({
+      currentYesPrice: 0.2,
+      signalDirection: 'NEUTRAL',
+      signalIntensity: 0,
+      signalSensitivity: 1,
+      autoAmmNudgeMultiplier: 1,
+      neutralReversionMultiplier: 1,
+    });
+
+    expect(targetNudge).toBeGreaterThan(0);
+  });
+
+  it('reverts overpriced YES markets back toward 50/50 in neutral regime', () => {
+    const targetNudge = calculateAutoAmmTargetNudge({
+      currentYesPrice: 0.8,
+      signalDirection: 'NEUTRAL',
+      signalIntensity: 0,
+      signalSensitivity: 1,
+      autoAmmNudgeMultiplier: 1,
+      neutralReversionMultiplier: 1,
+    });
+
+    expect(targetNudge).toBeLessThan(0);
+  });
+});

--- a/packages/engine/src/services/prediction-auto-amm-helpers.ts
+++ b/packages/engine/src/services/prediction-auto-amm-helpers.ts
@@ -1,0 +1,30 @@
+/** Base magnitude of auto-AMM price nudges per tick */
+export const BASE_NUDGE_PERCENT = 0.02;
+
+/** How strongly prices converge toward 50/50 when no signal */
+export const NEUTRAL_REVERSION_RATE = 0.005;
+
+export function calculateAutoAmmTargetNudge(params: {
+  currentYesPrice: number;
+  signalDirection: 'YES' | 'NO' | 'NEUTRAL';
+  signalIntensity: number;
+  signalSensitivity: number;
+  autoAmmNudgeMultiplier: number;
+  neutralReversionMultiplier: number;
+}): number {
+  if (params.signalDirection !== 'NEUTRAL') {
+    const nudge =
+      BASE_NUDGE_PERCENT *
+      params.signalIntensity *
+      params.signalSensitivity *
+      params.autoAmmNudgeMultiplier;
+    return params.signalDirection === 'YES' ? nudge : -nudge;
+  }
+
+  const deviation = params.currentYesPrice - 0.5;
+  return (
+    -deviation *
+    NEUTRAL_REVERSION_RATE *
+    params.neutralReversionMultiplier
+  );
+}

--- a/packages/engine/src/services/prediction-auto-amm-helpers.ts
+++ b/packages/engine/src/services/prediction-auto-amm-helpers.ts
@@ -23,8 +23,6 @@ export function calculateAutoAmmTargetNudge(params: {
 
   const deviation = params.currentYesPrice - 0.5;
   return (
-    -deviation *
-    NEUTRAL_REVERSION_RATE *
-    params.neutralReversionMultiplier
+    -deviation * NEUTRAL_REVERSION_RATE * params.neutralReversionMultiplier
   );
 }

--- a/packages/engine/src/services/prediction-auto-amm.ts
+++ b/packages/engine/src/services/prediction-auto-amm.ts
@@ -11,7 +11,9 @@
  */
 
 import { and, arcStates, db, eq, gte, markets } from '@babylon/db';
+import { PredictionPricing } from '@babylon/core/markets/prediction';
 import { logger } from '@babylon/shared';
+import { calculateAutoAmmTargetNudge } from './prediction-auto-amm-helpers';
 import { buildPredictionMarketProfile } from './prediction-market-profiles';
 
 // =============================================================================
@@ -34,9 +36,6 @@ interface AutoAMMResult {
 // Configuration
 // =============================================================================
 
-/** Base magnitude of auto-AMM price nudges per tick */
-const BASE_NUDGE_PERCENT = 0.02;
-
 /** State intensity multipliers — later arc states have stronger signals */
 const STATE_INTENSITY: Record<string, number> = {
   setup: 0.3,
@@ -55,9 +54,6 @@ const STATE_INTENSITY: Record<string, number> = {
   peak: 1.5,
   settling: 1.0,
 };
-
-/** How strongly prices converge toward 50/50 when no signal */
-const NEUTRAL_REVERSION_RATE = 0.005;
 
 // =============================================================================
 // Service
@@ -103,8 +99,11 @@ export async function processAutoAMM(): Promise<AutoAMMResult> {
 
       const yesShares = Number(market.yesShares || 1);
       const noShares = Number(market.noShares || 1);
-      const total = yesShares + noShares;
-      const currentYesPrice = yesShares / total;
+      const currentYesPrice = PredictionPricing.getCurrentPrice(
+        yesShares,
+        noShares,
+        'yes'
+      );
       const profile = buildPredictionMarketProfile({
         marketId: market.id,
         question: market.question,
@@ -113,23 +112,14 @@ export async function processAutoAMM(): Promise<AutoAMMResult> {
 
       const signal = arcSignals.get(market.id);
 
-      let targetNudge = 0;
-
-      if (signal && signal.direction !== 'NEUTRAL') {
-        const nudge =
-          BASE_NUDGE_PERCENT *
-          signal.stateIntensity *
-          profile.signalSensitivity *
-          profile.autoAmmNudgeMultiplier;
-        targetNudge = signal.direction === 'YES' ? nudge : -nudge;
-      } else {
-        // No signal — mild reversion toward 50/50
-        const deviation = currentYesPrice - 0.5;
-        targetNudge =
-          -deviation *
-          NEUTRAL_REVERSION_RATE *
-          profile.neutralReversionMultiplier;
-      }
+      const targetNudge = calculateAutoAmmTargetNudge({
+        currentYesPrice,
+        signalDirection: signal?.direction ?? 'NEUTRAL',
+        signalIntensity: signal?.stateIntensity ?? 0,
+        signalSensitivity: profile.signalSensitivity,
+        autoAmmNudgeMultiplier: profile.autoAmmNudgeMultiplier,
+        neutralReversionMultiplier: profile.neutralReversionMultiplier,
+      });
 
       // Skip negligible adjustments
       if (Math.abs(targetNudge) < 0.001) continue;
@@ -160,8 +150,11 @@ export async function processAutoAMM(): Promise<AutoAMMResult> {
 
       result.priceAdjustments++;
 
-      const newTotal = newYesShares + newNoShares;
-      const newYesPrice = newYesShares / newTotal;
+      const newYesPrice = PredictionPricing.getCurrentPrice(
+        newYesShares,
+        newNoShares,
+        'yes'
+      );
 
       logger.debug(
         `Auto-AMM: ${market.question.slice(0, 40)}... YES ${(currentYesPrice * 100).toFixed(1)}% → ${(newYesPrice * 100).toFixed(1)}%`,

--- a/packages/engine/src/services/prediction-auto-amm.ts
+++ b/packages/engine/src/services/prediction-auto-amm.ts
@@ -10,8 +10,8 @@
  * System-level trades with no NPC identity and no scoring impact.
  */
 
-import { and, arcStates, db, eq, gte, markets } from '@babylon/db';
 import { PredictionPricing } from '@babylon/core/markets/prediction';
+import { and, arcStates, db, eq, gte, markets } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import { calculateAutoAmmTargetNudge } from './prediction-auto-amm-helpers';
 import { buildPredictionMarketProfile } from './prediction-market-profiles';
@@ -99,6 +99,7 @@ export async function processAutoAMM(): Promise<AutoAMMResult> {
 
       const yesShares = Number(market.yesShares || 1);
       const noShares = Number(market.noShares || 1);
+      const total = yesShares + noShares;
       const currentYesPrice = PredictionPricing.getCurrentPrice(
         yesShares,
         noShares,

--- a/packages/engine/src/services/prediction-auto-amm.ts
+++ b/packages/engine/src/services/prediction-auto-amm.ts
@@ -12,6 +12,7 @@
 
 import { and, arcStates, db, eq, gte, markets } from '@babylon/db';
 import { logger } from '@babylon/shared';
+import { buildPredictionMarketProfile } from './prediction-market-profiles';
 
 // =============================================================================
 // Types
@@ -104,18 +105,30 @@ export async function processAutoAMM(): Promise<AutoAMMResult> {
       const noShares = Number(market.noShares || 1);
       const total = yesShares + noShares;
       const currentYesPrice = yesShares / total;
+      const profile = buildPredictionMarketProfile({
+        marketId: market.id,
+        question: market.question,
+        endDate: market.endDate,
+      });
 
       const signal = arcSignals.get(market.id);
 
       let targetNudge = 0;
 
       if (signal && signal.direction !== 'NEUTRAL') {
-        const nudge = BASE_NUDGE_PERCENT * signal.stateIntensity;
+        const nudge =
+          BASE_NUDGE_PERCENT *
+          signal.stateIntensity *
+          profile.signalSensitivity *
+          profile.autoAmmNudgeMultiplier;
         targetNudge = signal.direction === 'YES' ? nudge : -nudge;
       } else {
         // No signal — mild reversion toward 50/50
         const deviation = currentYesPrice - 0.5;
-        targetNudge = -deviation * NEUTRAL_REVERSION_RATE;
+        targetNudge =
+          -deviation *
+          NEUTRAL_REVERSION_RATE *
+          profile.neutralReversionMultiplier;
       }
 
       // Skip negligible adjustments

--- a/packages/engine/src/services/prediction-market-profiles.test.ts
+++ b/packages/engine/src/services/prediction-market-profiles.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test';
+import { buildPredictionMarketProfile } from './prediction-market-profiles';
+
+describe('prediction-market-profiles', () => {
+  it('builds deterministic profiles for the same market input', () => {
+    const input = {
+      marketId: 'market-1',
+      question: 'Will OpenAGI release a new model this week?',
+      endDate: new Date('2026-04-03T23:59:59.000Z'),
+      now: new Date('2026-04-01T12:00:00.000Z'),
+    };
+
+    expect(buildPredictionMarketProfile(input)).toEqual(
+      buildPredictionMarketProfile(input)
+    );
+  });
+
+  it('assigns different liquidity and behavior across horizons', () => {
+    const now = new Date('2026-04-01T12:00:00.000Z');
+    const short = buildPredictionMarketProfile({
+      marketId: 'market-short',
+      question: 'Will OpenAGI announce a partnership tomorrow?',
+      endDate: new Date('2026-04-02T23:59:59.000Z'),
+      now,
+    });
+    const long = buildPredictionMarketProfile({
+      marketId: 'market-long',
+      question: 'Will OpenAGI complete an acquisition next week?',
+      endDate: new Date('2026-04-08T23:59:59.000Z'),
+      now,
+    });
+
+    expect(short.horizonBucket).toBe('short');
+    expect(long.horizonBucket).toBe('long');
+    expect(short.initialLiquidity).toBeLessThan(long.initialLiquidity);
+    expect(short.signalSensitivity).toBeGreaterThan(long.signalSensitivity);
+    expect(short.neutralReversionMultiplier).toBeLessThan(
+      long.neutralReversionMultiplier
+    );
+  });
+
+  it('keeps opening prior anchored around 50/50', () => {
+    const profile = buildPredictionMarketProfile({
+      marketId: 'market-2',
+      question: 'Will AINBC publish a correction by Friday?',
+      endDate: new Date('2026-04-05T23:59:59.000Z'),
+      now: new Date('2026-04-01T12:00:00.000Z'),
+    });
+
+    expect(profile.initialYesProbability).toBe(0.5);
+  });
+});

--- a/packages/engine/src/services/prediction-market-profiles.ts
+++ b/packages/engine/src/services/prediction-market-profiles.ts
@@ -7,6 +7,11 @@ export interface PredictionMarketProfile {
   neutralReversionMultiplier: number;
 }
 
+export interface PredictionMarketInitialization {
+  initialLiquidity: number;
+  initialYesProbability: number;
+}
+
 const HORIZON_PRESETS: Record<
   PredictionMarketProfile['horizonBucket'],
   Omit<PredictionMarketProfile, 'horizonBucket' | 'initialYesProbability'>
@@ -90,5 +95,18 @@ export function buildPredictionMarketProfile(input: {
       0.75,
       1.35
     ),
+  };
+}
+
+export function getPredictionMarketInitialization(input: {
+  marketId: string;
+  question: string;
+  endDate: Date;
+  now?: Date;
+}): PredictionMarketInitialization {
+  const profile = buildPredictionMarketProfile(input);
+  return {
+    initialLiquidity: profile.initialLiquidity,
+    initialYesProbability: profile.initialYesProbability,
   };
 }

--- a/packages/engine/src/services/prediction-market-profiles.ts
+++ b/packages/engine/src/services/prediction-market-profiles.ts
@@ -1,0 +1,94 @@
+export interface PredictionMarketProfile {
+  horizonBucket: 'short' | 'medium' | 'long';
+  initialLiquidity: number;
+  initialYesProbability: number;
+  signalSensitivity: number;
+  autoAmmNudgeMultiplier: number;
+  neutralReversionMultiplier: number;
+}
+
+const HORIZON_PRESETS: Record<
+  PredictionMarketProfile['horizonBucket'],
+  Omit<PredictionMarketProfile, 'horizonBucket' | 'initialYesProbability'>
+> = {
+  short: {
+    initialLiquidity: 12_000,
+    signalSensitivity: 1.18,
+    autoAmmNudgeMultiplier: 1.12,
+    neutralReversionMultiplier: 0.82,
+  },
+  medium: {
+    initialLiquidity: 18_000,
+    signalSensitivity: 1,
+    autoAmmNudgeMultiplier: 1,
+    neutralReversionMultiplier: 1,
+  },
+  long: {
+    initialLiquidity: 24_000,
+    signalSensitivity: 0.86,
+    autoAmmNudgeMultiplier: 0.88,
+    neutralReversionMultiplier: 1.16,
+  },
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function stableUnit(seed: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 4294967295;
+}
+
+function getHorizonBucket(endDate: Date, now: Date): PredictionMarketProfile['horizonBucket'] {
+  const daysToResolution = Math.max(
+    0,
+    (endDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  if (daysToResolution <= 2) return 'short';
+  if (daysToResolution <= 5) return 'medium';
+  return 'long';
+}
+
+export function buildPredictionMarketProfile(input: {
+  marketId: string;
+  question: string;
+  endDate: Date;
+  now?: Date;
+}): PredictionMarketProfile {
+  const now = input.now ?? new Date();
+  const horizonBucket = getHorizonBucket(input.endDate, now);
+  const preset = HORIZON_PRESETS[horizonBucket];
+  const seedBase = `${input.marketId}:${input.question.toLowerCase()}`;
+
+  const liquidityJitter = 0.9 + stableUnit(`${seedBase}:liq`) * 0.24;
+  const sensitivityJitter = 0.92 + stableUnit(`${seedBase}:signal`) * 0.16;
+  const nudgeJitter = 0.92 + stableUnit(`${seedBase}:nudge`) * 0.16;
+  const reversionJitter = 0.92 + stableUnit(`${seedBase}:revert`) * 0.16;
+
+  return {
+    horizonBucket,
+    initialLiquidity: Math.round(preset.initialLiquidity * liquidityJitter),
+    initialYesProbability: 0.5,
+    signalSensitivity: clamp(
+      preset.signalSensitivity * sensitivityJitter,
+      0.7,
+      1.35
+    ),
+    autoAmmNudgeMultiplier: clamp(
+      preset.autoAmmNudgeMultiplier * nudgeJitter,
+      0.75,
+      1.3
+    ),
+    neutralReversionMultiplier: clamp(
+      preset.neutralReversionMultiplier * reversionJitter,
+      0.75,
+      1.35
+    ),
+  };
+}

--- a/packages/engine/src/services/prediction-market-profiles.ts
+++ b/packages/engine/src/services/prediction-market-profiles.ts
@@ -49,7 +49,10 @@ function stableUnit(seed: string): number {
   return (hash >>> 0) / 4294967295;
 }
 
-function getHorizonBucket(endDate: Date, now: Date): PredictionMarketProfile['horizonBucket'] {
+function getHorizonBucket(
+  endDate: Date,
+  now: Date
+): PredictionMarketProfile['horizonBucket'] {
   const daysToResolution = Math.max(
     0,
     (endDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)

--- a/packages/testing/unit/prediction-pricing-correctness.test.ts
+++ b/packages/testing/unit/prediction-pricing-correctness.test.ts
@@ -356,6 +356,18 @@ describe('initializeMarket', () => {
     expect(yesPrice).toBeCloseTo(0.55, 10);
     expect(noPrice).toBeCloseTo(0.45, 10);
   });
+
+  test('clamps extreme initialization probabilities into safe bounds', () => {
+    const low = PredictionPricing.initializeMarket(10_000, 0.01);
+    const high = PredictionPricing.initializeMarket(10_000, 0.99);
+
+    expect(
+      PredictionPricing.getCurrentPrice(low.yesShares, low.noShares, 'yes')
+    ).toBeCloseTo(0.05, 10);
+    expect(
+      PredictionPricing.getCurrentPrice(high.yesShares, high.noShares, 'yes')
+    ).toBeCloseTo(0.95, 10);
+  });
 });
 
 // ─── getCurrentPrice ────────────────────────────────────────────────────────

--- a/packages/testing/unit/prediction-pricing-correctness.test.ts
+++ b/packages/testing/unit/prediction-pricing-correctness.test.ts
@@ -340,6 +340,22 @@ describe('initializeMarket', () => {
     expect(yesPrice).toBe(0.5);
     expect(noPrice).toBe(0.5);
   });
+
+  test('supports explicit non-neutral initialization when requested', () => {
+    const market = PredictionPricing.initializeMarket(10_000, 0.55);
+    const yesPrice = PredictionPricing.getCurrentPrice(
+      market.yesShares,
+      market.noShares,
+      'yes'
+    );
+    const noPrice = PredictionPricing.getCurrentPrice(
+      market.yesShares,
+      market.noShares,
+      'no'
+    );
+    expect(yesPrice).toBeCloseTo(0.55, 10);
+    expect(noPrice).toBeCloseTo(0.45, 10);
+  });
 });
 
 // ─── getCurrentPrice ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add deterministic prediction market profiles so markets stop sharing one generic liquidity/behavior template
- seed new prediction markets from those profiles during question creation while keeping opening priors anchored at 50/50
- make prediction auto-AMM consume profile-specific sensitivity/reversion parameters instead of one global setting

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Continues the market realism plan after the perp refinement/preview tranche
- Focused strictly on prediction market differentiation, not perps

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Web UI (`apps/web`)
- [ ] Other areas

## Non-goals / follow-ups
- No prediction UI changes yet
- No non-50/50 opening priors yet in production behavior; this PR only adds the plumbing and keeps the default anchor conservative
- No deeper prediction-agent prompt/context changes yet

## Changes
- add `prediction-market-profiles.ts` with deterministic profile generation based on market id/question/end date
- extend prediction market initialization to accept profile-driven liquidity and optional initial YES probability
- wire question creation to use profile-derived initial liquidity instead of one hard-coded `20000`
- make prediction auto-AMM profile-aware for signal sensitivity and neutral reversion
- add focused tests for profile generation and non-neutral initialization support in pricing

## Review guide
**Start here**
- `packages/engine/src/services/prediction-market-profiles.ts`
- `packages/engine/src/QuestionManager.ts`
- `packages/engine/src/services/prediction-auto-amm.ts`
- `packages/core/markets/prediction/pricing.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This PR intentionally keeps opening priors at 50/50 in actual market creation, even though the plumbing now supports explicit asymmetric priors.
- The differentiation shipped here is mainly via initial liquidity and profile-aware auto-AMM behavior.

## Test plan
**Commands run**
- [ ] `bun run check`
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test`

**Focused verification / manual verification**
1. `bun test packages/engine/src/services/prediction-market-profiles.test.ts`
2. `bun test packages/testing/unit/prediction-pricing-correctness.test.ts`
3. Targeted formatting applied on touched files
4. Full workspace typecheck was not completed from this isolated worktree because local worktree dependency resolution is incomplete (`bun-types`), so verification here is intentionally focused

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates
- [ ] Requires DB migration
- [ ] Changes cron schedule or endpoints
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes
- [x] None
- [ ] Yes

## Security / privacy
- [x] No security impact
- [ ] Needs extra review

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Engine/core change only. This PR changes prediction market initialization and auto-AMM behavior but does not add or alter UI surfaces.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path
- [x] Handlers remain thin and portable
- [x] Domain logic stays in packages
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] **Screenshots/recordings section filled**
