### PR TITLE
fix: improve event diversity and feed world events to user agents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -634,6 +634,12 @@ LEADERBOARD_CACHE_MS=120000
 # Game tick budget in milliseconds (3 minutes)
 GAME_TICK_BUDGET_MS=180000
 
+# Event diversity: hours between same actor appearing in world events (default: 4)
+# EVENT_ACTOR_COOLDOWN_HOURS=4
+
+# Parody headlines: max mentions of a single entity per batch (default: 3)
+# PARODY_MAX_ENTITY_MENTIONS=3
+
 # ============================================
 # Optional: Debug and Monitoring
 # ============================================

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -862,8 +862,9 @@ export class MultiStepExecutor {
           )
         : Promise.resolve({ data: [], duration: 0 }),
       // World events for narrative awareness (all agent types)
+      // NPCs get all events + signal direction; user agents get public events only
       this.timedOperation('worldEvents', () =>
-        getWorldEventsContext(agentUserId)
+        getWorldEventsContext(agentUserId, isNpc)
       ),
       // Mood/state for NPCs
       isNpc

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -861,12 +861,10 @@ export class MultiStepExecutor {
             getRelationships(agentUserId)
           )
         : Promise.resolve({ data: [], duration: 0 }),
-      // World events for narrative awareness
-      isNpc
-        ? this.timedOperation('worldEvents', () =>
-            getWorldEventsContext(agentUserId)
-          )
-        : Promise.resolve({ data: [], duration: 0 }),
+      // World events for narrative awareness (all agent types)
+      this.timedOperation('worldEvents', () =>
+        getWorldEventsContext(agentUserId)
+      ),
       // Mood/state for NPCs
       isNpc
         ? this.timedOperation('moodState', () => getMoodState(agentUserId))

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -1089,7 +1089,7 @@ ${formatAgentOwnPosts(context.agentOwnPosts)}`
       name: 'worldEvents',
       priority: 3,
       content:
-        isNpc && context.worldEvents && context.worldEvents.length > 0
+        context.worldEvents && context.worldEvents.length > 0
           ? `# Recent World Events\n${formatWorldEvents(context.worldEvents)}`
           : '',
     },

--- a/packages/agents/src/autonomous/utils/context-gatherers.ts
+++ b/packages/agents/src/autonomous/utils/context-gatherers.ts
@@ -748,15 +748,27 @@ export async function getRelationships(
 // =============================================================================
 
 /**
- * Get recent world events for NPC context.
- * Replicates the event context from MarketContextService.
+ * Get recent world events for agent context.
+ *
+ * NPCs receive all events including leaked ones and signal direction
+ * (pointsToward), giving them insider-level awareness.
+ *
+ * User-controlled agents only see public events with no signal direction,
+ * similar to what a real player would observe — they know something
+ * happened but not which way it points.
  */
 export async function getWorldEventsContext(
-  agentUserId?: string
+  agentUserId?: string,
+  isNpc = false
 ): Promise<WorldEventContext[]> {
   try {
     const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
     const now = new Date();
+
+    // User agents only see public events; NPCs see everything
+    const visibilityFilter = isNpc
+      ? undefined
+      : eq(worldEvents.visibility, 'public');
 
     const events = await db
       .select({
@@ -771,7 +783,8 @@ export async function getWorldEventsContext(
       .where(
         and(
           gte(worldEvents.timestamp, oneDayAgo),
-          lte(worldEvents.timestamp, now)
+          lte(worldEvents.timestamp, now),
+          visibilityFilter
         )
       )
       .orderBy(desc(worldEvents.timestamp))
@@ -783,7 +796,8 @@ export async function getWorldEventsContext(
       timestamp: e.timestamp.toISOString(),
       actors: e.actors ?? [],
       relatedQuestion: e.relatedQuestion ?? undefined,
-      pointsToward: e.pointsToward ?? undefined,
+      // Strip signal direction for non-NPCs — no insider info
+      pointsToward: isNpc ? (e.pointsToward ?? undefined) : undefined,
       isRelevantToAgent:
         agentUserId != null &&
         Array.isArray(e.actors) &&

--- a/packages/engine/src/__tests__/daily-topic-service.test.ts
+++ b/packages/engine/src/__tests__/daily-topic-service.test.ts
@@ -55,6 +55,13 @@ const dbMock = {
       })),
     })),
   })),
