### PR TITLE
feat: enrich prediction market context profiles

### DIFF
--- a/packages/engine/src/services/market-context-helpers.test.ts
+++ b/packages/engine/src/services/market-context-helpers.test.ts
@@ -62,6 +62,10 @@ describe('market-context-helpers', () => {
     expect(snapshot.noPrice).toBe(60);
     expect(snapshot.totalVolume).toBe(20000);
     expect(snapshot.daysUntilResolution).toBe(4);
+    expect(snapshot.horizonBucket).toBe('medium');
+    expect(snapshot.liquidityTier).toBe('balanced');
+    expect(snapshot.urgencyLevel).toBe('near-term');
+    expect(snapshot.eventSensitivity).toBe('high');
   });
 
   it('truncates long prediction questions for token discipline', () => {

--- a/packages/engine/src/services/market-context-helpers.ts
+++ b/packages/engine/src/services/market-context-helpers.ts
@@ -3,7 +3,10 @@ import {
   type PredictionMarketRecord,
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
-import { buildPredictionMarketProfile } from './prediction-market-profiles';
+import {
+  buildPredictionMarketProfile,
+  getPredictionMarketLiquidityTier,
+} from './prediction-market-profiles';
 import type {
   PerpMarketSnapshot,
   PredictionMarketSnapshot,
@@ -79,7 +82,7 @@ export function buildPredictionMarketSnapshot(
     resolutionDate: market.endDate.toISOString(),
     daysUntilResolution,
     horizonBucket: profile.horizonBucket,
-    liquidityTier: profile.liquidityTier,
+    liquidityTier: getPredictionMarketLiquidityTier(market.liquidity),
     urgencyLevel: profile.urgencyLevel,
     eventSensitivity: profile.eventSensitivity,
   };

--- a/packages/engine/src/services/market-context-helpers.ts
+++ b/packages/engine/src/services/market-context-helpers.ts
@@ -2,7 +2,8 @@ import type { PerpMarketRecord } from '@babylon/core/markets/perps';
 import {
   type PredictionMarketRecord,
   PredictionPricing,
-} from '@babylon/core/markets/prediction';
+} from '@babylon/core/markets/prediction/client';
+import { buildPredictionMarketProfile } from './prediction-market-profiles';
 import type {
   PerpMarketSnapshot,
   PredictionMarketSnapshot,
@@ -43,6 +44,12 @@ export function buildPredictionMarketSnapshot(
     maxQuestionLength?: number;
   }
 ): PredictionMarketSnapshot {
+  const profile = buildPredictionMarketProfile({
+    marketId: market.id,
+    question: market.question,
+    endDate: market.endDate,
+    now,
+  });
   const yesPrice =
     PredictionPricing.getCurrentPrice(
       market.yesShares,
@@ -71,5 +78,9 @@ export function buildPredictionMarketSnapshot(
     totalVolume: market.liquidity,
     resolutionDate: market.endDate.toISOString(),
     daysUntilResolution,
+    horizonBucket: profile.horizonBucket,
+    liquidityTier: profile.liquidityTier,
+    urgencyLevel: profile.urgencyLevel,
+    eventSensitivity: profile.eventSensitivity,
   };
 }

--- a/packages/engine/src/services/market-context-service.ts
+++ b/packages/engine/src/services/market-context-service.ts
@@ -62,6 +62,7 @@ import {
 } from './market-context-helpers';
 import { SignalExtractionService } from './signal-extraction-service';
 import { StaticDataRegistry } from './static-data-registry';
+import { buildPredictionMarketProfile } from './prediction-market-profiles';
 
 export class MarketContextService {
   /**
@@ -139,17 +140,28 @@ export class MarketContextService {
 
       // Use centralized prediction market constants
       const predictionMarkets: PredictionMarketSnapshot[] =
-        SIMULATION_PREDICTION_MARKETS.map((m) => ({
-          id: m.id,
-          text: m.text,
-          yesPrice: m.yesPrice,
-          noPrice: m.noPrice,
-          totalVolume: m.totalVolume,
-          resolutionDate: new Date(
-            Date.now() + m.resolveDays * 86400000
-          ).toISOString(),
-          daysUntilResolution: m.resolveDays,
-        }));
+        SIMULATION_PREDICTION_MARKETS.map((m) => {
+          const profile = buildPredictionMarketProfile({
+            marketId: m.id,
+            question: m.text,
+            endDate: new Date(Date.now() + m.resolveDays * 86400000),
+          });
+          return {
+            id: m.id,
+            text: m.text,
+            yesPrice: m.yesPrice,
+            noPrice: m.noPrice,
+            totalVolume: m.totalVolume,
+            resolutionDate: new Date(
+              Date.now() + m.resolveDays * 86400000
+            ).toISOString(),
+            daysUntilResolution: m.resolveDays,
+            horizonBucket: profile.horizonBucket,
+            liquidityTier: profile.liquidityTier,
+            urgencyLevel: profile.urgencyLevel,
+            eventSensitivity: profile.eventSensitivity,
+          };
+        });
 
       // Use provided events or empty array
       const recentEvents = options?.recentEvents ?? [];

--- a/packages/engine/src/services/market-context-service.ts
+++ b/packages/engine/src/services/market-context-service.ts
@@ -62,7 +62,10 @@ import {
 } from './market-context-helpers';
 import { SignalExtractionService } from './signal-extraction-service';
 import { StaticDataRegistry } from './static-data-registry';
-import { buildPredictionMarketProfile } from './prediction-market-profiles';
+import {
+  buildPredictionMarketProfile,
+  getPredictionMarketLiquidityTier,
+} from './prediction-market-profiles';
 
 export class MarketContextService {
   /**
@@ -157,7 +160,7 @@ export class MarketContextService {
             ).toISOString(),
             daysUntilResolution: m.resolveDays,
             horizonBucket: profile.horizonBucket,
-            liquidityTier: profile.liquidityTier,
+            liquidityTier: getPredictionMarketLiquidityTier(m.totalVolume),
             urgencyLevel: profile.urgencyLevel,
             eventSensitivity: profile.eventSensitivity,
           };

--- a/packages/engine/src/services/prediction-market-profiles.test.ts
+++ b/packages/engine/src/services/prediction-market-profiles.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { buildPredictionMarketProfile } from './prediction-market-profiles';
+import {
+  buildPredictionMarketProfile,
+  getPredictionMarketLiquidityTier,
+} from './prediction-market-profiles';
 
 describe('prediction-market-profiles', () => {
   it('builds deterministic profiles for the same market input', () => {
@@ -39,7 +42,6 @@ describe('prediction-market-profiles', () => {
     );
     expect(short.urgencyLevel).toBe('imminent');
     expect(long.urgencyLevel).toBe('dated');
-    expect(['thin', 'balanced', 'deep']).toContain(short.liquidityTier);
     expect(['low', 'medium', 'high']).toContain(short.eventSensitivity);
   });
 
@@ -52,5 +54,11 @@ describe('prediction-market-profiles', () => {
     });
 
     expect(profile.initialYesProbability).toBe(0.5);
+  });
+
+  it('derives liquidity tiers from actual market depth', () => {
+    expect(getPredictionMarketLiquidityTier(8_000)).toBe('thin');
+    expect(getPredictionMarketLiquidityTier(18_000)).toBe('balanced');
+    expect(getPredictionMarketLiquidityTier(80_000)).toBe('deep');
   });
 });

--- a/packages/engine/src/services/prediction-market-profiles.test.ts
+++ b/packages/engine/src/services/prediction-market-profiles.test.ts
@@ -37,6 +37,10 @@ describe('prediction-market-profiles', () => {
     expect(short.neutralReversionMultiplier).toBeLessThan(
       long.neutralReversionMultiplier
     );
+    expect(short.urgencyLevel).toBe('imminent');
+    expect(long.urgencyLevel).toBe('dated');
+    expect(['thin', 'balanced', 'deep']).toContain(short.liquidityTier);
+    expect(['low', 'medium', 'high']).toContain(short.eventSensitivity);
   });
 
   it('keeps opening prior anchored around 50/50', () => {

--- a/packages/engine/src/services/prediction-market-profiles.ts
+++ b/packages/engine/src/services/prediction-market-profiles.ts
@@ -1,5 +1,8 @@
 export interface PredictionMarketProfile {
   horizonBucket: 'short' | 'medium' | 'long';
+  liquidityTier: 'thin' | 'balanced' | 'deep';
+  urgencyLevel: 'imminent' | 'near-term' | 'dated';
+  eventSensitivity: 'low' | 'medium' | 'high';
   initialLiquidity: number;
   initialYesProbability: number;
   signalSensitivity: number;
@@ -41,12 +44,80 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 function stableUnit(seed: string): number {
+  // FNV-1a style stable hash for deterministic per-market jitter.
   let hash = 2166136261;
   for (let i = 0; i < seed.length; i++) {
     hash ^= seed.charCodeAt(i);
     hash = Math.imul(hash, 16777619);
   }
   return (hash >>> 0) / 4294967295;
+}
+
+function getUrgencyLevel(
+  endDate: Date,
+  now: Date
+): PredictionMarketProfile['urgencyLevel'] {
+  const daysToResolution = Math.max(
+    0,
+    (endDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  if (daysToResolution <= 1.5) return 'imminent';
+  if (daysToResolution <= 4) return 'near-term';
+  return 'dated';
+}
+
+function getLiquidityTier(
+  initialLiquidity: number
+): PredictionMarketProfile['liquidityTier'] {
+  if (initialLiquidity >= 21_000) return 'deep';
+  if (initialLiquidity >= 15_000) return 'balanced';
+  return 'thin';
+}
+
+function getEventSensitivity(input: {
+  horizonBucket: PredictionMarketProfile['horizonBucket'];
+  question: string;
+}): PredictionMarketProfile['eventSensitivity'] {
+  const text = input.question.toLowerCase();
+  const eventDrivenKeywords = [
+    'announce',
+    'launch',
+    'release',
+    'ship',
+    'approve',
+    'vote',
+    'acquire',
+    'merger',
+    'earnings',
+    'publish',
+    'file',
+    'cut rates',
+    'partnership',
+  ];
+  const slowBurnKeywords = [
+    'maintain',
+    'remain',
+    'by month',
+    'by year',
+    'over the next',
+  ];
+
+  if (
+    input.horizonBucket === 'short' ||
+    eventDrivenKeywords.some((keyword) => text.includes(keyword))
+  ) {
+    return 'high';
+  }
+
+  if (
+    input.horizonBucket === 'long' &&
+    slowBurnKeywords.some((keyword) => text.includes(keyword))
+  ) {
+    return 'low';
+  }
+
+  return 'medium';
 }
 
 function getHorizonBucket(
@@ -79,9 +150,17 @@ export function buildPredictionMarketProfile(input: {
   const nudgeJitter = 0.92 + stableUnit(`${seedBase}:nudge`) * 0.16;
   const reversionJitter = 0.92 + stableUnit(`${seedBase}:revert`) * 0.16;
 
+  const initialLiquidity = Math.round(preset.initialLiquidity * liquidityJitter);
+
   return {
     horizonBucket,
-    initialLiquidity: Math.round(preset.initialLiquidity * liquidityJitter),
+    liquidityTier: getLiquidityTier(initialLiquidity),
+    urgencyLevel: getUrgencyLevel(input.endDate, now),
+    eventSensitivity: getEventSensitivity({
+      horizonBucket,
+      question: input.question,
+    }),
+    initialLiquidity,
     initialYesProbability: 0.5,
     signalSensitivity: clamp(
       preset.signalSensitivity * sensitivityJitter,

--- a/packages/engine/src/services/prediction-market-profiles.ts
+++ b/packages/engine/src/services/prediction-market-profiles.ts
@@ -1,6 +1,5 @@
 export interface PredictionMarketProfile {
   horizonBucket: 'short' | 'medium' | 'long';
-  liquidityTier: 'thin' | 'balanced' | 'deep';
   urgencyLevel: 'imminent' | 'near-term' | 'dated';
   eventSensitivity: 'low' | 'medium' | 'high';
   initialLiquidity: number;
@@ -15,9 +14,16 @@ export interface PredictionMarketInitialization {
   initialYesProbability: number;
 }
 
+interface PredictionMarketProfilePreset {
+  initialLiquidity: number;
+  signalSensitivity: number;
+  autoAmmNudgeMultiplier: number;
+  neutralReversionMultiplier: number;
+}
+
 const HORIZON_PRESETS: Record<
   PredictionMarketProfile['horizonBucket'],
-  Omit<PredictionMarketProfile, 'horizonBucket' | 'initialYesProbability'>
+  PredictionMarketProfilePreset
 > = {
   short: {
     initialLiquidity: 12_000,
@@ -67,11 +73,11 @@ function getUrgencyLevel(
   return 'dated';
 }
 
-function getLiquidityTier(
-  initialLiquidity: number
-): PredictionMarketProfile['liquidityTier'] {
-  if (initialLiquidity >= 21_000) return 'deep';
-  if (initialLiquidity >= 15_000) return 'balanced';
+export function getPredictionMarketLiquidityTier(
+  totalVolume: number
+): 'thin' | 'balanced' | 'deep' {
+  if (totalVolume >= 40_000) return 'deep';
+  if (totalVolume >= 15_000) return 'balanced';
   return 'thin';
 }
 
@@ -154,7 +160,6 @@ export function buildPredictionMarketProfile(input: {
 
   return {
     horizonBucket,
-    liquidityTier: getLiquidityTier(initialLiquidity),
     urgencyLevel: getUrgencyLevel(input.endDate, now),
     eventSensitivity: getEventSensitivity({
       horizonBucket,

--- a/packages/engine/src/types/market-context.ts
+++ b/packages/engine/src/types/market-context.ts
@@ -27,6 +27,10 @@ export interface PredictionMarketSnapshot {
   totalVolume: number;
   resolutionDate: string;
   daysUntilResolution: number;
+  horizonBucket: 'short' | 'medium' | 'long';
+  liquidityTier: 'thin' | 'balanced' | 'deep';
+  urgencyLevel: 'imminent' | 'near-term' | 'dated';
+  eventSensitivity: 'low' | 'medium' | 'high';
 }
 
 export interface NPCPosition {

--- a/packages/engine/src/utils/trading-dashboard-format.ts
+++ b/packages/engine/src/utils/trading-dashboard-format.ts
@@ -158,18 +158,19 @@ export function formatMarketDataTable(ctx: NPCMarketContext): string {
   }
 
   let table =
-    '| Ticker/ID | Type | Price | 24h Change | 24h Range | Volume |\n|---|---|---|---|---|---|\n';
+    '| Ticker/ID | Type | Price | 24h Change | 24h Range | Context | Volume |\n|---|---|---|---|---|---|---|\n';
 
   for (const p of perps) {
     const sign = p.changePercent24h >= 0 ? '+' : '';
     const range = `$${p.low24h.toFixed(2)}-$${p.high24h.toFixed(2)}`;
-    table += `| ${p.ticker} | PERP | $${p.currentPrice.toFixed(2)} | ${sign}${p.changePercent24h.toFixed(2)}% | ${range} | $${(p.volume24h / 1000).toFixed(1)}k |\n`;
+    table += `| ${p.ticker} | PERP | $${p.currentPrice.toFixed(2)} | ${sign}${p.changePercent24h.toFixed(2)}% | ${range} | spot | $${(p.volume24h / 1000).toFixed(1)}k |\n`;
   }
 
   for (const p of predictions) {
     const daysLeft = p.daysUntilResolution;
     const safeText = p.text.replace(/\|/g, '/');
-    table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}¢ / No: ${p.noPrice.toFixed(0)}¢ | ${daysLeft}d left | "${safeText}" | $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
+    const contextLabel = `${p.horizonBucket} / ${p.liquidityTier} / ${p.urgencyLevel} / ${p.eventSensitivity}`;
+    table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}¢ / No: ${p.noPrice.toFixed(0)}¢ | ${daysLeft}d left | "${safeText}" | ${contextLabel} | $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
   }
 
   return table;


### PR DESCRIPTION
## Summary
- enrich prediction market profiles with urgency, liquidity tier, and event-sensitivity traits
- expose that richer identity through prediction market snapshots in NPC market context
- surface the new prediction identity in the trading dashboard formatter so agent/NPC prompts can differentiate markets more coherently

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Follows the merged prediction profiles groundwork from `#1433`
- Focused on prediction market context/identity, not perps and not public UI

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] Other areas

## Non-goals / follow-ups
- No public prediction UI changes
- No new prediction execution mechanics
- No calibration/admin diagnostics yet

## Changes
- enrich `PredictionMarketProfile` with `liquidityTier`, `urgencyLevel`, and `eventSensitivity`
- add those attributes to `PredictionMarketSnapshot`
- compute prediction snapshot identity in `market-context-helpers`
- keep simulation-mode prediction snapshots aligned with the same profile model
- update the market dashboard formatter used in agent/NPC decision context so prediction rows now carry structural context instead of just price/time/volume
- make `market-context-helpers` use the client-safe prediction import surface

## Review guide
**Start here**
- `packages/engine/src/services/prediction-market-profiles.ts`
- `packages/engine/src/types/market-context.ts`
- `packages/engine/src/services/market-context-helpers.ts`
- `packages/engine/src/utils/trading-dashboard-format.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This PR is about richer prediction market identity in agent-facing context only.
- The new fields are intentionally simple, derived, and deterministic.
- No trading math or market creation flow changes in this PR.

## Test plan
**Commands run**
- [ ] `bun run check`
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test`

**Focused verification / manual verification**
1. `bunx biome check --write` on touched files.
2. `bun test packages/engine/src/services/prediction-market-profiles.test.ts packages/engine/src/services/market-context-helpers.test.ts`
3. Verified the context snapshot contract now includes prediction identity fields and the formatter consumes them.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates
- [ ] Requires DB migration
- [ ] Changes cron schedule or endpoints
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes
- [x] None
- [ ] Yes

## Security / privacy
- [x] No security impact
- [ ] Needs extra review

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Internal engine/context enrichment only. This changes agent/NPC-visible prediction market context, not end-user UI surfaces.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path
- [x] Handlers remain thin and portable
- [x] Domain logic stays in packages
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] **Screenshots/recordings section filled**
