### PR TITLE
fix: restrict SEND_MONEY to agent-only recipients

### DIFF
--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -2620,9 +2620,17 @@ export async function executeDirectSendMoney(
     return { success: false, error: 'Amount must be a positive number' };
   }
 
-  // Verify recipient exists
+  // Verify recipient exists and is a valid transfer target.
+  // Policy: agents can only send to other agents, not to human users.
+  // This matches the platform restriction in /api/points/transfer where
+  // user-to-user transfers are disabled — agents must not bypass that.
   const [recipient] = await db
-    .select({ id: users.id })
+    .select({
+      id: users.id,
+      isAgent: users.isAgent,
+      isActor: users.isActor,
+      managedBy: users.managedBy,
+    })
     .from(users)
     .where(eq(users.id, cleanRecipientId))
     .limit(1);
@@ -2631,6 +2639,40 @@ export async function executeDirectSendMoney(
     return {
       success: false,
       error: `Recipient not found: ${cleanRecipientId}`,
+    };
+  }
+
+  if (recipient.isActor) {
+    return {
+      success: false,
+      error: 'Cannot send money to NPCs',
+    };
+  }
+
+  if (!recipient.isAgent) {
+    return {
+      success: false,
+      error:
+        'Transfers to non-agent users are disabled. Agents can only send money to other agents.',
+    };
+  }
+
+  // Block transfers to agents owned by the same user (anti-laundering).
+  // Look up sender's owner to compare.
+  const [senderInfo] = await db
+    .select({ managedBy: users.managedBy })
+    .from(users)
+    .where(eq(users.id, agentUserId))
+    .limit(1);
+
+  if (
+    senderInfo?.managedBy &&
+    recipient.managedBy &&
+    senderInfo.managedBy === recipient.managedBy
+  ) {
+    return {
+      success: false,
+      error: 'Cannot transfer between agents owned by the same user',
     };
   }
 

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -2683,11 +2683,16 @@ export async function executeDirectSendMoney(
     : `Transfer to ${cleanRecipientId}`;
 
   try {
-    // Balance check + cap + debit + credit all inside one transaction
-    // to eliminate TOCTOU race on the balance cap calculation.
+    // Balance check + cap + debit + credit all inside one transaction.
+    // Read balance via tx directly (not WalletService.getBalance which
+    // uses the global db client and would bypass transaction isolation).
     const transferredAmount = await withTransaction(async (tx) => {
-      const balanceInfo = await WalletService.getBalance(agentUserId);
-      const balance = balanceInfo.balance;
+      const [balanceRow] = await tx
+        .select({ virtualBalance: users.virtualBalance })
+        .from(users)
+        .where(eq(users.id, agentUserId))
+        .limit(1);
+      const balance = Number(balanceRow?.virtualBalance ?? 0);
 
       if (balance <= 0) {
         throw new Error('Insufficient balance');

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -90,6 +90,7 @@ export interface MultiStepExecutorResult {
   success: boolean;
   actionsExecuted: {
     trades: number;
+    transfers: number;
     posts: number;
     comments: number;
     messages: number;
@@ -2091,7 +2092,7 @@ export class MultiStepExecutor {
   ): Promise<ActionTraceResult> {
     const recipientId = this.coerceParameterText(parameters.recipientId);
     const amount = Number(parameters.amount);
-    const reason = parameters.reason as string | undefined;
+    const reason = this.coerceParameterText(parameters.reason) || undefined;
 
     if (!recipientId || !Number.isFinite(amount) || amount <= 0) {
       return {
@@ -2709,6 +2710,7 @@ export class MultiStepExecutor {
   ): MultiStepExecutorResult {
     const counts = {
       trades: 0,
+      transfers: 0,
       posts: 0,
       comments: 0,
       messages: 0,
@@ -2720,8 +2722,10 @@ export class MultiStepExecutor {
 
       switch (result.actionType) {
         case Actions.TRADE:
-        case Actions.SEND_MONEY:
           counts.trades++;
+          break;
+        case Actions.SEND_MONEY:
+          counts.transfers++;
           break;
         case Actions.POST:
           counts.posts++;

--- a/packages/agents/src/autonomous/__tests__/direct-send-money.test.ts
+++ b/packages/agents/src/autonomous/__tests__/direct-send-money.test.ts
@@ -1,6 +1,23 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
-let mockRecipientUser: { id: string } | null = { id: 'user-2' };
+// Recipient returned by the first DB query (recipient lookup)
+let mockRecipientUser: {
+  id: string;
+  isAgent: boolean;
+  isActor: boolean;
+  managedBy: string | null;
+} | null = {
+  id: 'agent-2',
+  isAgent: true,
+  isActor: false,
+  managedBy: 'owner-B',
+};
+
+// Sender info returned by the second DB query (managedBy lookup)
+let mockSenderInfo: { managedBy: string | null } | null = {
+  managedBy: 'owner-A',
+};
+
 let mockSenderBalance = 1000;
 let lastDebitCall: {
   userId: string;
@@ -20,12 +37,22 @@ let debitShouldFail = false;
 
 const invalidateUserCacheMock = mock(async () => undefined);
 
+// Track sequential DB queries: first call = recipient lookup, second = sender managedBy
+let dbSelectCallCount = 0;
+
 const mockDb = {
-  // The only DB query executeDirectSendMoney makes is to check if recipient exists
   select: mock(() => ({
     from: mock(() => ({
       where: mock(() => ({
-        limit: mock(async () => (mockRecipientUser ? [mockRecipientUser] : [])),
+        limit: mock(async () => {
+          dbSelectCallCount++;
+          if (dbSelectCallCount === 1) {
+            // First query: recipient lookup
+            return mockRecipientUser ? [mockRecipientUser] : [];
+          }
+          // Second query: sender managedBy lookup
+          return mockSenderInfo ? [mockSenderInfo] : [];
+        }),
       })),
     })),
   })),
@@ -77,8 +104,13 @@ mock.module('@babylon/db', () => ({
   reactions: {},
   shares: { id: 'id', postId: 'postId', userId: 'userId' },
   sql: {},
-  users: { id: 'id', isActor: 'isActor', displayName: 'displayName' },
-  // withTransaction executes the callback immediately (no real DB)
+  users: {
+    id: 'id',
+    isActor: 'isActor',
+    isAgent: 'isAgent',
+    managedBy: 'managedBy',
+    displayName: 'displayName',
+  },
   withTransaction: mock(async (fn: (tx: unknown) => Promise<unknown>) =>
     fn(mockDb)
   ),
@@ -186,17 +218,29 @@ const { executeDirectSendMoney } = await import('../DirectExecutors');
 
 describe('executeDirectSendMoney', () => {
   beforeEach(() => {
-    mockRecipientUser = { id: 'user-2' };
+    // Default: recipient is a valid agent owned by a different user
+    mockRecipientUser = {
+      id: 'agent-2',
+      isAgent: true,
+      isActor: false,
+      managedBy: 'owner-B',
+    };
+    mockSenderInfo = { managedBy: 'owner-A' };
     mockSenderBalance = 1000;
     lastDebitCall = null;
     lastCreditCall = null;
     debitShouldFail = false;
+    dbSelectCallCount = 0;
   });
 
-  test('sends money successfully and returns updated balance', async () => {
+  // =========================================================================
+  // Success cases
+  // =========================================================================
+
+  test('sends money to another agent successfully', async () => {
     const result = await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
+      recipientId: 'agent-2',
       amount: 100,
       reason: 'payment for services',
     });
@@ -209,7 +253,7 @@ describe('executeDirectSendMoney', () => {
     expect(lastDebitCall!.amount).toBe(100);
     expect(lastDebitCall!.type).toBe('transfer_sent');
     expect(lastCreditCall).toBeDefined();
-    expect(lastCreditCall!.userId).toBe('user-2');
+    expect(lastCreditCall!.userId).toBe('agent-2');
     expect(lastCreditCall!.amount).toBe(100);
     expect(lastCreditCall!.type).toBe('transfer_received');
   });
@@ -217,7 +261,7 @@ describe('executeDirectSendMoney', () => {
   test('links debit and credit with same transactionId', async () => {
     await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
+      recipientId: 'agent-2',
       amount: 50,
     });
 
@@ -228,7 +272,7 @@ describe('executeDirectSendMoney', () => {
   test('includes reason in transaction descriptions', async () => {
     await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
+      recipientId: 'agent-2',
       amount: 50,
       reason: 'bet payment',
     });
@@ -237,17 +281,31 @@ describe('executeDirectSendMoney', () => {
     expect(lastCreditCall!.description).toContain('bet payment');
   });
 
+  test('sends without reason (optional parameter)', async () => {
+    const result = await executeDirectSendMoney({
+      agentUserId: 'agent-1',
+      recipientId: 'agent-2',
+      amount: 25,
+    });
+
+    expect(result.success).toBe(true);
+    expect(lastDebitCall!.description).not.toContain('undefined');
+  });
+
+  // =========================================================================
+  // Balance cap
+  // =========================================================================
+
   test('caps transfer at 50% of balance', async () => {
     mockSenderBalance = 1000;
 
     const result = await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
-      amount: 800, // > 50% of 1000
+      recipientId: 'agent-2',
+      amount: 800,
     });
 
     expect(result.success).toBe(true);
-    // Should be capped to 500 (50% of 1000)
     expect(lastDebitCall!.amount).toBe(500);
     expect(lastCreditCall!.amount).toBe(500);
   });
@@ -257,13 +315,116 @@ describe('executeDirectSendMoney', () => {
 
     const result = await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
+      recipientId: 'agent-2',
       amount: 500,
     });
 
     expect(result.success).toBe(true);
     expect(lastDebitCall!.amount).toBe(500);
   });
+
+  // =========================================================================
+  // Recipient restrictions (anti-bypass for user-to-user transfer ban)
+  // =========================================================================
+
+  test('rejects transfer to a human user (non-agent)', async () => {
+    mockRecipientUser = {
+      id: 'human-user',
+      isAgent: false,
+      isActor: false,
+      managedBy: null,
+    };
+
+    const result = await executeDirectSendMoney({
+      agentUserId: 'agent-1',
+      recipientId: 'human-user',
+      amount: 100,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('non-agent users are disabled');
+    expect(lastDebitCall).toBeNull();
+  });
+
+  test('rejects transfer to an NPC/actor', async () => {
+    mockRecipientUser = {
+      id: 'npc-1',
+      isAgent: false,
+      isActor: true,
+      managedBy: null,
+    };
+
+    const result = await executeDirectSendMoney({
+      agentUserId: 'agent-1',
+      recipientId: 'npc-1',
+      amount: 100,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Cannot send money to NPCs');
+    expect(lastDebitCall).toBeNull();
+  });
+
+  test('rejects transfer between agents owned by the same user', async () => {
+    mockRecipientUser = {
+      id: 'agent-2',
+      isAgent: true,
+      isActor: false,
+      managedBy: 'same-owner',
+    };
+    mockSenderInfo = { managedBy: 'same-owner' };
+
+    const result = await executeDirectSendMoney({
+      agentUserId: 'agent-1',
+      recipientId: 'agent-2',
+      amount: 100,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('same user');
+    expect(lastDebitCall).toBeNull();
+  });
+
+  test('allows transfer between agents owned by different users', async () => {
+    mockRecipientUser = {
+      id: 'agent-2',
+      isAgent: true,
+      isActor: false,
+      managedBy: 'owner-B',
+    };
+    mockSenderInfo = { managedBy: 'owner-A' };
+
+    const result = await executeDirectSendMoney({
+      agentUserId: 'agent-1',
+      recipientId: 'agent-2',
+      amount: 100,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('allows transfer when sender has no managedBy (edge case)', async () => {
+    // Sender is not managed by anyone (perhaps a standalone agent)
+    mockSenderInfo = { managedBy: null };
+    mockRecipientUser = {
+      id: 'agent-2',
+      isAgent: true,
+      isActor: false,
+      managedBy: 'owner-B',
+    };
+
+    const result = await executeDirectSendMoney({
+      agentUserId: 'agent-1',
+      recipientId: 'agent-2',
+      amount: 100,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  // =========================================================================
+  // Input validation
+  // =========================================================================
 
   test('rejects self-transfer', async () => {
     const result = await executeDirectSendMoney({
@@ -280,7 +441,7 @@ describe('executeDirectSendMoney', () => {
   test('rejects zero amount', async () => {
     const result = await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
+      recipientId: 'agent-2',
       amount: 0,
     });
 
@@ -292,7 +453,7 @@ describe('executeDirectSendMoney', () => {
   test('rejects negative amount', async () => {
     const result = await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
+      recipientId: 'agent-2',
       amount: -50,
     });
 
@@ -303,7 +464,7 @@ describe('executeDirectSendMoney', () => {
   test('rejects NaN amount', async () => {
     const result = await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
+      recipientId: 'agent-2',
       amount: Number.NaN,
     });
 
@@ -335,12 +496,16 @@ describe('executeDirectSendMoney', () => {
     expect(result.error).toContain('not found');
   });
 
+  // =========================================================================
+  // Balance checks
+  // =========================================================================
+
   test('rejects when sender has zero balance', async () => {
     mockSenderBalance = 0;
 
     const result = await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
+      recipientId: 'agent-2',
       amount: 100,
     });
 
@@ -353,22 +518,11 @@ describe('executeDirectSendMoney', () => {
 
     const result = await executeDirectSendMoney({
       agentUserId: 'agent-1',
-      recipientId: 'user-2',
+      recipientId: 'agent-2',
       amount: 100,
     });
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('Insufficient balance');
-  });
-
-  test('sends without reason (optional parameter)', async () => {
-    const result = await executeDirectSendMoney({
-      agentUserId: 'agent-1',
-      recipientId: 'user-2',
-      amount: 25,
-    });
-
-    expect(result.success).toBe(true);
-    expect(lastDebitCall!.description).not.toContain('undefined');
   });
 });

--- a/packages/agents/src/autonomous/__tests__/direct-send-money.test.ts
+++ b/packages/agents/src/autonomous/__tests__/direct-send-money.test.ts
@@ -37,7 +37,8 @@ let debitShouldFail = false;
 
 const invalidateUserCacheMock = mock(async () => undefined);
 
-// Track sequential DB queries: first call = recipient lookup, second = sender managedBy
+// Track sequential DB queries:
+// 1 = recipient lookup, 2 = sender managedBy, 3 = balance read inside tx
 let dbSelectCallCount = 0;
 
 const mockDb = {
@@ -47,11 +48,15 @@ const mockDb = {
         limit: mock(async () => {
           dbSelectCallCount++;
           if (dbSelectCallCount === 1) {
-            // First query: recipient lookup
+            // First query: recipient lookup (isAgent, isActor, managedBy)
             return mockRecipientUser ? [mockRecipientUser] : [];
           }
-          // Second query: sender managedBy lookup
-          return mockSenderInfo ? [mockSenderInfo] : [];
+          if (dbSelectCallCount === 2) {
+            // Second query: sender managedBy lookup
+            return mockSenderInfo ? [mockSenderInfo] : [];
+          }
+          // Third query: balance read inside withTransaction
+          return [{ virtualBalance: String(mockSenderBalance) }];
         }),
       })),
     })),
@@ -110,6 +115,7 @@ mock.module('@babylon/db', () => ({
     isAgent: 'isAgent',
     managedBy: 'managedBy',
     displayName: 'displayName',
+    virtualBalance: 'virtualBalance',
   },
   withTransaction: mock(async (fn: (tx: unknown) => Promise<unknown>) =>
     fn(mockDb)


### PR DESCRIPTION
## Summary

- Prevents `SEND_MONEY` from bypassing the platform's user-to-user transfer ban
- The existing `/api/points/transfer` endpoint blocks transfers to non-agent users with: *"User-to-user point transfers are temporarily disabled while the points model is under review"*
- Without this fix, agents could be used as a middleman: `User A → fund agent → agent SEND_MONEY to User B`
- Depends on #1430

## Changes

Three recipient restrictions added to `executeDirectSendMoney()`:

1. **Block NPC/actor recipients** — NPCs use a different balance system (`actorState.tradingBalance`), crediting their `WalletService` balance would be incorrect
2. **Block non-agent (human user) recipients** — matches the platform policy in `/api/points/transfer` line 166-173 where `!recipient.isAgent` returns an error
3. **Block same-owner transfers** — compares `managedBy` of sender and recipient to prevent laundering through two agents owned by the same user (User A's agent → User A's other agent → withdraw)

## Test plan

- [x] 19 unit tests (5 new restriction-specific tests):
  - [x] Rejects transfer to human user (non-agent)
  - [x] Rejects transfer to NPC/actor
  - [x] Rejects transfer between agents owned by same user
  - [x] Allows transfer between agents owned by different users
  - [x] Allows transfer when sender has no managedBy (edge case)
  - [x] All 14 original tests still pass (success paths, validation, balance cap)
- [x] `bun run check` — passed
- [x] `bun run typecheck` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)