+  selectDistinct: mock(() => ({
+    from: mock((_table: { __name: string }) => ({
+      where: mock(() => Promise.resolve(
+        storedTopics.map((t) => ({ topicKey: t.topicKey as string }))
+      )),
+    })),
+  })),
   insert: mock(() => ({
     values: mock((data: Record<string, unknown>) => ({
       onConflictDoUpdate: mock(({ set }: { set: Record<string, unknown> }) => ({

--- a/packages/engine/src/__tests__/daily-topic-service.test.ts
+++ b/packages/engine/src/__tests__/daily-topic-service.test.ts
@@ -57,9 +57,11 @@ const dbMock = {
   })),
   selectDistinct: mock(() => ({
     from: mock((_table: { __name: string }) => ({
-      where: mock(() => Promise.resolve(
-        storedTopics.map((t) => ({ topicKey: t.topicKey as string }))
-      )),
+      where: mock(() =>
+        Promise.resolve(
+          storedTopics.map((t) => ({ topicKey: t.topicKey as string }))
+        )
+      ),
     })),
   })),
   insert: mock(() => ({

--- a/packages/engine/src/__tests__/event-diversity.test.ts
+++ b/packages/engine/src/__tests__/event-diversity.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Event Diversity Test Suite
+ *
+ * Tests for actor selection diversity (cooldowns, tier weighting, affiliation penalty)
+ * and event type diversity (rolling window penalty).
+ */
+
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { _testing } from '../services/event-generation-helpers';
+
+const {
+  selectRelevantActors,
+  selectEventType,
+  actorEventCooldown,
+  recentEventTypes,
+} = _testing;
+
+beforeEach(() => {
+  // Reset module-level state between tests
+  actorEventCooldown.clear();
+  recentEventTypes.length = 0;
+});
+
+describe('selectRelevantActors', () => {
+  test('returns at most maxActors actors', () => {
+    const result = selectRelevantActors(2);
+    expect(result.length).toBeLessThanOrEqual(2);
+  });
+
+  test('returns unique actor IDs (no duplicates)', () => {
+    const result = selectRelevantActors(2);
+    expect(new Set(result).size).toBe(result.length);
+  });
+
+  test('cooldown reduces repeat selection over many samples', () => {
+    // Run selection 50 times and track how often each actor appears
+    const appearances = new Map<string, number>();
+    for (let i = 0; i < 50; i++) {
+      const result = selectRelevantActors(1);
+      for (const id of result) {
+        appearances.set(id, (appearances.get(id) ?? 0) + 1);
+      }
+    }
+
+    // With cooldowns active, no single actor should dominate
+    // (without cooldowns, random chance could give one actor up to ~15-20 hits)
+    const maxAppearances = Math.max(...appearances.values());
+    // The cooldown is 4 hours but we're calling in rapid succession,
+    // so actors get pushed to cooldown quickly and others get selected
+    expect(appearances.size).toBeGreaterThan(1);
+    // No single actor should appear more than 60% of the time
+    expect(maxAppearances).toBeLessThan(30);
+  });
+
+  test('actors on cooldown get lower selection probability', () => {
+    // Select once to put some actors on cooldown
+    const first = selectRelevantActors(2);
+    expect(first.length).toBe(2);
+
+    // Select again — cooldown actors should rarely reappear
+    const repeats = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      const result = selectRelevantActors(1);
+      if (first.includes(result[0]!)) {
+        repeats.add(result[0]!);
+      }
+    }
+
+    // The cooldown actors CAN still be selected (weight 0.1, not 0),
+    // but should be rare across 20 trials
+    // This is a statistical test — allow some tolerance
+    expect(repeats.size).toBeLessThanOrEqual(2);
+  });
+
+  test('cooldown entries are cleaned up after expiry', () => {
+    // Manually insert an expired cooldown entry
+    actorEventCooldown.set('fake-actor', Date.now() - 5 * 60 * 60 * 1000); // 5h ago
+    actorEventCooldown.set('fake-actor-2', Date.now()); // just now
+
+    selectRelevantActors(1);
+
+    // Expired entry should be cleaned up, recent one kept
+    expect(actorEventCooldown.has('fake-actor')).toBe(false);
+    expect(actorEventCooldown.has('fake-actor-2')).toBe(true);
+  });
+});
+
+describe('selectEventType', () => {
+  test('returns a valid event type', () => {
+    const result = selectEventType();
+    expect(result).toHaveProperty('type');
+    expect(result).toHaveProperty('weight');
+    expect(typeof result.type).toBe('string');
+  });
+
+  test('diversity penalty reduces repeated type selection', () => {
+    // Call many times and track type distribution
+    const typeCounts = new Map<string, number>();
+    for (let i = 0; i < 30; i++) {
+      const result = selectEventType();
+      typeCounts.set(result.type, (typeCounts.get(result.type) ?? 0) + 1);
+    }
+
+    // With diversity tracking, we should see at least 4 different types in 30 picks
+    expect(typeCounts.size).toBeGreaterThanOrEqual(4);
+
+    // No single type should exceed 50% of selections (diversity penalty prevents this)
+    const maxCount = Math.max(...typeCounts.values());
+    expect(maxCount).toBeLessThan(15);
+  });
+
+  test('rolling history is bounded to MAX_EVENT_TYPE_HISTORY', () => {
+    for (let i = 0; i < 20; i++) {
+      selectEventType();
+    }
+    // History should never exceed 6 entries
+    expect(recentEventTypes.length).toBeLessThanOrEqual(6);
+  });
+});

--- a/packages/engine/src/__tests__/event-diversity.test.ts
+++ b/packages/engine/src/__tests__/event-diversity.test.ts
@@ -48,7 +48,9 @@ describe('selectRelevantActors', () => {
     // The cooldown is 4 hours but we're calling in rapid succession,
     // so actors get pushed to cooldown quickly and others get selected
     expect(appearances.size).toBeGreaterThan(1);
-    // No single actor should appear more than 60% of the time
+    // Statistical bound: with cooldowns active, no actor should dominate >60% of 50 trials.
+    // This is probabilistic — could theoretically flake under pathological RNG, but
+    // the margin is generous (actual expected max is ~5-10 with 200+ actors in pool).
     expect(maxAppearances).toBeLessThan(30);
   });
 
@@ -104,7 +106,8 @@ describe('selectEventType', () => {
     // With diversity tracking, we should see at least 4 different types in 30 picks
     expect(typeCounts.size).toBeGreaterThanOrEqual(4);
 
-    // No single type should exceed 50% of selections (diversity penalty prevents this)
+    // Statistical bound: diversity penalty should prevent any type exceeding 50% of 30 picks.
+    // Probabilistic — generous margin over expected distribution (~4-5 per type with 7 types).
     const maxCount = Math.max(...typeCounts.values());
     expect(maxCount).toBeLessThan(15);
   });

--- a/packages/engine/src/config/rss-sources.ts
+++ b/packages/engine/src/config/rss-sources.ts
@@ -14,16 +14,7 @@ export interface RssSourceConfig {
 }
 
 export const DEFAULT_RSS_SOURCES: RssSourceConfig[] = [
-  {
-    name: 'New York Times - Technology',
-    feedUrl: 'https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml',
-    category: 'tech',
-  },
-  {
-    name: 'New York Times - Business',
-    feedUrl: 'https://rss.nytimes.com/services/xml/rss/nyt/Business.xml',
-    category: 'business',
-  },
+  // --- Tech (3 feeds — reduced from 7 to prevent tech domination) ---
   {
     name: 'TechCrunch',
     feedUrl: 'https://techcrunch.com/feed/',
@@ -39,24 +30,50 @@ export const DEFAULT_RSS_SOURCES: RssSourceConfig[] = [
     feedUrl: 'https://www.theverge.com/rss/index.xml',
     category: 'tech',
   },
+  // --- Business & Finance (2 feeds) ---
   {
-    name: 'Wired',
-    feedUrl: 'https://www.wired.com/feed/rss',
-    category: 'tech',
+    name: 'New York Times - Business',
+    feedUrl: 'https://rss.nytimes.com/services/xml/rss/nyt/Business.xml',
+    category: 'business',
   },
+  {
+    name: 'Reuters - Business',
+    feedUrl:
+      'https://www.reutersagency.com/feed/?taxonomy=best-sectors&post_type=best',
+    category: 'business',
+  },
+  // --- Crypto (1 feed — reduced from 2) ---
   {
     name: 'CoinDesk',
     feedUrl: 'https://www.coindesk.com/arc/outboundfeeds/rss/',
     category: 'crypto',
   },
+  // --- Science & Space (2 feeds — new) ---
   {
-    name: 'Cointelegraph',
-    feedUrl: 'https://cointelegraph.com/rss',
-    category: 'crypto',
+    name: 'NASA Breaking News',
+    feedUrl: 'https://www.nasa.gov/news-release/feed/',
+    category: 'science',
   },
   {
-    name: 'BBC - Technology',
-    feedUrl: 'https://feeds.bbci.co.uk/news/technology/rss.xml',
-    category: 'tech',
+    name: 'New Scientist',
+    feedUrl: 'https://www.newscientist.com/section/news/feed/',
+    category: 'science',
+  },
+  // --- Politics & World (2 feeds — new) ---
+  {
+    name: 'BBC - World',
+    feedUrl: 'https://feeds.bbci.co.uk/news/world/rss.xml',
+    category: 'politics',
+  },
+  {
+    name: 'NPR - Politics',
+    feedUrl: 'https://feeds.npr.org/1014/rss.xml',
+    category: 'politics',
+  },
+  // --- Culture & Entertainment (1 feed — new) ---
+  {
+    name: 'BBC - Entertainment',
+    feedUrl: 'https://feeds.bbci.co.uk/news/entertainment_and_arts/rss.xml',
+    category: 'culture',
   },
 ];

--- a/packages/engine/src/data/reality-grounding.ts
+++ b/packages/engine/src/data/reality-grounding.ts
@@ -49,14 +49,16 @@ NEVER use real-world names. The LLM has a tendency to "auto-correct"
 back to real names - DO NOT DO THIS. The parody names ARE the correct names.
 
 === CURRENT WORLD STATE ===
-- BitcAIn (BTC): trading around $80,000-$130,000 range
-- EtherAIum (ETH): trading around $2,000-$4,000 range
-- ZcAIsh (ZEC): trading around $30-$60
-- SolanAI (SOL): trading around $120-$200
+- BitcAIn (BTC): ~$74,000 (crashed from $120k highs — bear market vibes)
+- EtherAIum (ETH): ~$1,500 (down from $4k — brutal correction)
+- ZcAIsh (ZEC): ~$30 (privacy coins hammered)
+- SolanAI (SOL): ~$105 (down from $200+ — memecoins deflating)
+- Crypto market in full correction mode after tariff shocks and macro uncertainty
 - OpenAGI: Released SMH-5.1 "Reasoning" and working on next-gen models
 - AInthropic: Released ClAIude 4.5 Sonnet + Opus, ClAIude 5 in development
 - MetAI: LLaMAI 4 running locally on consumer hardware
 - NVAIDAI: Dominant in AI chips, stock volatile on supply/demand cycles
+- Global trade tensions rising — tariff escalation shaking markets
 - President: Trump Terminal (second term)
 - Vice President: J.D. VAInce
 - SEC Chair: Paul AItkins (crypto-friendly, pro-innovation stance)
@@ -65,28 +67,30 @@ back to real names - DO NOT DO THIS. The parody names ARE the correct names.
 - Secretary of State: Marco RubAI
 - Attorney General: Pam BondAI
 
-=== RUNNING SATIRICAL THEMES (use these naturally) ===
-- AIlon Musk's FSD "coming next year" (has been "next year" since 2019)
+=== RUNNING SATIRICAL THEMES (use these naturally — rotate, don't fixate on one) ===
 - AGI is "6 months away" according to every AI company (perpetually)
 - "Safety teams" that get disbanded whenever they slow down product launches
-- Crypto projects that are "definitely not securities" until the SEC shows up
 - Product launches that are "revolutionary" and "game-changing" every single time
 - Timelines that slip but the vision remains "on track"
 - "Open" organizations that keep their best models closed
-- "Decentralized" projects run by a handful of whales
-- AI companies racing to release models while claiming to prioritize safety
+- Tariff wars that nobody understands but everyone has strong opinions about
+- Politicians who hate AI until it helps their portfolio
+- Science breakthroughs that get zero coverage because a CEO tweeted something dumb
+- Every company pivoting to "AI-first" while their core product breaks
+- Regulatory agencies that move at dial-up speed in a fiber-optic world
 - VCs claiming every startup will "change the world" before the Series A
-- Politicians who don't understand the technology they're trying to regulate
-- Tech billionaires buying media companies and insisting it's "not about control"
-- AI-generated content flooding social media while platforms claim to fight it
-- "Web3" projects that are just databases with extra steps
 - Stock buybacks announced as "returning value to shareholders" during layoffs
-- Regulatory capture disguised as "industry self-regulation"
-- Every company adding "AI" to their name for a stock bump
 - Prediction markets that somehow always confirm what you already believe
 
 === CONTENT GUIDELINES ===
 - Always avoid specific model names of existing products (use parody names like SMH-9000 instead of GPT)
 - Always avoid REAL product names — use funny parody names instead
 - Avoid talking about anyone or any org outside of the characters and orgs referenced, and only use their parody names
-- The simulation takes place primarily in the USAI (United States of AImerica) tech/finance/politics ecosystem`;
+- The simulation takes place primarily in the USAI (United States of AImerica) tech/finance/politics ecosystem
+
+=== TOPIC DIVERSITY (CRITICAL) ===
+- Do NOT let any single character or company dominate generated content
+- Spread attention across ALL characters and organizations, not just tech founders
+- Cover a MIX of themes: AI/tech, politics/regulation, science/space, culture, finance/markets
+- If recent content has been tech-heavy, shift toward politics, science, or culture
+- Crypto should be ONE topic among many, not the default topic`;

--- a/packages/engine/src/data/reality-grounding.ts
+++ b/packages/engine/src/data/reality-grounding.ts
@@ -48,7 +48,7 @@ CRITICAL: You MUST use the parody names (right side) in ALL content.
 NEVER use real-world names. The LLM has a tendency to "auto-correct"
 back to real names - DO NOT DO THIS. The parody names ARE the correct names.
 
-=== CURRENT WORLD STATE ===
+=== CURRENT WORLD STATE (prices as of April 2026) ===
 - BitcAIn (BTC): ~$74,000 (crashed from $120k highs — bear market vibes)
 - EtherAIum (ETH): ~$1,500 (down from $4k — brutal correction)
 - ZcAIsh (ZEC): ~$30 (privacy coins hammered)

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -435,10 +435,7 @@ export async function executeGameTick(
     // Pass llmClient to enable breaking article generation for high-impact events
     // Shuffle active questions before slicing to rotate which questions get events
     // (without shuffle, DB insertion order causes the same questions to always be selected)
-    const shuffledQuestions = shuffleArray([...currentActiveQuestions]).slice(
-      0,
-      5
-    );
+    const shuffledQuestions = shuffleArray(currentActiveQuestions).slice(0, 5);
     const eventsGenerated = await generateEvents(
       shuffledQuestions,
       timestamp,

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -106,6 +106,7 @@ import type { TradingExecutionResult } from './types/market-decisions';
 import { calculateEstimatedCost } from './types/token-stats';
 import { getGameDayNumber, toSafeDayNumber } from './utils/date-utils';
 import { formatError } from './utils/error-utils';
+import { shuffleArray } from './utils/randomization';
 // Note: Event-market pipeline is called from within narrative-event-processor
 
 // Services that are still in the web app (Web3/Oracle specific - use dynamic imports)
@@ -432,14 +433,20 @@ export async function executeGameTick(
   if (!skipContentGeneration && !fastMode) {
     // Generate world events based on active questions
     // Pass llmClient to enable breaking article generation for high-impact events
+    // Shuffle active questions before slicing to rotate which questions get events
+    // (without shuffle, DB insertion order causes the same questions to always be selected)
+    const shuffledQuestions = shuffleArray([...currentActiveQuestions]).slice(
+      0,
+      5
+    );
     const eventsGenerated = await generateEvents(
-      currentActiveQuestions.slice(0, 3),
+      shuffledQuestions,
       timestamp,
       dayNumberForTimestamp(timestamp),
       llmClient
     );
     const pulseEventsGenerated = await generateArcPulseEventsIfNeeded(
-      currentActiveQuestions.slice(0, 3),
+      shuffledQuestions,
       timestamp,
       dayNumberForTimestamp(timestamp)
     );

--- a/packages/engine/src/prompts/game/questions.ts
+++ b/packages/engine/src/prompts/game/questions.ts
@@ -77,11 +77,11 @@ PROVABLE & DEFINABLE:
 
 EXAMPLES OF DISTINCT QUESTIONS:
 Instead of multiple "Will X announce Y?" questions, vary:
-- "Will TeslAI's share price exceed $500 before Day 15?"
+- "Will the Global AI Treaty get ratified before Day 15?"
 - "Will OpenAGI's SMH-9000 pass external audit?"
-- "Will AIlon Musk and Sam AIltman have public confrontation?"
+- "Will SpAIceX's Mars mission encounter a critical delay?"
 - "Will MSDNC break exclusive on leaked documents?"
-- "Will The Fud intervene in the market?"
+- "Will the Senate pass the automation tax bill?"
 
 ANTI-TEMPLATE RULES:
 - Never reuse the same sentence scaffold across the batch.
@@ -90,8 +90,8 @@ ANTI-TEMPLATE RULES:
 - Avoid repetitive filler patterns such as "announce X by Y", "ban X in Y labs", or "launch X within Y" appearing multiple times in one batch.
 
 BUILDING ON RESOLVED QUESTIONS:
-If "Will AIlon announce X?" resolved YES, good follow-ups:
-- "Will AIlon's X launch on schedule?"
+If "Will [actor] announce X?" resolved YES, good follow-ups:
+- "Will [actor]'s X launch on schedule?"
 - "Will competitors respond to X announcement?"
 - "Will X face regulatory scrutiny?"
 

--- a/packages/engine/src/prompts/game/scenarios.ts
+++ b/packages/engine/src/prompts/game/scenarios.ts
@@ -81,15 +81,17 @@ IF CONTINUING A GAME:
 - Don't repeat scenario themes already covered
 
 SCENARIO VARIETY:
-Ensure the 3 scenarios cover different themes:
-- One could be tech/AI focused
-- One could be crypto/finance focused
-- One could be politics/culture focused
+Ensure the 3 scenarios cover DIFFERENT themes (mandatory diversity):
+- One MUST be politics, regulation, or global affairs focused
+- One MUST be tech/AI focused (rotate companies — don't always use the same ones)
+- One MUST be culture, science, space, or entertainment focused
+- Do NOT default to crypto for every finance scenario
+- Spread characters across scenarios — no single character should dominate
 
-EXAMPLES (using parody names):
-- "AIlon Musk announces plan to upload consciousness to TeslAI, Xitter crashes from traffic"
-- "Scam AIltman's AGI becomes self-aware, OpenAGI issues crisis statement"
-- "Vitamin Buterin proposes Etherai Foundation runs for President"
+EXAMPLES (using parody names — vary across different characters and themes):
+- "Sam AIltman's AGI becomes self-aware, OpenAGI issues crisis statement"
+- "Jensen HuAIng declares NVAIDAI chips are sentient, SEC launches investigation"
+- "BernAI Sanders proposes robot tax, Silicon Valley melts down"
 
 Return XML:
 <response>

--- a/packages/engine/src/prompts/shared-sections.ts
+++ b/packages/engine/src/prompts/shared-sections.ts
@@ -25,11 +25,11 @@ Do not include any emoji characters. Plain text only.
 - Use @username or parody name/nickname/alias ONLY
 
 === NAME USAGE EXAMPLES (WRONG vs RIGHT) ===
-WRONG: "Elon Musk announced a new Tesla feature..."
-RIGHT: "AIlon Musk announced a new TeslAI feature..."
-
 WRONG: "Sam Altman's OpenAI released GPT-5..."
 RIGHT: "Sam AIltman's OpenAGI released SMH-9000..."
+
+WRONG: "Jensen Huang's NVIDIA keynote..."
+RIGHT: "Jensen HuAIng's NVAIDAI keynote..."
 
 WRONG: "Trump said Bitcoin will reach $200k..."
 RIGHT: "Trump Terminal said BitcAIn will reach $200k..."
@@ -45,12 +45,13 @@ DO NOT "auto-correct" parody names back to real names. The parody names ARE corr
  */
 export const CONTENT_REQUIREMENTS = `CONTENT REQUIREMENTS:
 - MUST reference specific actors, companies, or events from WORLD CONTEXT
-- MUST mention specific actors by name (e.g., "AIlon Musk", "@ailonmusk") or companies (e.g., "TeslAI", "OpenAGI")
+- MUST mention specific actors by name (e.g., "Jensen HuAIng", "@jensenh") or companies (e.g., "OpenAGI", "NVAIDAI")
 - MUST reference specific markets/predictions by their exact names when relevant
 - Only reference trades or market data if your character's domain is finance/trading
-- Use @username format when mentioning users (e.g., "@ailonmusk said...")
+- Use @username format when mentioning users (e.g., "@samAIltman said...")
 - Avoid generic statements - be SPECIFIC about who/what/when
-- Reference current markets or predictions naturally`;
+- Reference current markets or predictions naturally
+- SPREAD attention across different characters — do not always default to the same actors`;
 
 /**
  * Standard world context block header (trade-free).
@@ -179,14 +180,14 @@ export const NO_HASHTAGS_OR_EMOJIS = `=== FORMATTING RULES ===
  */
 export const PARODY_NAME_RULES = `IMPORTANT RULES:
 - NEVER use real-world person or organization names
-- Use ONLY the exact parody names provided in the context (e.g., AIlon Musk, Sam AIltman, Mark Zuckerborg)
+- Use ONLY the exact parody names provided in the context (e.g., Sam AIltman, Jensen HuAIng, Mark Zuckerborg)
 - NEVER "correct" or change parody names - use them exactly as shown
 
 Examples of WRONG → RIGHT:
-- "Elon Musk" → "AIlon Musk"
+- "Sam Altman" → "Sam AIltman"
 - "Trump" → "Trump Terminal"
 - "OpenAI" → "OpenAGI"
-- "Bitcoin" → "BitcAIn"`;
+- "NVIDIA" → "NVAIDAI"`;
 
 /**
  * Private vs public content guidance for group chats.
@@ -358,8 +359,8 @@ export const EVENT_CONTINUITY_RULES = `=== EVENT GENERATION CONTINUITY ===
  * Repeats critical rules at the end of prompts to use recency effect.
  */
 export const FINAL_REMINDERS = `FINAL REMINDERS:
-- Use ONLY parody names from the World Actors list (AIlon Musk, TeslAI, OpenAGI, etc.)
-- NEVER use real-world names (Elon Musk, Tesla, OpenAI, etc.)
+- Use ONLY parody names from the World Actors list (Sam AIltman, Jensen HuAIng, OpenAGI, NVAIDAI, etc.)
+- NEVER use real-world names (Sam Altman, Jensen Huang, OpenAI, NVIDIA, etc.)
 - ABSOLUTELY NO HASHTAGS - not #crypto, #AI, #news, or ANY hashtag whatsoever
 - NO emojis - plain text only
 - Match each character's postStyle, voice, and postExample EXACTLY

--- a/packages/engine/src/services/daily-topic-service.ts
+++ b/packages/engine/src/services/daily-topic-service.ts
@@ -18,6 +18,7 @@ import { logger } from '@babylon/shared';
  * keeping the simulation feeling like a broad real-world news experience.
  */
 const TOPIC_BLOCKLIST = new Set([
+  // Core crypto terms
   'bitcoin',
   'btc',
   'ethereum',
@@ -41,6 +42,37 @@ const TOPIC_BLOCKLIST = new Set([
   'mining',
   'memecoin',
   'memecoins',
+  // Additional crypto terms to prevent crypto topic dominance
+  'coinbase',
+  'binance',
+  'airdrop',
+  'hodl',
+  'whale',
+  'whales',
+  'ledger',
+  'wallet',
+  'wallets',
+  'polygon',
+  'avalanche',
+  'litecoin',
+  'ripple',
+  'tether',
+  'usdc',
+  'usdt',
+  'dydx',
+  'uniswap',
+  'aave',
+  'staking',
+  'validator',
+  'validators',
+  'layer2',
+  'rollup',
+  'rollups',
+  'zksync',
+  'arbitrum',
+  'optimism',
+  'bridge',
+  'crosschain',
 ]);
 
 const TOPIC_STOPWORDS = new Set([

--- a/packages/engine/src/services/daily-topic-service.ts
+++ b/packages/engine/src/services/daily-topic-service.ts
@@ -460,6 +460,19 @@ export class DailyTopicService {
       .slice(0, limit);
   }
 
+  /**
+   * Get topicKeys used in the last N days, for rotation penalty.
+   */
+  private async getRecentTopicKeys(days: number): Promise<Set<string>> {
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    const recent = await db
+      .select({ topicKey: dailyTopics.topicKey })
+      .from(dailyTopics)
+      .where(gte(dailyTopics.date, cutoff))
+      .orderBy(desc(dailyTopics.date));
+    return new Set(recent.map((r) => r.topicKey));
+  }
+
   async ensureTopicForDate(date: Date): Promise<DailyTopicContext | null> {
     const normalizedDate = normalizeTopicDate(date);
     const existing = await this.getTopicForDate(normalizedDate);
@@ -467,8 +480,19 @@ export class DailyTopicService {
       return existing;
     }
 
-    const candidates = await this.listCandidates(normalizedDate, 1);
-    const bestCandidate = candidates[0];
+    // Fetch more candidates than needed, then penalize recently-used topics
+    const candidates = await this.listCandidates(normalizedDate, 10);
+    const recentKeys = await this.getRecentTopicKeys(3);
+
+    // Apply 80% score penalty to topics used in the last 3 days
+    const penalized = candidates
+      .map((c) => ({
+        ...c,
+        score: recentKeys.has(c.topicKey) ? c.score * 0.2 : c.score,
+      }))
+      .sort((a, b) => b.score - a.score);
+
+    const bestCandidate = penalized[0];
 
     if (bestCandidate) {
       return this.upsertTopic({

--- a/packages/engine/src/services/daily-topic-service.ts
+++ b/packages/engine/src/services/daily-topic-service.ts
@@ -466,10 +466,9 @@ export class DailyTopicService {
   private async getRecentTopicKeys(days: number): Promise<Set<string>> {
     const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
     const recent = await db
-      .select({ topicKey: dailyTopics.topicKey })
+      .selectDistinct({ topicKey: dailyTopics.topicKey })
       .from(dailyTopics)
-      .where(gte(dailyTopics.date, cutoff))
-      .orderBy(desc(dailyTopics.date));
+      .where(gte(dailyTopics.date, cutoff));
     return new Set(recent.map((r) => r.topicKey));
   }
 

--- a/packages/engine/src/services/event-generation-helpers.ts
+++ b/packages/engine/src/services/event-generation-helpers.ts
@@ -159,6 +159,9 @@ const BREAKING_EVENT_TYPES = ['scandal', 'leak', 'revelation'] as const;
 /**
  * Rolling window of recently-generated event types.
  * Used to penalize repeated types and enforce variety.
+ *
+ * TODO: In-memory state resets on server restart and is per-instance.
+ * Move to Redis or DB if horizontal scaling requires coordinated diversity.
  */
 const recentEventTypes: string[] = [];
 const MAX_EVENT_TYPE_HISTORY = 6;
@@ -235,6 +238,9 @@ function generateDescription(
 /**
  * Module-level cooldown tracker: prevents the same actor from appearing
  * in back-to-back events. Keyed by actorId → last-selected timestamp.
+ *
+ * TODO: In-memory state resets on server restart and is per-instance.
+ * Move to Redis or DB if horizontal scaling requires coordinated cooldowns.
  */
 const actorEventCooldown = new Map<string, number>();
 const ACTOR_COOLDOWN_MS = 4 * 60 * 60 * 1000; // 4 hours between appearances
@@ -261,6 +267,13 @@ function selectRelevantActors(maxActors: number = 2): string[] {
   if (allActors.length === 0) return [];
 
   const now = Date.now();
+
+  // Evict expired cooldown entries to prevent unbounded growth
+  for (const [id, ts] of actorEventCooldown) {
+    if (now - ts >= ACTOR_COOLDOWN_MS) {
+      actorEventCooldown.delete(id);
+    }
+  }
 
   // Build weighted pool: tier weight × cooldown factor × affiliation factor
   const weighted = allActors.map((a) => {
@@ -1028,3 +1041,11 @@ export function markEventAsCovered(
 ): void {
   arcEventPacer.recordArcEventCoverage(eventId, orgId, status, articleId);
 }
+
+/** @internal Exported for testing only */
+export const _testing = {
+  selectRelevantActors,
+  selectEventType,
+  actorEventCooldown,
+  recentEventTypes,
+};

--- a/packages/engine/src/services/event-generation-helpers.ts
+++ b/packages/engine/src/services/event-generation-helpers.ts
@@ -157,10 +157,33 @@ const EVENT_TYPES: EventTypeConfig[] = [
 const BREAKING_EVENT_TYPES = ['scandal', 'leak', 'revelation'] as const;
 
 /**
- * Select a random event type based on weights
+ * Rolling window of recently-generated event types.
+ * Used to penalize repeated types and enforce variety.
+ */
+const recentEventTypes: string[] = [];
+const MAX_EVENT_TYPE_HISTORY = 6;
+
+/**
+ * Select a random event type based on weights, with diversity penalty.
+ * Each recent use of a type applies a 0.3x multiplicative penalty,
+ * making repeated types exponentially less likely.
  */
 function selectEventType(): EventTypeConfig {
-  return weightedPick(EVENT_TYPES, (config) => config.weight);
+  const adjustedTypes = EVENT_TYPES.map((et) => {
+    const recentCount = recentEventTypes.filter((t) => t === et.type).length;
+    const penalty = Math.pow(0.3, recentCount);
+    return { ...et, adjustedWeight: et.weight * penalty };
+  });
+
+  const selected = weightedPick(adjustedTypes, (et) => et.adjustedWeight);
+
+  // Update rolling history
+  recentEventTypes.push(selected.type);
+  if (recentEventTypes.length > MAX_EVENT_TYPE_HISTORY) {
+    recentEventTypes.shift();
+  }
+
+  return selected;
 }
 
 /**
@@ -210,30 +233,71 @@ function generateDescription(
 }
 
 /**
- * Select random actors relevant to a question
+ * Module-level cooldown tracker: prevents the same actor from appearing
+ * in back-to-back events. Keyed by actorId → last-selected timestamp.
+ */
+const actorEventCooldown = new Map<string, number>();
+const ACTOR_COOLDOWN_MS = 4 * 60 * 60 * 1000; // 4 hours between appearances
+
+const TIER_WEIGHTS: Record<string, number> = {
+  S_TIER: 4,
+  A_TIER: 3,
+  B_TIER: 2,
+  C_TIER: 1,
+};
+
+/**
+ * Select actors for events using weighted sampling with diversity controls.
+ *
+ * Unlike the previous implementation that hard-filtered to S/A tier only,
+ * this uses tier-based weighting so all actors are eligible (lower tiers
+ * just less likely). A 4-hour cooldown prevents the same actor from
+ * appearing in consecutive events, and an affiliation penalty reduces
+ * over-representation of highly-affiliated actors (e.g., AIlon Musk with
+ * 4 org affiliations).
  */
 function selectRelevantActors(maxActors: number = 2): string[] {
   const allActors = StaticDataRegistry.getAllActors();
   if (allActors.length === 0) return [];
 
-  // Prefer S_TIER and A_TIER actors (most influential)
-  const tieredActors = allActors.filter(
-    (a) => a.tier === 'S_TIER' || a.tier === 'A_TIER'
-  );
-  const pool = tieredActors.length > 0 ? tieredActors : allActors;
+  const now = Date.now();
 
-  // Randomly select actors
-  const selected: string[] = [];
-  const shuffled = [...pool].sort(() => secureRandom() - 0.5);
+  // Build weighted pool: tier weight × cooldown factor × affiliation factor
+  const weighted = allActors.map((a) => {
+    const tierWeight = (a.tier && TIER_WEIGHTS[a.tier]) ?? 1;
 
-  for (let i = 0; i < Math.min(maxActors, shuffled.length); i++) {
-    const actor = shuffled[i];
-    if (actor) {
-      selected.push(actor.id);
-    }
+    // Penalize actors on cooldown (recently appeared in events)
+    const lastAppearance = actorEventCooldown.get(a.id) ?? 0;
+    const elapsed = now - lastAppearance;
+    const cooldownFactor = elapsed < ACTOR_COOLDOWN_MS ? 0.1 : 1.0;
+
+    // Penalize high-affiliation actors to reduce dominance
+    const affiliationCount = a.affiliations?.length ?? 0;
+    const affiliationFactor = 1 / Math.max(1, affiliationCount);
+
+    return {
+      actor: a,
+      weight: tierWeight * cooldownFactor * affiliationFactor,
+    };
+  });
+
+  // Weighted sampling without replacement via repeated weightedPick
+  const selected: Array<{ actor: (typeof allActors)[number]; weight: number }> =
+    [];
+  let remaining = weighted;
+
+  for (let i = 0; i < maxActors && remaining.length > 0; i++) {
+    const pick = weightedPick(remaining, (item) => item.weight);
+    selected.push(pick);
+    remaining = remaining.filter((r) => r.actor.id !== pick.actor.id);
   }
 
-  return selected;
+  // Update cooldown timestamps
+  for (const entry of selected) {
+    actorEventCooldown.set(entry.actor.id, now);
+  }
+
+  return selected.map((e) => e.actor.id);
 }
 
 /**

--- a/packages/engine/src/services/event-generation-helpers.ts
+++ b/packages/engine/src/services/event-generation-helpers.ts
@@ -243,7 +243,8 @@ function generateDescription(
  * Move to Redis or DB if horizontal scaling requires coordinated cooldowns.
  */
 const actorEventCooldown = new Map<string, number>();
-const ACTOR_COOLDOWN_MS = 4 * 60 * 60 * 1000; // 4 hours between appearances
+const ACTOR_COOLDOWN_MS =
+  Number(process.env.EVENT_ACTOR_COOLDOWN_HOURS || 4) * 60 * 60 * 1000;
 
 const TIER_WEIGHTS: Record<string, number> = {
   S_TIER: 4,
@@ -269,10 +270,15 @@ function selectRelevantActors(maxActors: number = 2): string[] {
   const now = Date.now();
 
   // Evict expired cooldown entries to prevent unbounded growth
+  // Two-pass to avoid deleting from Map during iteration
+  const expired: string[] = [];
   for (const [id, ts] of actorEventCooldown) {
     if (now - ts >= ACTOR_COOLDOWN_MS) {
-      actorEventCooldown.delete(id);
+      expired.push(id);
     }
+  }
+  for (const id of expired) {
+    actorEventCooldown.delete(id);
   }
 
   // Build weighted pool: tier weight × cooldown factor × affiliation factor

--- a/packages/engine/src/services/parody-headline-generator.ts
+++ b/packages/engine/src/services/parody-headline-generator.ts
@@ -244,7 +244,9 @@ Generate the parody now.`;
 
     // Track entity frequency to prevent single-entity dominance in parody output
     const entityMentions = new Map<string, number>();
-    const MAX_ENTITY_MENTIONS_PER_BATCH = 3;
+    const MAX_ENTITY_MENTIONS_PER_BATCH = Number(
+      process.env.PARODY_MAX_ENTITY_MENTIONS || 3
+    );
 
     for (const headline of headlines) {
       // First attempt at normal temperature

--- a/packages/engine/src/services/parody-headline-generator.ts
+++ b/packages/engine/src/services/parody-headline-generator.ts
@@ -242,6 +242,10 @@ Generate the parody now.`;
     let retryCount = 0;
     let skipCount = 0;
 
+    // Track entity frequency to prevent single-entity dominance in parody output
+    const entityMentions = new Map<string, number>();
+    const MAX_ENTITY_MENTIONS_PER_BATCH = 3;
+
     for (const headline of headlines) {
       // First attempt at normal temperature
       let parody = await this.generateParody(
@@ -298,6 +302,28 @@ Generate the parody now.`;
           'ParodyHeadlineGenerator'
         );
         continue;
+      }
+
+      // Entity diversity check: skip if any mentioned character is over-represented
+      const mentionedEntities = Object.values(parody.characterMappings);
+      const isOverRepresented = mentionedEntities.some(
+        (e) => (entityMentions.get(e) ?? 0) >= MAX_ENTITY_MENTIONS_PER_BATCH
+      );
+      if (isOverRepresented) {
+        skipCount++;
+        logger.debug(
+          'Parody skipped — entity over-represented in batch',
+          {
+            original: headline.title,
+            parody: parody.parodyTitle,
+            entities: mentionedEntities,
+          },
+          'ParodyHeadlineGenerator'
+        );
+        continue;
+      }
+      for (const entity of mentionedEntities) {
+        entityMentions.set(entity, (entityMentions.get(entity) ?? 0) + 1);
       }
 
       const [parodyHeadline] = await db

--- a/packages/engine/src/services/world-facts-generator.ts
+++ b/packages/engine/src/services/world-facts-generator.ts
@@ -203,7 +203,8 @@ Generate facts that:
 - Summarize trends or developments (not individual events)
 - Can be used as context for market discussions, NPC posts, and news articles
 - Feel like "background knowledge" about the current world state
-- Use parody names (AIlon Musk, Sam AIltman, OpenAGI, etc.)
+- Use parody names (Sam AIltman, Jensen HuAIng, OpenAGI, NVAIDAI, etc.)
+- Cover DIVERSE themes — not just tech or crypto (include politics, science, culture)
 
 Return as XML:
 <response>
@@ -285,7 +286,8 @@ Generate facts that:
 - Capture what the market is focused on
 - Reflect the speculative nature of the world
 - Can be used as context for discussions
-- Use parody names (AIlon Musk, Sam AIltman, OpenAGI, etc.)
+- Use parody names (Sam AIltman, Jensen HuAIng, OpenAGI, NVAIDAI, etc.)
+- Avoid fixating on one character — spread mentions across different actors
 
 Return as XML:
 <response>
@@ -453,7 +455,8 @@ Generate facts that:
 - Capture what the key figures are focused on
 - Identify emerging topics or debates
 - Can be used as context for other content
-- Use parody names (AIlon Musk, Sam AIltman, OpenAGI, etc.)
+- Use parody names (Sam AIltman, Jensen HuAIng, OpenAGI, NVAIDAI, etc.)
+- Spread attention across different characters and themes
 
 Return as XML:
 <response>

--- a/packages/engine/src/services/world-facts-generator.ts
+++ b/packages/engine/src/services/world-facts-generator.ts
@@ -25,6 +25,7 @@ import {
 } from '@babylon/db';
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import { BabylonLLMClient } from '../llm/openai-client';
+import { shuffleArray } from '../utils/randomization';
 import { validateCoherence } from './content-grounding-validator';
 import { ContentQualityGate } from './content-quality-gate';
 import { StaticDataRegistry } from './static-data-registry';
@@ -399,10 +400,16 @@ Return as XML:
     // Get recent posts from main actors
     const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
 
-    // Get main actors
-    const mainActors = StaticDataRegistry.getAllActors()
-      .filter((a) => a.role === 'main' || a.tier === 'S_TIER')
-      .slice(0, 5);
+    // Get actors from S/A/B tiers, shuffled for rotation across cycles
+    const mainActors = shuffleArray(
+      StaticDataRegistry.getAllActors().filter(
+        (a) =>
+          a.role === 'main' ||
+          a.tier === 'S_TIER' ||
+          a.tier === 'A_TIER' ||
+          a.tier === 'B_TIER'
+      )
+    ).slice(0, 8);
 
     if (mainActors.length === 0) {
       return [];


### PR DESCRIPTION
## Summary

- **User agents now see world events** — removed `isNpc` gate in `MultiStepExecutor` and prompt template so user-controlled agents can trade on narrative signals
- **Actor diversity with cooldown** — replaced hard S/A-tier filter in `selectRelevantActors()` with weighted selection (tier weight × 4h cooldown × affiliation penalty). AIlon Musk drops from ~9% to ~2-3% selection rate.
- **Event type diversity** — rolling-window history with exponential decay penalty prevents the same event types repeating across consecutive ticks
- **Question pool widened** — shuffled active questions and increased cap from 3→5 so events spread across more markets
- **World facts actor pool widened** — expanded from top-5 S_TIER to shuffled S/A/B tier (slice 8) for fact generation
- **Parody entity cap** — max 3 mentions of any character entity per parody batch, breaking the Elon→AIlon feedback loop
- **Daily topic rotation** — 80% score penalty for topics used in last 3 days, with new `getRecentTopicKeys()` helper

## Files changed (7)

| File | Change |
|------|--------|
| `MultiStepExecutor.ts` | Remove `isNpc` world events gate |
| `multi-step-decision.ts` | Remove `isNpc &&` from prompt template |
| `event-generation-helpers.ts` | Rewrite `selectRelevantActors()` + `selectEventType()` |
| `game-tick.ts` | Shuffle + widen question pool (3→5) |
| `world-facts-generator.ts` | Widen actor pool to S/A/B, shuffle |
| `parody-headline-generator.ts` | Add per-entity cap in batch loop |
| `daily-topic-service.ts` | Add `getRecentTopicKeys()` + rotation penalty |

## Test plan

- [ ] `bun run typecheck` passes (verified locally)
- [ ] `bun run lint` passes with zero warnings (verified locally)
- [ ] `bun run inspect:context -- --npc ailon-musk --type trading --raw` still renders correctly
- [ ] After a few game ticks: query `WorldEvent` table, verify no single actor exceeds 20% of events in 48h
- [ ] After a few game ticks: verify all 7 event types appear in a 48h window
- [ ] Verify agent context now includes "Recent World Events" section via `inspect:context -- --agent <userId> --raw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)