### PR TITLE
feat: client-side message caching — instant chat switching + IndexedDB persistence

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -92,6 +92,7 @@
     "geist": "^1.5.1",
     "grammy": "^1.41.1",
     "html-to-image": "^1.11.13",
+    "idb-keyval": "^6.2.2",
     "ioredis": "^5.8.2",
     "lucide-react": "^0.555.0",
     "nanoid": "5.1.7",

--- a/apps/web/src/app/api/chats/[id]/route.ts
+++ b/apps/web/src/app/api/chats/[id]/route.ts
@@ -376,15 +376,18 @@ export const GET = withErrorHandling(
     }
 
     // Check if there are more messages.
-    // For `after` queries: no pagination trick (we fetched exactly `limit`),
-    // and messages are already in chronological (ASC) order.
+    // For `after` queries: if we got exactly `limit` rows, there may be more
+    // beyond this page. Signal hasMore so the client can paginate.
+    // For cursor/initial queries: the +1 overfetch trick detects more pages.
     const isAfterQuery = !!after;
     const hasMore = isAfterQuery
-      ? false
+      ? fullChat.messages.length >= effectiveLimit
       : fullChat.messages.length > effectiveLimit;
-    const messagesList = hasMore
-      ? fullChat.messages.slice(0, effectiveLimit)
-      : fullChat.messages;
+    const messagesList = isAfterQuery
+      ? fullChat.messages
+      : hasMore
+        ? fullChat.messages.slice(0, effectiveLimit)
+        : fullChat.messages;
 
     // For cursor/initial queries: reverse from DESC to chronological order.
     // For after queries: already in ASC order from the query.

--- a/apps/web/src/app/api/chats/[id]/route.ts
+++ b/apps/web/src/app/api/chats/[id]/route.ts
@@ -61,6 +61,7 @@ import {
 import { requireNftChatAccess } from '@babylon/api/services/nft-chat-gating-service';
 import {
   and,
+  asc,
   asSystem,
   asUser,
   chatParticipants,
@@ -68,6 +69,7 @@ import {
   count,
   desc,
   eq,
+  gt,
   inArray,
   lt,
   messageReactions,
@@ -101,7 +103,8 @@ export const GET = withErrorHandling(
 
     const all = searchParams.get('all');
     const debug = searchParams.get('debug');
-    const cursor = searchParams.get('cursor'); // Cursor for pagination (message ID)
+    const cursor = searchParams.get('cursor'); // Cursor for pagination (message ID — loads OLDER messages)
+    const after = searchParams.get('after'); // ISO timestamp — loads NEWER messages since this time
     const limitParam = searchParams.get('limit');
 
     if (all) query.all = all;
@@ -187,10 +190,36 @@ export const GET = withErrorHandling(
         .from(chatParticipants)
         .where(eq(chatParticipants.chatId, chatId));
 
-      // Build message query with cursor-based pagination
+      // Build message query — three modes:
+      // 1. `after` (ISO timestamp): fetch messages NEWER than this time (ASC order, for sync)
+      // 2. `cursor` (message ID): fetch messages OLDER than this cursor (DESC order, for load-more)
+      // 3. Neither: fetch latest messages (DESC order, initial load)
       let messagesList;
-      if (cursor) {
-        // Get the cursor message to find its createdAt
+      if (after) {
+        // Incremental sync: only messages after the given timestamp
+        const afterDate = new Date(after);
+        if (Number.isNaN(afterDate.getTime())) {
+          messagesList = await db
+            .select()
+            .from(messages)
+            .where(eq(messages.chatId, chatId))
+            .orderBy(desc(messages.createdAt))
+            .limit(effectiveLimit + 1);
+        } else {
+          messagesList = await db
+            .select()
+            .from(messages)
+            .where(
+              and(
+                eq(messages.chatId, chatId),
+                gt(messages.createdAt, afterDate)
+              )
+            )
+            .orderBy(asc(messages.createdAt))
+            .limit(effectiveLimit);
+        }
+      } else if (cursor) {
+        // Load older messages: get cursor's timestamp, then fetch before it
         const [cursorMessage] = await db
           .select({ createdAt: messages.createdAt })
           .from(messages)
@@ -218,6 +247,7 @@ export const GET = withErrorHandling(
             .limit(effectiveLimit + 1);
         }
       } else {
+        // Initial load: latest messages
         messagesList = await db
           .select()
           .from(messages)
@@ -346,14 +376,22 @@ export const GET = withErrorHandling(
       }
     }
 
-    // Check if there are more messages
-    const hasMore = fullChat.messages.length > effectiveLimit;
+    // Check if there are more messages.
+    // For `after` queries: no pagination trick (we fetched exactly `limit`),
+    // and messages are already in chronological (ASC) order.
+    const isAfterQuery = !!after && !Number.isNaN(new Date(after).getTime());
+    const hasMore = isAfterQuery
+      ? false
+      : fullChat.messages.length > effectiveLimit;
     const messagesList = hasMore
       ? fullChat.messages.slice(0, effectiveLimit)
       : fullChat.messages;
 
-    // Reverse to get chronological order (oldest first)
-    const messagesInOrder = [...messagesList].reverse();
+    // For cursor/initial queries: reverse from DESC to chronological order.
+    // For after queries: already in ASC order from the query.
+    const messagesInOrder = isAfterQuery
+      ? messagesList
+      : [...messagesList].reverse();
 
     // Message reactions summary (counts + reactedByMe)
     const messageIds = messagesInOrder.map((m) => m.id);

--- a/apps/web/src/app/api/chats/[id]/route.ts
+++ b/apps/web/src/app/api/chats/[id]/route.ts
@@ -54,6 +54,7 @@
 import {
   AuthorizationError,
   authenticate,
+  BusinessLogicError,
   NotFoundError,
   successResponse,
   withErrorHandling,
@@ -199,12 +200,10 @@ export const GET = withErrorHandling(
         // Incremental sync: only messages after the given timestamp
         const afterDate = new Date(after);
         if (Number.isNaN(afterDate.getTime())) {
-          messagesList = await db
-            .select()
-            .from(messages)
-            .where(eq(messages.chatId, chatId))
-            .orderBy(desc(messages.createdAt))
-            .limit(effectiveLimit + 1);
+          throw new BusinessLogicError(
+            'Invalid after timestamp',
+            'INVALID_AFTER_TIMESTAMP'
+          );
         } else {
           messagesList = await db
             .select()
@@ -379,7 +378,7 @@ export const GET = withErrorHandling(
     // Check if there are more messages.
     // For `after` queries: no pagination trick (we fetched exactly `limit`),
     // and messages are already in chronological (ASC) order.
-    const isAfterQuery = !!after && !Number.isNaN(new Date(after).getTime());
+    const isAfterQuery = !!after;
     const hasMore = isAfterQuery
       ? false
       : fullChat.messages.length > effectiveLimit;

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -16,7 +16,8 @@ import type {
   ReplyToMessage,
 } from '../types';
 
-const CHAT_LIST_QUERY_KEY = ['chat-list'] as const;
+const chatListQueryKey = (userId: string | null) =>
+  userId ? (['chat-list', userId] as const) : (['chat-list'] as const);
 const CHAT_LIST_STALE_TIME = 30_000; // 30s — chat list changes when new messages arrive
 const CHAT_LIST_GC_TIME = 10 * 60_000; // 10 min
 
@@ -169,7 +170,7 @@ export function useChatPage() {
     }
 
     const chats = await queryClient.fetchQuery({
-      queryKey: CHAT_LIST_QUERY_KEY,
+      queryKey: chatListQueryKey(user?.id ?? null),
       queryFn: () => fetchChatList(token),
       staleTime: CHAT_LIST_STALE_TIME,
       gcTime: CHAT_LIST_GC_TIME,
@@ -184,6 +185,7 @@ export function useChatPage() {
     authenticated,
     queryClient,
     fetchChatList,
+    user?.id,
   ]);
 
   // Load chat details

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { logger } from '@babylon/shared';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
@@ -15,10 +16,15 @@ import type {
   ReplyToMessage,
 } from '../types';
 
+const CHAT_LIST_QUERY_KEY = ['chat-list'] as const;
+const CHAT_LIST_STALE_TIME = 30_000; // 30s — chat list changes when new messages arrive
+const CHAT_LIST_GC_TIME = 10 * 60_000; // 10 min
+
 export function useChatPage() {
   const router = useRouter();
   const { ready, authenticated, getAccessToken } = useAuth();
   const { user } = useAuthStore();
+  const queryClient = useQueryClient();
 
   // UI state
   const [activeFilter, setActiveFilter] = useState<ChatFilter>('all');
@@ -103,7 +109,49 @@ export function useChatPage() {
     markPendingReactionDelta,
   });
 
-  // Load chats
+  // Fetch chat list — shared query function used by both loadChats and React Query
+  const fetchChatList = useCallback(
+    async (token: string | null): Promise<Chat[]> => {
+      const [personalResponse, gameResponse] = await Promise.all([
+        fetch('/api/chats', {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        }),
+        isDebugMode ? fetch('/api/chats?all=true') : Promise.resolve(null),
+      ]);
+
+      if (!personalResponse.ok) return [];
+
+      const personalData = await personalResponse.json();
+
+      let gameChats: Chat[] = [];
+      if (gameResponse?.ok) {
+        const gameData = await gameResponse.json();
+        gameChats = gameData.chats || [];
+      }
+
+      const combined = [
+        ...(personalData.groupChats || []),
+        ...(personalData.directChats || []),
+        ...gameChats,
+      ].sort((a: Chat, b: Chat) => {
+        const aTime = a.lastMessage?.createdAt || a.updatedAt;
+        const bTime = b.lastMessage?.createdAt || b.updatedAt;
+        return new Date(bTime).getTime() - new Date(aTime).getTime();
+      });
+
+      // Client-side fallback: filter out DMs with the user's own agents
+      return combined.filter((chat: Chat) => {
+        if (chat.isGroup) return true;
+        if (chat.otherUser?.isAgent && chat.otherUser?.managedBy === user?.id) {
+          return false;
+        }
+        return true;
+      });
+    },
+    [isDebugMode, user?.id]
+  );
+
+  // Load chats — uses React Query for caching so revisiting the chat page is instant
   const loadChats = useCallback(async () => {
     setLoading(true);
 
@@ -120,52 +168,23 @@ export function useChatPage() {
       return;
     }
 
-    const [personalResponse, gameResponse] = await Promise.all([
-      fetch('/api/chats', {
-        headers: { Authorization: `Bearer ${token}` },
-      }),
-      isDebugMode ? fetch('/api/chats?all=true') : Promise.resolve(null),
-    ]);
-
-    if (!personalResponse.ok) {
-      setLoading(false);
-      return;
-    }
-
-    const personalData = await personalResponse.json();
-
-    let gameChats: Chat[] = [];
-    if (gameResponse?.ok) {
-      const gameData = await gameResponse.json();
-      gameChats = gameData.chats || [];
-    }
-
-    const combined = [
-      ...(personalData.groupChats || []),
-      ...(personalData.directChats || []),
-      ...gameChats,
-    ].sort((a, b) => {
-      const aTime = a.lastMessage?.createdAt || a.updatedAt;
-      const bTime = b.lastMessage?.createdAt || b.updatedAt;
-      return new Date(bTime).getTime() - new Date(aTime).getTime();
+    const chats = await queryClient.fetchQuery({
+      queryKey: CHAT_LIST_QUERY_KEY,
+      queryFn: () => fetchChatList(token),
+      staleTime: CHAT_LIST_STALE_TIME,
+      gcTime: CHAT_LIST_GC_TIME,
     });
 
-    // Client-side fallback: filter out DMs with the user's own agents
-    // This guards against any edge cases where API-level filtering didn't catch them
-    // Agent-owner communication should happen through /agents/team instead
-    const filteredCombined = combined.filter((chat) => {
-      // Only filter DMs (not group chats)
-      if (chat.isGroup) return true;
-      // Check if the other user is an agent managed by the current user
-      if (chat.otherUser?.isAgent && chat.otherUser?.managedBy === user?.id) {
-        return false;
-      }
-      return true;
-    });
-
-    setAllChats(filteredCombined);
+    setAllChats(chats);
     setLoading(false);
-  }, [getAccessToken, isDebugMode, ready, authenticated, user?.id]);
+  }, [
+    getAccessToken,
+    isDebugMode,
+    ready,
+    authenticated,
+    queryClient,
+    fetchChatList,
+  ]);
 
   // Load chat details
   const loadChatDetails = useCallback(

--- a/apps/web/src/components/providers/Providers.tsx
+++ b/apps/web/src/components/providers/Providers.tsx
@@ -2,7 +2,11 @@
 
 import { logger, privyConfig } from '@babylon/shared';
 import { type PrivyClientConfig, PrivyProvider } from '@privy-io/react-auth';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useTheme } from 'next-themes';
 import { Fragment, Suspense, useEffect, useRef, useState } from 'react';
 import { PostHogErrorBoundary } from '@/components/analytics/PostHogErrorBoundary';
@@ -15,6 +19,7 @@ import { WidgetRefreshProvider } from '@/contexts/WidgetRefreshContext';
 import { SessionHeartbeatProvider } from '@/hooks/useSessionHeartbeat';
 import { getBrowserDevAuthSession } from '@/lib/auth/dev-auth';
 import { hydrateChatCacheFromIndexedDB } from '@/lib/chat/hydrateChatCache';
+import { useAuthStore } from '@/stores/authStore';
 import { DiscordActivityProvider } from './DiscordActivityProvider';
 import { FarcasterMiniAppProvider } from './FarcasterMiniAppProvider';
 import { GameGuideProvider } from './GameGuideProvider';
@@ -196,6 +201,25 @@ function ThemedPrivyProvider({ children }: { children: React.ReactNode }) {
 }
 
 /**
+ * Hydrates the React Query chat cache from IndexedDB once the authenticated
+ * user is known. Renders nothing — purely a side-effect component.
+ */
+function ChatCacheHydrator() {
+  const user = useAuthStore((s) => s.user);
+  const queryClient = useQueryClient();
+  const hydratedForRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (user?.id && hydratedForRef.current !== user.id) {
+      hydratedForRef.current = user.id;
+      void hydrateChatCacheFromIndexedDB(queryClient, user.id);
+    }
+  }, [user?.id, queryClient]);
+
+  return null;
+}
+
+/**
  * Root providers component wrapping the application with all necessary providers.
  *
  * Provides all application-level context providers including:
@@ -227,20 +251,17 @@ export function Providers({
   const [mounted, setMounted] = useState(false);
   const devAuthSession = getBrowserDevAuthSession();
 
-  const [queryClient] = useState(() => {
-    const client = new QueryClient({
-      defaultOptions: {
-        queries: {
-          staleTime: 60 * 1000, // 1 minute
-          refetchOnWindowFocus: false,
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000, // 1 minute
+            refetchOnWindowFocus: false,
+          },
         },
-      },
-    });
-    // Fire-and-forget: seed React Query cache from IndexedDB so
-    // previously-visited chats render instantly on page load.
-    void hydrateChatCacheFromIndexedDB(client);
-    return client;
-  });
+      })
+  );
 
   // Check if Privy is configured (for build-time safety)
   const shouldUseBrowserDevAuth = devAuthSession !== null;
@@ -297,6 +318,7 @@ export function Providers({
                   <FontSizeProvider>
                     <QueryClientProvider client={queryClient}>
                       <GamePlaybackManager />
+                      <ChatCacheHydrator />
                       <FarcasterMiniAppProvider>
                         <TelegramMiniAppProvider>
                           <DiscordActivityProvider>
@@ -400,6 +422,7 @@ export function Providers({
                 <FontSizeProvider>
                   <QueryClientProvider client={queryClient}>
                     <GamePlaybackManager />
+                    <ChatCacheHydrator />
                     <ThemedPrivyProvider>
                       <FarcasterMiniAppProvider>
                         <TelegramMiniAppProvider>

--- a/apps/web/src/components/providers/Providers.tsx
+++ b/apps/web/src/components/providers/Providers.tsx
@@ -14,6 +14,7 @@ import { FontSizeProvider } from '@/contexts/FontSizeContext';
 import { WidgetRefreshProvider } from '@/contexts/WidgetRefreshContext';
 import { SessionHeartbeatProvider } from '@/hooks/useSessionHeartbeat';
 import { getBrowserDevAuthSession } from '@/lib/auth/dev-auth';
+import { hydrateChatCacheFromIndexedDB } from '@/lib/chat/hydrateChatCache';
 import { DiscordActivityProvider } from './DiscordActivityProvider';
 import { FarcasterMiniAppProvider } from './FarcasterMiniAppProvider';
 import { GameGuideProvider } from './GameGuideProvider';
@@ -226,17 +227,20 @@ export function Providers({
   const [mounted, setMounted] = useState(false);
   const devAuthSession = getBrowserDevAuthSession();
 
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 60 * 1000, // 1 minute
-            refetchOnWindowFocus: false,
-          },
+  const [queryClient] = useState(() => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 60 * 1000, // 1 minute
+          refetchOnWindowFocus: false,
         },
-      })
-  );
+      },
+    });
+    // Fire-and-forget: seed React Query cache from IndexedDB so
+    // previously-visited chats render instantly on page load.
+    void hydrateChatCacheFromIndexedDB(client);
+    return client;
+  });
 
   // Check if Privy is configured (for build-time safety)
   const shouldUseBrowserDevAuth = devAuthSession !== null;

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -6,6 +6,7 @@ import {
   usePrivy,
   useWallets,
 } from '@privy-io/react-auth';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import {
@@ -13,6 +14,7 @@ import {
   getBrowserDevAuthSession,
 } from '@/lib/auth/dev-auth';
 import { getPrivyAccessTokenWithRetry } from '@/lib/auth/privyAccessToken';
+import { clearUserChatCache } from '@/lib/chat/message-store';
 import {
   getPrivyErrorMessage,
   getPrivyLoginErrorMessage,
@@ -125,6 +127,7 @@ export function useAuth(): UseAuthReturn {
     setIsLoadingProfile,
     clearAuth,
   } = useAuthStore();
+  const queryClient = useQueryClient();
   const [devAuthSession, setDevAuthSession] = useState(() =>
     getBrowserDevAuthSession()
   );
@@ -833,6 +836,14 @@ export function useAuth(): UseAuthReturn {
   }, [privyLogin]);
 
   const handleLogout = async () => {
+    // Purge chat caches (React Query + IndexedDB) so the next user
+    // never sees stale data from the previous session.
+    const logoutUserId = user?.id;
+    queryClient.clear();
+    if (logoutUserId) {
+      void clearUserChatCache(logoutUserId);
+    }
+
     if (devAuthSession) {
       clearBrowserDevAuthSession();
       setDevAuthSession(null);

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -344,45 +344,56 @@ export function useChatMessages(chatId: string | null) {
       return;
 
     setIsLoadingMore(true);
-    const token = await getSafeAccessToken();
-    if (!token) {
-      logger.error(
-        'Failed to load more messages - no auth token',
-        { chatId },
-        'useChatMessages'
-      );
-      setIsLoadingMore(false);
-      return;
-    }
-
-    const response = await fetch(
-      `/api/chats/${chatId}?cursor=${currentData.nextCursor}&limit=${CHAT_PAGE_SIZE}`,
-      { headers: { Authorization: `Bearer ${token}` } }
-    );
-
-    if (response.ok) {
-      const data = await response.json();
-      if (data.messages?.length > 0) {
-        const formatted = (data.messages as RawApiMessage[]).map((msg) =>
-          formatMessage(msg, chatId)
+    try {
+      const token = await getSafeAccessToken();
+      if (!token) {
+        logger.error(
+          'Failed to load more messages - no auth token',
+          { chatId },
+          'useChatMessages'
         );
-        setCachedData((old) => {
-          if (!old) return old;
-          return {
-            messages: [...formatted, ...old.messages],
-            hasMore: data.pagination?.hasMore ?? false,
-            nextCursor: data.pagination?.nextCursor ?? null,
-          };
-        });
+        return;
       }
-    } else {
-      logger.error(
-        'Failed to load more messages',
-        { chatId, status: response.status },
+
+      const response = await fetch(
+        `/api/chats/${chatId}?cursor=${currentData.nextCursor}&limit=${CHAT_PAGE_SIZE}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.messages?.length > 0) {
+          const formatted = (data.messages as RawApiMessage[]).map((msg) =>
+            formatMessage(msg, chatId)
+          );
+          setCachedData((old) => {
+            if (!old) return old;
+            return {
+              messages: [...formatted, ...old.messages],
+              hasMore: data.pagination?.hasMore ?? false,
+              nextCursor: data.pagination?.nextCursor ?? null,
+            };
+          });
+        }
+      } else {
+        logger.error(
+          'Failed to load more messages',
+          { chatId, status: response.status },
+          'useChatMessages'
+        );
+      }
+    } catch (error) {
+      logger.warn(
+        'Loading more messages failed',
+        {
+          chatId,
+          error: error instanceof Error ? error.message : String(error),
+        },
         'useChatMessages'
       );
+    } finally {
+      setIsLoadingMore(false);
     }
-    setIsLoadingMore(false);
   }, [chatId, isLoadingMore, getSafeAccessToken, getCachedData, setCachedData]);
 
   // ── SSE handler ─────────────────────────────────────────────────────
@@ -507,43 +518,54 @@ export function useChatMessages(chatId: string | null) {
   // ── Incremental sync: fetch only new messages via ?after= param ─────
   const syncNewMessages = useCallback(
     async (targetChatId: string) => {
-      const currentData = queryClient.getQueryData<ChatMessagesData>(
-        chatMessagesQueryKey(targetChatId)
-      );
-      const lastMessage = currentData?.messages?.at(-1);
-      if (!lastMessage) {
-        // No cache — do a full reload instead of sync
-        hasLoadedRef.current.delete(targetChatId);
-        void loadMessages(targetChatId);
-        return;
-      }
-
-      const token = await getSafeAccessToken();
-      if (!token) return;
-
-      const response = await fetch(
-        `/api/chats/${targetChatId}?after=${encodeURIComponent(lastMessage.createdAt)}&limit=${CHAT_PAGE_SIZE}`,
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-      if (!response.ok) return;
-
-      const data = await response.json();
-      if (!data.messages || data.messages.length === 0) return;
-
-      const newMessages = (data.messages as RawApiMessage[]).map((msg) =>
-        formatMessage(msg, targetChatId)
-      );
-
-      queryClient.setQueryData<ChatMessagesData>(
-        chatMessagesQueryKey(targetChatId),
-        (old) => {
-          if (!old) return old;
-          const existingIds = new Set(old.messages.map((m) => m.id));
-          const deduped = newMessages.filter((m) => !existingIds.has(m.id));
-          if (deduped.length === 0) return old;
-          return { ...old, messages: [...old.messages, ...deduped] };
+      try {
+        const currentData = queryClient.getQueryData<ChatMessagesData>(
+          chatMessagesQueryKey(targetChatId)
+        );
+        const lastMessage = currentData?.messages?.at(-1);
+        if (!lastMessage) {
+          // No cache — do a full reload instead of sync
+          hasLoadedRef.current.delete(targetChatId);
+          void loadMessages(targetChatId);
+          return;
         }
-      );
+
+        const token = await getSafeAccessToken();
+        if (!token) return;
+
+        const response = await fetch(
+          `/api/chats/${targetChatId}?after=${encodeURIComponent(lastMessage.createdAt)}&limit=${CHAT_PAGE_SIZE}`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        if (!response.ok) return;
+
+        const data = await response.json();
+        if (!data.messages || data.messages.length === 0) return;
+
+        const newMessages = (data.messages as RawApiMessage[]).map((msg) =>
+          formatMessage(msg, targetChatId)
+        );
+
+        queryClient.setQueryData<ChatMessagesData>(
+          chatMessagesQueryKey(targetChatId),
+          (old) => {
+            if (!old) return old;
+            const existingIds = new Set(old.messages.map((m) => m.id));
+            const deduped = newMessages.filter((m) => !existingIds.has(m.id));
+            if (deduped.length === 0) return old;
+            return { ...old, messages: [...old.messages, ...deduped] };
+          }
+        );
+      } catch (error) {
+        logger.warn(
+          'Incremental chat sync failed',
+          {
+            chatId: targetChatId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'useChatMessages'
+        );
+      }
     },
     [queryClient, getSafeAccessToken, loadMessages]
   );

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -164,10 +164,13 @@ const POLLING_INTERVAL_MS = 15000;
 
 /**
  * React Query cache key for chat messages.
+ * Scoped to userId so different users never share cached data.
  * Exported so other modules can read/invalidate.
  */
-export const chatMessagesQueryKey = (chatId: string) =>
-  ['chat-messages', chatId] as const;
+export const chatMessagesQueryKey = (chatId: string, userId?: string | null) =>
+  userId
+    ? (['chat-messages', userId, chatId] as const)
+    : (['chat-messages', chatId] as const);
 
 /**
  * Shape of the data stored in the React Query cache for a chat.
@@ -227,13 +230,15 @@ export function useChatMessages(chatId: string | null) {
     [getAccessToken]
   );
 
+  const userId = user?.id ?? null;
+
   // ── Helpers to read/write the React Query cache ─────────────────────
   const getCachedData = useCallback((): ChatMessagesData | undefined => {
     if (!chatId) return undefined;
     return queryClient.getQueryData<ChatMessagesData>(
-      chatMessagesQueryKey(chatId)
+      chatMessagesQueryKey(chatId, userId)
     );
-  }, [chatId, queryClient]);
+  }, [chatId, userId, queryClient]);
 
   const setCachedData = useCallback(
     (
@@ -243,11 +248,11 @@ export function useChatMessages(chatId: string | null) {
     ) => {
       if (!chatId) return;
       queryClient.setQueryData<ChatMessagesData>(
-        chatMessagesQueryKey(chatId),
+        chatMessagesQueryKey(chatId, userId),
         updater
       );
     },
-    [chatId, queryClient]
+    [chatId, userId, queryClient]
   );
 
   // ── Initial message loading ─────────────────────────────────────────
@@ -260,7 +265,7 @@ export function useChatMessages(chatId: string | null) {
     async (targetChatId: string) => {
       // If React Query already has data for this chat, skip the fetch
       const existing = queryClient.getQueryData<ChatMessagesData>(
-        chatMessagesQueryKey(targetChatId)
+        chatMessagesQueryKey(targetChatId, userId)
       );
       if (existing && existing.messages.length > 0) {
         hasLoadedRef.current.add(targetChatId);
@@ -295,7 +300,7 @@ export function useChatMessages(chatId: string | null) {
               formatMessage(msg, targetChatId)
             );
             queryClient.setQueryData<ChatMessagesData>(
-              chatMessagesQueryKey(targetChatId),
+              chatMessagesQueryKey(targetChatId, userId),
               {
                 messages: formatted,
                 hasMore: data.pagination?.hasMore ?? false,
@@ -329,7 +334,7 @@ export function useChatMessages(chatId: string | null) {
         setIsLoading(false);
       }
     },
-    [getSafeAccessToken, queryClient]
+    [getSafeAccessToken, userId, queryClient]
   );
 
   // ── Load more (older messages via cursor pagination) ────────────────
@@ -516,11 +521,12 @@ export function useChatMessages(chatId: string | null) {
   }, [chatId, loadMessages]);
 
   // ── Incremental sync: fetch only new messages via ?after= param ─────
+  // Paginates until hasMore is false so long disconnects don't silently drop messages.
   const syncNewMessages = useCallback(
     async (targetChatId: string) => {
       try {
         const currentData = queryClient.getQueryData<ChatMessagesData>(
-          chatMessagesQueryKey(targetChatId)
+          chatMessagesQueryKey(targetChatId, userId)
         );
         const lastMessage = currentData?.messages?.at(-1);
         if (!lastMessage) {
@@ -533,29 +539,42 @@ export function useChatMessages(chatId: string | null) {
         const token = await getSafeAccessToken();
         if (!token) return;
 
-        const response = await fetch(
-          `/api/chats/${targetChatId}?after=${encodeURIComponent(lastMessage.createdAt)}&limit=${CHAT_PAGE_SIZE}`,
-          { headers: { Authorization: `Bearer ${token}` } }
-        );
-        if (!response.ok) return;
+        // Paginate until all missed messages are fetched
+        let afterTimestamp = lastMessage.createdAt;
+        const MAX_SYNC_PAGES = 10; // Safety cap to avoid infinite loops
+        for (let page = 0; page < MAX_SYNC_PAGES; page++) {
+          const response = await fetch(
+            `/api/chats/${targetChatId}?after=${encodeURIComponent(afterTimestamp)}&limit=${CHAT_PAGE_SIZE}`,
+            { headers: { Authorization: `Bearer ${token}` } }
+          );
+          if (!response.ok) return;
 
-        const data = await response.json();
-        if (!data.messages || data.messages.length === 0) return;
+          const data = await response.json();
+          if (!data.messages || data.messages.length === 0) return;
 
-        const newMessages = (data.messages as RawApiMessage[]).map((msg) =>
-          formatMessage(msg, targetChatId)
-        );
+          const newMessages = (data.messages as RawApiMessage[]).map((msg) =>
+            formatMessage(msg, targetChatId)
+          );
 
-        queryClient.setQueryData<ChatMessagesData>(
-          chatMessagesQueryKey(targetChatId),
-          (old) => {
-            if (!old) return old;
-            const existingIds = new Set(old.messages.map((m) => m.id));
-            const deduped = newMessages.filter((m) => !existingIds.has(m.id));
-            if (deduped.length === 0) return old;
-            return { ...old, messages: [...old.messages, ...deduped] };
-          }
-        );
+          queryClient.setQueryData<ChatMessagesData>(
+            chatMessagesQueryKey(targetChatId, userId),
+            (old) => {
+              if (!old) return old;
+              const existingIds = new Set(old.messages.map((m) => m.id));
+              const deduped = newMessages.filter((m) => !existingIds.has(m.id));
+              if (deduped.length === 0) return old;
+              return { ...old, messages: [...old.messages, ...deduped] };
+            }
+          );
+
+          // If server says no more, we're caught up
+          if (!data.pagination?.hasMore) break;
+
+          // Advance cursor to the last message we received
+          const lastNew = newMessages.at(-1);
+          if (!lastNew) break;
+          afterTimestamp = lastNew.createdAt;
+        }
       } catch (error) {
         logger.warn(
           'Incremental chat sync failed',
@@ -567,7 +586,7 @@ export function useChatMessages(chatId: string | null) {
         );
       }
     },
-    [queryClient, getSafeAccessToken, loadMessages]
+    [queryClient, userId, getSafeAccessToken, loadMessages]
   );
 
   // ── Polling fallback — only when SSE is disconnected ────────────────
@@ -624,7 +643,8 @@ export function useChatMessages(chatId: string | null) {
   const lastPersistedCountRef = useRef(0);
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    if (!chatId || !cachedData || cachedData.messages.length === 0) return;
+    if (!chatId || !userId || !cachedData || cachedData.messages.length === 0)
+      return;
     const confirmedMessages = cachedData.messages.filter(
       (m) =>
         !m.id.startsWith(OptimisticMessageIdPrefix.Pending) &&
@@ -635,6 +655,7 @@ export function useChatMessages(chatId: string | null) {
     // Debounce: wait 2s of quiet before persisting
     if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
     const capturedChatId = chatId;
+    const capturedUserId = userId;
     const capturedData = {
       messages: confirmedMessages,
       hasMore: cachedData.hasMore,
@@ -642,14 +663,14 @@ export function useChatMessages(chatId: string | null) {
     };
     persistTimerRef.current = setTimeout(() => {
       lastPersistedCountRef.current = confirmedMessages.length;
-      void setCachedMessages(capturedChatId, capturedData);
+      void setCachedMessages(capturedUserId, capturedChatId, capturedData);
       persistTimerRef.current = null;
     }, 2000);
 
     return () => {
       if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
     };
-  }, [chatId, cachedData]);
+  }, [chatId, userId, cachedData]);
 
   // ── Mutation helpers (same interface as before) ─────────────────────
   const addMessage = useCallback(
@@ -703,21 +724,21 @@ export function useChatMessages(chatId: string | null) {
   const clearMessages = useCallback(() => {
     if (chatId) {
       queryClient.removeQueries({
-        queryKey: chatMessagesQueryKey(chatId),
+        queryKey: chatMessagesQueryKey(chatId, userId),
       });
     }
     hasLoadedRef.current.clear();
-  }, [chatId, queryClient]);
+  }, [chatId, userId, queryClient]);
 
   const reloadMessages = useCallback(() => {
     if (chatId) {
       hasLoadedRef.current.delete(chatId);
       queryClient.removeQueries({
-        queryKey: chatMessagesQueryKey(chatId),
+        queryKey: chatMessagesQueryKey(chatId, userId),
       });
       void loadMessages(chatId);
     }
-  }, [chatId, loadMessages, queryClient]);
+  }, [chatId, userId, loadMessages, queryClient]);
 
   return {
     messages,

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -159,20 +159,6 @@ export function replaceOptimisticMessage(
   return [...messages, confirmed];
 }
 
-function reactionsEqual(
-  a: MessageReactionSummary[] | undefined,
-  b: MessageReactionSummary[] | undefined
-): boolean {
-  if (!a?.length && !b?.length) return true;
-  if (!a || !b) return false;
-  if (a.length !== b.length) return false;
-  const key = (r: MessageReactionSummary) =>
-    `${r.emoji}:${r.count}:${r.reactedByMe ? 1 : 0}`;
-  const as = [...a].map(key).sort().join('|');
-  const bs = [...b].map(key).sort().join('|');
-  return as === bs;
-}
-
 /** Polling interval — only used when SSE is disconnected */
 const POLLING_INTERVAL_MS = 15000;
 
@@ -502,12 +488,56 @@ export function useChatMessages(chatId: string | null) {
     }
   }, [chatId, loadMessages]);
 
+  // ── Incremental sync: fetch only new messages via ?after= param ─────
+  const syncNewMessages = useCallback(
+    async (targetChatId: string) => {
+      const currentData = queryClient.getQueryData<ChatMessagesData>(
+        chatMessagesQueryKey(targetChatId)
+      );
+      const lastMessage = currentData?.messages?.at(-1);
+      if (!lastMessage) {
+        // No cache — do a full reload instead of sync
+        hasLoadedRef.current.delete(targetChatId);
+        void loadMessages(targetChatId);
+        return;
+      }
+
+      const token = await getSafeAccessToken();
+      if (!token) return;
+
+      const response = await fetch(
+        `/api/chats/${targetChatId}?after=${encodeURIComponent(lastMessage.createdAt)}&limit=${CHAT_PAGE_SIZE}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!response.ok) return;
+
+      const data = await response.json();
+      if (!data.messages || data.messages.length === 0) return;
+
+      const newMessages = (data.messages as RawApiMessage[]).map((msg) =>
+        formatMessage(msg, targetChatId)
+      );
+
+      queryClient.setQueryData<ChatMessagesData>(
+        chatMessagesQueryKey(targetChatId),
+        (old) => {
+          if (!old) return old;
+          const existingIds = new Set(old.messages.map((m) => m.id));
+          const deduped = newMessages.filter((m) => !existingIds.has(m.id));
+          if (deduped.length === 0) return old;
+          return { ...old, messages: [...old.messages, ...deduped] };
+        }
+      );
+    },
+    [queryClient, getSafeAccessToken, loadMessages]
+  );
+
   // ── Polling fallback — only when SSE is disconnected ────────────────
+  // Uses incremental sync (?after=) instead of full refetch.
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     if (!chatId || isConnected) {
-      // SSE is connected — no need to poll
       if (pollIntervalRef.current) {
         clearInterval(pollIntervalRef.current);
         pollIntervalRef.current = null;
@@ -515,80 +545,9 @@ export function useChatMessages(chatId: string | null) {
       return;
     }
 
-    // SSE is disconnected — start polling as fallback
     const startTimeout = setTimeout(() => {
-      pollIntervalRef.current = setInterval(async () => {
-        const token = await getSafeAccessToken();
-        if (!token) return;
-
-        const response = await fetch(
-          `/api/chats/${chatId}?limit=${CHAT_PAGE_SIZE}`,
-          { headers: { Authorization: `Bearer ${token}` } }
-        );
-        if (!response.ok) return;
-
-        const data = await response.json();
-        if (!data.messages) return;
-
-        const formatted = (data.messages as RawApiMessage[]).map((msg) =>
-          formatMessage(msg, chatId)
-        );
-
-        setCachedData((old) => {
-          if (!old) {
-            return {
-              messages: formatted,
-              hasMore: data.pagination?.hasMore ?? false,
-              nextCursor: data.pagination?.nextCursor ?? null,
-            };
-          }
-
-          const existingIds = new Set(old.messages.map((m) => m.id));
-          const updated = [...old.messages];
-          let changed = false;
-
-          for (const msg of formatted) {
-            if (existingIds.has(msg.id)) {
-              const existingIdx = updated.findIndex((m) => m.id === msg.id);
-              if (existingIdx < 0) continue;
-              const existing = updated[existingIdx]!;
-
-              if (!reactionsEqual(existing.reactions, msg.reactions)) {
-                updated[existingIdx] = {
-                  ...existing,
-                  reactions: msg.reactions,
-                };
-                changed = true;
-              }
-              if (msg.metadata && !existing.metadata) {
-                updated[existingIdx] = {
-                  ...updated[existingIdx]!,
-                  metadata: msg.metadata,
-                };
-                changed = true;
-              }
-              continue;
-            }
-
-            const pending = updated.find((m) => isMatchingOptimistic(m, msg));
-            if (pending) {
-              const idx = updated.indexOf(pending);
-              updated[idx] = {
-                ...msg,
-                stableKey: pending.stableKey || pending.id,
-                createdAt: pending.createdAt,
-              };
-              changed = true;
-            } else {
-              updated.push(msg);
-              changed = true;
-            }
-          }
-
-          return changed ? { ...old, messages: updated } : old;
-        });
-
-        hasLoadedRef.current.add(chatId);
+      pollIntervalRef.current = setInterval(() => {
+        void syncNewMessages(chatId);
       }, POLLING_INTERVAL_MS);
     }, 1000);
 
@@ -599,7 +558,16 @@ export function useChatMessages(chatId: string | null) {
         pollIntervalRef.current = null;
       }
     };
-  }, [chatId, isConnected, getSafeAccessToken, setCachedData]);
+  }, [chatId, isConnected, syncNewMessages]);
+
+  // On SSE reconnect, sync any messages missed during the disconnect
+  const wasConnectedRef = useRef(isConnected);
+  useEffect(() => {
+    if (isConnected && !wasConnectedRef.current && chatId) {
+      void syncNewMessages(chatId);
+    }
+    wasConnectedRef.current = isConnected;
+  }, [isConnected, chatId, syncNewMessages]);
 
   // SSE connected means we're ready
   useEffect(() => {

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -9,6 +9,7 @@ import {
   type ReplyToMessage,
 } from '@/components/chats/types';
 import { getPrivyAccessTokenSafely } from '@/lib/auth/privyAccessToken';
+import { setCachedMessages } from '@/lib/chat/message-store';
 import { CHAT_PAGE_SIZE } from '@/lib/constants';
 import { useAuthStore } from '@/stores/authStore';
 import { useSSEChannel } from './useSSE';
@@ -609,6 +610,27 @@ export function useChatMessages(chatId: string | null) {
   const cachedData = getCachedData();
   const messages = cachedData?.messages ?? [];
   const hasMore = cachedData?.hasMore ?? false;
+
+  // ── Persist to IndexedDB for cross-session survival ─────────────────
+  // Fire-and-forget — never blocks renders. Only persists confirmed
+  // messages (filters out optimistic pending-* and thinking-* entries).
+  const lastPersistedCountRef = useRef(0);
+  useEffect(() => {
+    if (!chatId || !cachedData || cachedData.messages.length === 0) return;
+    // Only persist when message count changes to avoid thrashing IndexedDB
+    const confirmedMessages = cachedData.messages.filter(
+      (m) =>
+        !m.id.startsWith(OptimisticMessageIdPrefix.Pending) &&
+        !m.id.startsWith(OptimisticMessageIdPrefix.Thinking)
+    );
+    if (confirmedMessages.length === lastPersistedCountRef.current) return;
+    lastPersistedCountRef.current = confirmedMessages.length;
+    void setCachedMessages(chatId, {
+      messages: confirmedMessages,
+      hasMore: cachedData.hasMore,
+      nextCursor: cachedData.nextCursor,
+    });
+  }, [chatId, cachedData]);
 
   // ── Mutation helpers (same interface as before) ─────────────────────
   const addMessage = useCallback(

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -1,5 +1,6 @@
 import { logger, type MessageMetadata } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type MessageReactionSummary,
@@ -89,7 +90,7 @@ export enum OptimisticMessageIdPrefix {
 const OPTIMISTIC_MATCH_WINDOW_MS = 30000;
 
 /** Check if a message is an optimistic placeholder matching the incoming confirmed message */
-function isMatchingOptimistic(
+export function isMatchingOptimistic(
   pending: ChatMessage,
   incoming: ChatMessage
 ): boolean {
@@ -116,7 +117,7 @@ function isMatchingOptimistic(
  * Preserves the stableKey from the optimistic message to prevent React remount.
  * Merges metadata from SSE messages when a message with the same ID already exists.
  */
-function replaceOptimisticMessage(
+export function replaceOptimisticMessage(
   messages: ChatMessage[],
   confirmed: ChatMessage
 ): ChatMessage[] {
@@ -171,57 +172,40 @@ function reactionsEqual(
   return as === bs;
 }
 
-/** Polling interval - less aggressive since SSE is primary */
+/** Polling interval — only used when SSE is disconnected */
 const POLLING_INTERVAL_MS = 15000;
 
 /**
- * Hook for managing chat messages with real-time SSE updates.
+ * React Query cache key for chat messages.
+ * Exported so other modules can read/invalidate.
+ */
+export const chatMessagesQueryKey = (chatId: string) =>
+  ['chat-messages', chatId] as const;
+
+/**
+ * Shape of the data stored in the React Query cache for a chat.
+ * Bundles messages with pagination state so they stay in sync.
+ */
+export interface ChatMessagesData {
+  messages: ChatMessage[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+/**
+ * Hook for managing chat messages with React Query caching + real-time SSE updates.
  *
- * Provides comprehensive chat message management including:
- * - Initial message loading with pagination
- * - Real-time message updates via SSE
- * - Message history pagination (load more)
- * - Automatic deduplication
- * - Polling fallback for multi-instance serverless environments
+ * Uses React Query for in-memory caching so switching between chats is instant
+ * on return visits (gcTime: 30 min). SSE pushes live messages via
+ * queryClient.setQueryData. Polling fallback only activates when SSE drops.
  *
- * Replaces the previous WebSocket-based implementation with SSE for better
- * Vercel compatibility. Messages are automatically sorted by timestamp.
- *
- * @param chatId - The ID of the chat to load messages for, or null to clear messages.
- *
- * @returns An object containing:
- * - `messages`: Array of chat messages sorted by timestamp
- * - `isLoading`: Whether initial messages are being loaded
- * - `isLoadingMore`: Whether more messages are being loaded (pagination)
- * - `hasMore`: Whether there are more messages to load
- * - `loadMore`: Function to load older messages
- * - `addMessage`: Function to manually add a message to the list
- * - `clearMessages`: Function to clear all messages
- * - `reloadMessages`: Function to reload messages from the API
- * - `isConnected`: Whether SSE connection is active
- *
- * @example
- * ```tsx
- * const { messages, isLoading, loadMore, hasMore } = useChatMessages(chatId);
- *
- * return (
- *   <div>
- *     {messages.map(msg => <div key={msg.id}>{msg.content}</div>)}
- *     {hasMore && <button onClick={loadMore}>Load More</button>}
- *   </div>
- * );
- * ```
+ * @param chatId - The ID of the chat to load messages for, or null to clear.
  */
 export function useChatMessages(chatId: string | null) {
   const { getAccessToken } = usePrivy();
   const { user } = useAuthStore();
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const queryClient = useQueryClient();
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [hasMore, setHasMore] = useState(false);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const previousChatIdRef = useRef<string | null>(null);
-  const hasLoadedRef = useRef<Set<string>>(new Set());
   const pendingReactionDeltasRef = useRef<Set<string>>(new Set());
 
   const markPendingReactionDelta = useCallback(
@@ -232,7 +216,6 @@ export function useChatMessages(chatId: string | null) {
     }) => {
       const key = `${delta.messageId}:${delta.emoji}:${delta.action}`;
       pendingReactionDeltasRef.current.add(key);
-      // Safety: auto-expire in case the SSE event never arrives.
       setTimeout(() => pendingReactionDeltasRef.current.delete(key), 5000);
     },
     []
@@ -252,138 +235,158 @@ export function useChatMessages(chatId: string | null) {
     [getAccessToken]
   );
 
-  // Load existing messages from API (initial load)
+  // ── Helpers to read/write the React Query cache ─────────────────────
+  const getCachedData = useCallback((): ChatMessagesData | undefined => {
+    if (!chatId) return undefined;
+    return queryClient.getQueryData<ChatMessagesData>(
+      chatMessagesQueryKey(chatId)
+    );
+  }, [chatId, queryClient]);
+
+  const setCachedData = useCallback(
+    (
+      updater: (
+        old: ChatMessagesData | undefined
+      ) => ChatMessagesData | undefined
+    ) => {
+      if (!chatId) return;
+      queryClient.setQueryData<ChatMessagesData>(
+        chatMessagesQueryKey(chatId),
+        updater
+      );
+    },
+    [chatId, queryClient]
+  );
+
+  // ── Initial message loading ─────────────────────────────────────────
+  // Uses the query cache: if data already exists (from a previous visit
+  // or IndexedDB hydration), it's returned instantly with no fetch.
+  const [isLoading, setIsLoading] = useState(false);
+  const hasLoadedRef = useRef<Set<string>>(new Set());
+
   const loadMessages = useCallback(
-    async (chatId: string) => {
-      if (hasLoadedRef.current.has(chatId)) {
-        setIsLoading(false);
+    async (targetChatId: string) => {
+      // If React Query already has data for this chat, skip the fetch
+      const existing = queryClient.getQueryData<ChatMessagesData>(
+        chatMessagesQueryKey(targetChatId)
+      );
+      if (existing && existing.messages.length > 0) {
+        hasLoadedRef.current.add(targetChatId);
+        return;
+      }
+
+      if (hasLoadedRef.current.has(targetChatId)) {
         return;
       }
 
       setIsLoading(true);
-
-      try {
-        const token = await getSafeAccessToken();
-        if (!token) {
-          logger.error(
-            'Failed to load messages - no auth token',
-            { chatId },
-            'useChatMessages'
-          );
-          return;
-        }
-
-        const response = await fetch(
-          `/api/chats/${chatId}?limit=${CHAT_PAGE_SIZE}`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          }
-        );
-
-        if (response.ok) {
-          const data = await response.json();
-          if (data.messages) {
-            const formatted = (data.messages as RawApiMessage[]).map((msg) =>
-              formatMessage(msg, chatId)
-            );
-            setMessages(formatted);
-            setHasMore(data.pagination?.hasMore ?? false);
-            setNextCursor(data.pagination?.nextCursor ?? null);
-            hasLoadedRef.current.add(chatId);
-            logger.debug(
-              `Loaded ${formatted.length} messages`,
-              { chatId, count: formatted.length },
-              'useChatMessages'
-            );
-          }
-        } else {
-          logger.error(
-            'Failed to load messages',
-            { chatId, status: response.status },
-            'useChatMessages'
-          );
-        }
-      } catch (error) {
-        logger.error(
-          'Failed to load messages',
-          {
-            chatId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          'useChatMessages'
-        );
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [getSafeAccessToken]
-  );
-
-  // Load more older messages (pagination)
-  const loadMore = useCallback(async () => {
-    if (!chatId || !nextCursor || isLoadingMore || !hasMore) return;
-
-    setIsLoadingMore(true);
-
-    try {
       const token = await getSafeAccessToken();
       if (!token) {
         logger.error(
-          'Failed to load more messages - no auth token',
-          { chatId },
+          'Failed to load messages - no auth token',
+          { chatId: targetChatId },
           'useChatMessages'
         );
+        setIsLoading(false);
         return;
       }
 
       const response = await fetch(
-        `/api/chats/${chatId}?cursor=${nextCursor}&limit=${CHAT_PAGE_SIZE}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
+        `/api/chats/${targetChatId}?limit=${CHAT_PAGE_SIZE}`,
+        { headers: { Authorization: `Bearer ${token}` } }
       );
 
       if (response.ok) {
         const data = await response.json();
-        if (data.messages?.length > 0) {
+        if (data.messages) {
           const formatted = (data.messages as RawApiMessage[]).map((msg) =>
-            formatMessage(msg, chatId)
+            formatMessage(msg, targetChatId)
           );
-          setMessages((prev) => [...formatted, ...prev]);
-          setHasMore(data.pagination?.hasMore ?? false);
-          setNextCursor(data.pagination?.nextCursor ?? null);
+          queryClient.setQueryData<ChatMessagesData>(
+            chatMessagesQueryKey(targetChatId),
+            {
+              messages: formatted,
+              hasMore: data.pagination?.hasMore ?? false,
+              nextCursor: data.pagination?.nextCursor ?? null,
+            }
+          );
+          hasLoadedRef.current.add(targetChatId);
+          logger.debug(
+            `Loaded ${formatted.length} messages`,
+            { chatId: targetChatId, count: formatted.length },
+            'useChatMessages'
+          );
         }
       } else {
         logger.error(
-          'Failed to load more messages',
-          { chatId, status: response.status },
+          'Failed to load messages',
+          { chatId: targetChatId, status: response.status },
           'useChatMessages'
         );
       }
-    } catch (error) {
+      setIsLoading(false);
+    },
+    [getSafeAccessToken, queryClient]
+  );
+
+  // ── Load more (older messages via cursor pagination) ────────────────
+  const loadMore = useCallback(async () => {
+    const currentData = getCachedData();
+    if (
+      !chatId ||
+      !currentData?.nextCursor ||
+      isLoadingMore ||
+      !currentData.hasMore
+    )
+      return;
+
+    setIsLoadingMore(true);
+    const token = await getSafeAccessToken();
+    if (!token) {
       logger.error(
-        'Failed to load more messages',
-        {
-          chatId,
-          error: error instanceof Error ? error.message : String(error),
-        },
+        'Failed to load more messages - no auth token',
+        { chatId },
         'useChatMessages'
       );
-    } finally {
       setIsLoadingMore(false);
+      return;
     }
-  }, [chatId, nextCursor, isLoadingMore, hasMore, getSafeAccessToken]);
 
-  // Handle SSE updates for this chat
+    const response = await fetch(
+      `/api/chats/${chatId}?cursor=${currentData.nextCursor}&limit=${CHAT_PAGE_SIZE}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data.messages?.length > 0) {
+        const formatted = (data.messages as RawApiMessage[]).map((msg) =>
+          formatMessage(msg, chatId)
+        );
+        setCachedData((old) => {
+          if (!old) return old;
+          return {
+            messages: [...formatted, ...old.messages],
+            hasMore: data.pagination?.hasMore ?? false,
+            nextCursor: data.pagination?.nextCursor ?? null,
+          };
+        });
+      }
+    } else {
+      logger.error(
+        'Failed to load more messages',
+        { chatId, status: response.status },
+        'useChatMessages'
+      );
+    }
+    setIsLoadingMore(false);
+  }, [chatId, isLoadingMore, getSafeAccessToken, getCachedData, setCachedData]);
+
+  // ── SSE handler ─────────────────────────────────────────────────────
   const handleChatUpdate = useCallback(
     (data: Record<string, unknown>) => {
       if (data.type === 'new_message' && data.message) {
         const m = data.message as Record<string, unknown>;
-        // Type guard for required fields
         if (
           typeof m.id !== 'string' ||
           typeof m.content !== 'string' ||
@@ -421,7 +424,18 @@ export function useChatMessages(chatId: string | null) {
         };
 
         setIsLoading(false);
-        setMessages((prev) => replaceOptimisticMessage(prev, newMessage));
+        setCachedData((old) => {
+          if (!old)
+            return {
+              messages: [newMessage],
+              hasMore: false,
+              nextCursor: null,
+            };
+          return {
+            ...old,
+            messages: replaceOptimisticMessage(old.messages, newMessage),
+          };
+        });
         return;
       }
 
@@ -451,187 +465,218 @@ export function useChatMessages(chatId: string | null) {
           }
         }
 
-        setMessages((prev) => {
-          const idx = prev.findIndex((m) => m.id === r.messageId);
-          if (idx < 0) return prev;
-          const msg = prev[idx]!;
+        setCachedData((old) => {
+          if (!old) return old;
+          const idx = old.messages.findIndex((m) => m.id === r.messageId);
+          if (idx < 0) return old;
+          const msg = old.messages[idx]!;
           const next = applyReactionDelta(msg.reactions, emoji, action, isMine);
-          return prev.map((m, i) =>
-            i === idx ? { ...m, reactions: next } : m
-          );
+          return {
+            ...old,
+            messages: old.messages.map((m, i) =>
+              i === idx ? { ...m, reactions: next } : m
+            ),
+          };
         });
       }
     },
-    [chatId, user?.id]
+    [chatId, user?.id, setCachedData]
   );
 
   // Subscribe to chat channel
   const channel: `chat:${string}` | null = chatId ? `chat:${chatId}` : null;
   const { isConnected } = useSSEChannel(channel, handleChatUpdate);
 
-  // Load messages when switching chats
-  useEffect(() => {
-    const previousChatId = previousChatIdRef.current;
+  // ── Load on chat switch ─────────────────────────────────────────────
+  const previousChatIdRef = useRef<string | null>(null);
 
-    if (previousChatId !== chatId) {
-      // Clear the "already loaded" flag so switching back to this chat will reload
-      if (previousChatId) {
-        hasLoadedRef.current.delete(previousChatId);
-      }
+  useEffect(() => {
+    if (previousChatIdRef.current !== chatId) {
       if (chatId) {
-        setMessages([]);
-        setHasMore(false);
-        setNextCursor(null);
         void loadMessages(chatId);
       } else {
         setIsLoading(false);
-        setMessages([]);
-        setHasMore(false);
-        setNextCursor(null);
       }
       previousChatIdRef.current = chatId;
     }
   }, [chatId, loadMessages]);
 
-  // Polling fallback for SSE edge cases
+  // ── Polling fallback — only when SSE is disconnected ────────────────
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
-    if (!chatId) return;
+    if (!chatId || isConnected) {
+      // SSE is connected — no need to poll
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = null;
+      }
+      return;
+    }
 
-    // Start polling after brief delay for initial load
+    // SSE is disconnected — start polling as fallback
     const startTimeout = setTimeout(() => {
       pollIntervalRef.current = setInterval(async () => {
-        try {
-          // Get auth token for authenticated request
-          const token = await getSafeAccessToken();
-          if (!token) return;
+        const token = await getSafeAccessToken();
+        if (!token) return;
 
-          const response = await fetch(
-            `/api/chats/${chatId}?limit=${CHAT_PAGE_SIZE}`,
-            {
-              headers: {
-                Authorization: `Bearer ${token}`,
-              },
-            }
-          );
-          if (!response.ok) return;
+        const response = await fetch(
+          `/api/chats/${chatId}?limit=${CHAT_PAGE_SIZE}`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        if (!response.ok) return;
 
-          const data = await response.json();
-          if (!data.messages) return;
+        const data = await response.json();
+        if (!data.messages) return;
 
-          const formatted = (data.messages as RawApiMessage[]).map((msg) =>
-            formatMessage(msg, chatId)
-          );
+        const formatted = (data.messages as RawApiMessage[]).map((msg) =>
+          formatMessage(msg, chatId)
+        );
 
-          setMessages((prev) => {
-            const existingIds = new Set(prev.map((m) => m.id));
-            const updated = [...prev];
-            let changed = false;
+        setCachedData((old) => {
+          if (!old) {
+            return {
+              messages: formatted,
+              hasMore: data.pagination?.hasMore ?? false,
+              nextCursor: data.pagination?.nextCursor ?? null,
+            };
+          }
 
-            for (const msg of formatted) {
-              if (existingIds.has(msg.id)) {
-                const existingIdx = updated.findIndex((m) => m.id === msg.id);
-                if (existingIdx < 0) continue;
-                const existing = updated[existingIdx]!;
+          const existingIds = new Set(old.messages.map((m) => m.id));
+          const updated = [...old.messages];
+          let changed = false;
 
-                // Merge in reactions/metadata updates from the API snapshot.
-                if (!reactionsEqual(existing.reactions, msg.reactions)) {
-                  updated[existingIdx] = {
-                    ...existing,
-                    reactions: msg.reactions,
-                  };
-                  changed = true;
-                }
-                if (msg.metadata && !existing.metadata) {
-                  updated[existingIdx] = {
-                    ...updated[existingIdx]!,
-                    metadata: msg.metadata,
-                  };
-                  changed = true;
-                }
-                continue;
-              }
+          for (const msg of formatted) {
+            if (existingIds.has(msg.id)) {
+              const existingIdx = updated.findIndex((m) => m.id === msg.id);
+              if (existingIdx < 0) continue;
+              const existing = updated[existingIdx]!;
 
-              const pending = updated.find((m) => isMatchingOptimistic(m, msg));
-              if (pending) {
-                const idx = updated.indexOf(pending);
-                // Preserve original timestamp to maintain visual order
-                updated[idx] = {
-                  ...msg,
-                  stableKey: pending.stableKey || pending.id,
-                  createdAt: pending.createdAt,
+              if (!reactionsEqual(existing.reactions, msg.reactions)) {
+                updated[existingIdx] = {
+                  ...existing,
+                  reactions: msg.reactions,
                 };
                 changed = true;
-              } else {
-                // Just append new messages, don't sort
-                updated.push(msg);
+              }
+              if (msg.metadata && !existing.metadata) {
+                updated[existingIdx] = {
+                  ...updated[existingIdx]!,
+                  metadata: msg.metadata,
+                };
                 changed = true;
               }
+              continue;
             }
 
-            return changed ? updated : prev;
-          });
+            const pending = updated.find((m) => isMatchingOptimistic(m, msg));
+            if (pending) {
+              const idx = updated.indexOf(pending);
+              updated[idx] = {
+                ...msg,
+                stableKey: pending.stableKey || pending.id,
+                createdAt: pending.createdAt,
+              };
+              changed = true;
+            } else {
+              updated.push(msg);
+              changed = true;
+            }
+          }
 
-          hasLoadedRef.current.add(chatId);
-        } catch (error) {
-          logger.warn(
-            'Polling failed',
-            { chatId, error: String(error) },
-            'useChatMessages'
-          );
-        }
+          return changed ? { ...old, messages: updated } : old;
+        });
+
+        hasLoadedRef.current.add(chatId);
       }, POLLING_INTERVAL_MS);
     }, 1000);
 
     return () => {
       clearTimeout(startTimeout);
-      if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = null;
+      }
     };
-  }, [chatId, getSafeAccessToken]);
+  }, [chatId, isConnected, getSafeAccessToken, setCachedData]);
 
   // SSE connected means we're ready
   useEffect(() => {
     if (isConnected && chatId) setIsLoading(false);
   }, [isConnected, chatId]);
 
-  const addMessage = useCallback((message: ChatMessage) => {
-    // Optimistic/thinking messages should be appended directly without replacement logic
-    // Only confirmed messages (from SSE) should go through replacement to match their optimistic
-    const isOptimistic =
-      message.id.startsWith(OptimisticMessageIdPrefix.Pending) ||
-      message.id.startsWith(OptimisticMessageIdPrefix.Thinking);
-    if (isOptimistic) {
-      setMessages((prev) => [...prev, message]);
-    } else {
-      setMessages((prev) => replaceOptimisticMessage(prev, message));
-    }
-  }, []);
+  // ── Derived state from cache ────────────────────────────────────────
+  const cachedData = getCachedData();
+  const messages = cachedData?.messages ?? [];
+  const hasMore = cachedData?.hasMore ?? false;
+
+  // ── Mutation helpers (same interface as before) ─────────────────────
+  const addMessage = useCallback(
+    (message: ChatMessage) => {
+      const isOptimistic =
+        message.id.startsWith(OptimisticMessageIdPrefix.Pending) ||
+        message.id.startsWith(OptimisticMessageIdPrefix.Thinking);
+      setCachedData((old) => {
+        if (!old)
+          return { messages: [message], hasMore: false, nextCursor: null };
+        if (isOptimistic) {
+          return { ...old, messages: [...old.messages, message] };
+        }
+        return {
+          ...old,
+          messages: replaceOptimisticMessage(old.messages, message),
+        };
+      });
+    },
+    [setCachedData]
+  );
 
   const updateMessage = useCallback(
     (messageId: string, updates: Partial<ChatMessage>) => {
-      setMessages((prev) =>
-        prev.map((msg) => (msg.id === messageId ? { ...msg, ...updates } : msg))
-      );
+      setCachedData((old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          messages: old.messages.map((msg) =>
+            msg.id === messageId ? { ...msg, ...updates } : msg
+          ),
+        };
+      });
     },
-    []
+    [setCachedData]
   );
 
-  const removeMessage = useCallback((messageId: string) => {
-    setMessages((prev) => prev.filter((msg) => msg.id !== messageId));
-  }, []);
+  const removeMessage = useCallback(
+    (messageId: string) => {
+      setCachedData((old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          messages: old.messages.filter((msg) => msg.id !== messageId),
+        };
+      });
+    },
+    [setCachedData]
+  );
 
   const clearMessages = useCallback(() => {
-    setMessages([]);
+    if (chatId) {
+      queryClient.removeQueries({
+        queryKey: chatMessagesQueryKey(chatId),
+      });
+    }
     hasLoadedRef.current.clear();
-  }, []);
+  }, [chatId, queryClient]);
 
   const reloadMessages = useCallback(() => {
     if (chatId) {
       hasLoadedRef.current.delete(chatId);
+      queryClient.removeQueries({
+        queryKey: chatMessagesQueryKey(chatId),
+      });
       void loadMessages(chatId);
     }
-  }, [chatId, loadMessages]);
+  }, [chatId, loadMessages, queryClient]);
 
   return {
     messages,

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -172,6 +172,11 @@ export const chatMessagesQueryKey = (chatId: string) =>
 /**
  * Shape of the data stored in the React Query cache for a chat.
  * Bundles messages with pagination state so they stay in sync.
+ *
+ * Cache lifetime: Data is written/read via setQueryData/getQueryData (not useQuery).
+ * React Query's default gcTime (5 min) applies — unused chat data is garbage-collected
+ * 5 minutes after the last component stops referencing it. For frequently-visited chats,
+ * data stays alive indefinitely. For cross-session persistence, IndexedDB handles it.
  */
 export interface ChatMessagesData {
   messages: ChatMessage[];
@@ -267,51 +272,62 @@ export function useChatMessages(chatId: string | null) {
       }
 
       setIsLoading(true);
-      const token = await getSafeAccessToken();
-      if (!token) {
-        logger.error(
-          'Failed to load messages - no auth token',
-          { chatId: targetChatId },
-          'useChatMessages'
+      try {
+        const token = await getSafeAccessToken();
+        if (!token) {
+          logger.error(
+            'Failed to load messages - no auth token',
+            { chatId: targetChatId },
+            'useChatMessages'
+          );
+          return;
+        }
+
+        const response = await fetch(
+          `/api/chats/${targetChatId}?limit=${CHAT_PAGE_SIZE}`,
+          { headers: { Authorization: `Bearer ${token}` } }
         );
-        setIsLoading(false);
-        return;
-      }
 
-      const response = await fetch(
-        `/api/chats/${targetChatId}?limit=${CHAT_PAGE_SIZE}`,
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-
-      if (response.ok) {
-        const data = await response.json();
-        if (data.messages) {
-          const formatted = (data.messages as RawApiMessage[]).map((msg) =>
-            formatMessage(msg, targetChatId)
-          );
-          queryClient.setQueryData<ChatMessagesData>(
-            chatMessagesQueryKey(targetChatId),
-            {
-              messages: formatted,
-              hasMore: data.pagination?.hasMore ?? false,
-              nextCursor: data.pagination?.nextCursor ?? null,
-            }
-          );
-          hasLoadedRef.current.add(targetChatId);
-          logger.debug(
-            `Loaded ${formatted.length} messages`,
-            { chatId: targetChatId, count: formatted.length },
+        if (response.ok) {
+          const data = await response.json();
+          if (data.messages) {
+            const formatted = (data.messages as RawApiMessage[]).map((msg) =>
+              formatMessage(msg, targetChatId)
+            );
+            queryClient.setQueryData<ChatMessagesData>(
+              chatMessagesQueryKey(targetChatId),
+              {
+                messages: formatted,
+                hasMore: data.pagination?.hasMore ?? false,
+                nextCursor: data.pagination?.nextCursor ?? null,
+              }
+            );
+            hasLoadedRef.current.add(targetChatId);
+            logger.debug(
+              `Loaded ${formatted.length} messages`,
+              { chatId: targetChatId, count: formatted.length },
+              'useChatMessages'
+            );
+          }
+        } else {
+          logger.error(
+            'Failed to load messages',
+            { chatId: targetChatId, status: response.status },
             'useChatMessages'
           );
         }
-      } else {
+      } catch (error) {
         logger.error(
           'Failed to load messages',
-          { chatId: targetChatId, status: response.status },
+          {
+            chatId: targetChatId,
+            error: error instanceof Error ? error.message : String(error),
+          },
           'useChatMessages'
         );
+      } finally {
+        setIsLoading(false);
       }
-      setIsLoading(false);
     },
     [getSafeAccessToken, queryClient]
   );
@@ -582,22 +598,35 @@ export function useChatMessages(chatId: string | null) {
   // ── Persist to IndexedDB for cross-session survival ─────────────────
   // Fire-and-forget — never blocks renders. Only persists confirmed
   // messages (filters out optimistic pending-* and thinking-* entries).
+  // Debounced to 2s to batch rapid message bursts in active chats.
   const lastPersistedCountRef = useRef(0);
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     if (!chatId || !cachedData || cachedData.messages.length === 0) return;
-    // Only persist when message count changes to avoid thrashing IndexedDB
     const confirmedMessages = cachedData.messages.filter(
       (m) =>
         !m.id.startsWith(OptimisticMessageIdPrefix.Pending) &&
         !m.id.startsWith(OptimisticMessageIdPrefix.Thinking)
     );
     if (confirmedMessages.length === lastPersistedCountRef.current) return;
-    lastPersistedCountRef.current = confirmedMessages.length;
-    void setCachedMessages(chatId, {
+
+    // Debounce: wait 2s of quiet before persisting
+    if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+    const capturedChatId = chatId;
+    const capturedData = {
       messages: confirmedMessages,
       hasMore: cachedData.hasMore,
       nextCursor: cachedData.nextCursor,
-    });
+    };
+    persistTimerRef.current = setTimeout(() => {
+      lastPersistedCountRef.current = confirmedMessages.length;
+      void setCachedMessages(capturedChatId, capturedData);
+      persistTimerRef.current = null;
+    }, 2000);
+
+    return () => {
+      if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+    };
   }, [chatId, cachedData]);
 
   // ── Mutation helpers (same interface as before) ─────────────────────

--- a/apps/web/src/lib/chat/hydrateChatCache.ts
+++ b/apps/web/src/lib/chat/hydrateChatCache.ts
@@ -20,6 +20,9 @@ const HYDRATION_CHAT_LIMIT = 10;
 export async function hydrateChatCacheFromIndexedDB(
   queryClient: QueryClient
 ): Promise<void> {
+  // IndexedDB is only available in the browser — skip during SSR
+  if (typeof window === 'undefined') return;
+
   const chatIds = await getCachedChatIds(HYDRATION_CHAT_LIMIT);
   if (chatIds.length === 0) return;
 

--- a/apps/web/src/lib/chat/hydrateChatCache.ts
+++ b/apps/web/src/lib/chat/hydrateChatCache.ts
@@ -1,0 +1,49 @@
+/**
+ * Hydrates the React Query cache from IndexedDB on app startup.
+ *
+ * Called once during QueryClient initialization in Providers.tsx.
+ * Seeds the 10 most recently accessed chats into the query cache so
+ * opening any of them renders instantly (no spinner, no fetch).
+ *
+ * Data is marked stale immediately so React Query revalidates in the
+ * background — the user sees cached messages instantly while fresh
+ * data loads silently.
+ */
+
+import type { QueryClient } from '@tanstack/react-query';
+import type { ChatMessagesData } from '@/hooks/useChatMessages';
+import { chatMessagesQueryKey } from '@/hooks/useChatMessages';
+import { getCachedChatIds, getCachedMessages } from './message-store';
+
+const HYDRATION_CHAT_LIMIT = 10;
+
+export async function hydrateChatCacheFromIndexedDB(
+  queryClient: QueryClient
+): Promise<void> {
+  const chatIds = await getCachedChatIds(HYDRATION_CHAT_LIMIT);
+  if (chatIds.length === 0) return;
+
+  await Promise.all(
+    chatIds.map(async (chatId) => {
+      const cached = await getCachedMessages(chatId);
+      if (!cached || cached.messages.length === 0) return;
+
+      const data: ChatMessagesData = {
+        messages: cached.messages,
+        hasMore: cached.hasMore,
+        nextCursor: cached.nextCursor,
+      };
+
+      // Set data in cache
+      queryClient.setQueryData(chatMessagesQueryKey(chatId), data);
+
+      // Mark stale so next access triggers background revalidation.
+      // refetchType: 'none' means don't trigger a fetch right now —
+      // just mark the data as needing a refresh when it's next accessed.
+      queryClient.invalidateQueries({
+        queryKey: chatMessagesQueryKey(chatId),
+        refetchType: 'none',
+      });
+    })
+  );
+}

--- a/apps/web/src/lib/chat/hydrateChatCache.ts
+++ b/apps/web/src/lib/chat/hydrateChatCache.ts
@@ -18,17 +18,18 @@ import { getCachedChatIds, getCachedMessages } from './message-store';
 const HYDRATION_CHAT_LIMIT = 10;
 
 export async function hydrateChatCacheFromIndexedDB(
-  queryClient: QueryClient
+  queryClient: QueryClient,
+  userId: string
 ): Promise<void> {
   // IndexedDB is only available in the browser — skip during SSR
   if (typeof window === 'undefined') return;
 
-  const chatIds = await getCachedChatIds(HYDRATION_CHAT_LIMIT);
+  const chatIds = await getCachedChatIds(userId, HYDRATION_CHAT_LIMIT);
   if (chatIds.length === 0) return;
 
   await Promise.all(
     chatIds.map(async (chatId) => {
-      const cached = await getCachedMessages(chatId);
+      const cached = await getCachedMessages(userId, chatId);
       if (!cached || cached.messages.length === 0) return;
 
       const data: ChatMessagesData = {
@@ -37,14 +38,14 @@ export async function hydrateChatCacheFromIndexedDB(
         nextCursor: cached.nextCursor,
       };
 
-      // Set data in cache
-      queryClient.setQueryData(chatMessagesQueryKey(chatId), data);
+      // Set data in cache (user-scoped key)
+      queryClient.setQueryData(chatMessagesQueryKey(chatId, userId), data);
 
       // Mark stale so next access triggers background revalidation.
       // refetchType: 'none' means don't trigger a fetch right now —
       // just mark the data as needing a refresh when it's next accessed.
       queryClient.invalidateQueries({
-        queryKey: chatMessagesQueryKey(chatId),
+        queryKey: chatMessagesQueryKey(chatId, userId),
         refetchType: 'none',
       });
     })

--- a/apps/web/src/lib/chat/message-store.ts
+++ b/apps/web/src/lib/chat/message-store.ts
@@ -1,0 +1,71 @@
+/**
+ * IndexedDB persistence layer for chat messages.
+ *
+ * Stores the most recent messages per chat so conversations load instantly
+ * on page refresh or return visit. Uses idb-keyval for a simple key/value
+ * interface over IndexedDB.
+ *
+ * Storage limits:
+ * - 100 most recent messages per chat (~30 KB per chat)
+ * - 50 most recently accessed chats (LRU eviction)
+ * - Total: ~1.5 MB — well within IndexedDB quotas
+ */
+
+import { del, get, set } from 'idb-keyval';
+import type { ChatMessage, ChatMessagesData } from '@/hooks/useChatMessages';
+
+const MAX_CACHED_MESSAGES_PER_CHAT = 100;
+const MAX_CACHED_CHATS = 50;
+
+interface CachedChatMessages {
+  chatId: string;
+  messages: ChatMessage[];
+  hasMore: boolean;
+  nextCursor: string | null;
+  cachedAt: number;
+}
+
+const STORE_KEY_PREFIX = 'chat-msgs:';
+const INDEX_KEY = 'chat-msgs-index';
+
+export async function getCachedMessages(
+  chatId: string
+): Promise<CachedChatMessages | null> {
+  const cached = await get<CachedChatMessages>(`${STORE_KEY_PREFIX}${chatId}`);
+  return cached ?? null;
+}
+
+export async function setCachedMessages(
+  chatId: string,
+  data: ChatMessagesData
+): Promise<void> {
+  const trimmed: CachedChatMessages = {
+    chatId,
+    messages: data.messages.slice(-MAX_CACHED_MESSAGES_PER_CHAT),
+    hasMore: data.hasMore,
+    nextCursor: data.nextCursor,
+    cachedAt: Date.now(),
+  };
+  await set(`${STORE_KEY_PREFIX}${chatId}`, trimmed);
+
+  // Update LRU index and evict old chats if over limit.
+  // Multi-tab note: concurrent writes are last-write-wins on the index key.
+  // This is acceptable — per-chat data keys survive regardless, and the index
+  // is only used for startup hydration and eviction.
+  const index = (await get<string[]>(INDEX_KEY)) ?? [];
+  const updated = [chatId, ...index.filter((id) => id !== chatId)];
+  if (updated.length > MAX_CACHED_CHATS) {
+    const evicted = updated.splice(MAX_CACHED_CHATS);
+    await Promise.all(evicted.map((id) => del(`${STORE_KEY_PREFIX}${id}`)));
+  }
+  await set(INDEX_KEY, updated);
+}
+
+/**
+ * Returns the chat IDs stored in IndexedDB (most recent first), capped at `limit`.
+ */
+export async function getCachedChatIds(limit = 10): Promise<string[]> {
+  const index = await get<string[]>(INDEX_KEY);
+  if (!index) return [];
+  return index.slice(0, limit);
+}

--- a/apps/web/src/lib/chat/message-store.ts
+++ b/apps/web/src/lib/chat/message-store.ts
@@ -25,20 +25,27 @@ interface CachedChatMessages {
   cachedAt: number;
 }
 
-const STORE_KEY_PREFIX = 'chat-msgs:';
-const INDEX_KEY = 'chat-msgs-index';
-
 const isBrowser = typeof window !== 'undefined';
 
+/** User-scoped key helpers — isolate cached data per authenticated user. */
+function storeKey(userId: string, chatId: string): string {
+  return `chat-msgs:${userId}:${chatId}`;
+}
+function indexKey(userId: string): string {
+  return `chat-msgs-index:${userId}`;
+}
+
 export async function getCachedMessages(
+  userId: string,
   chatId: string
 ): Promise<CachedChatMessages | null> {
   if (!isBrowser) return null;
-  const cached = await get<CachedChatMessages>(`${STORE_KEY_PREFIX}${chatId}`);
+  const cached = await get<CachedChatMessages>(storeKey(userId, chatId));
   return cached ?? null;
 }
 
 export async function setCachedMessages(
+  userId: string,
   chatId: string,
   data: ChatMessagesData
 ): Promise<void> {
@@ -50,27 +57,43 @@ export async function setCachedMessages(
     nextCursor: data.nextCursor,
     cachedAt: Date.now(),
   };
-  await set(`${STORE_KEY_PREFIX}${chatId}`, trimmed);
+  await set(storeKey(userId, chatId), trimmed);
 
   // Update LRU index and evict old chats if over limit.
   // Multi-tab note: concurrent writes are last-write-wins on the index key.
   // This is acceptable — per-chat data keys survive regardless, and the index
   // is only used for startup hydration and eviction.
-  const index = (await get<string[]>(INDEX_KEY)) ?? [];
+  const idx = indexKey(userId);
+  const index = (await get<string[]>(idx)) ?? [];
   const updated = [chatId, ...index.filter((id) => id !== chatId)];
   if (updated.length > MAX_CACHED_CHATS) {
     const evicted = updated.splice(MAX_CACHED_CHATS);
-    await Promise.all(evicted.map((id) => del(`${STORE_KEY_PREFIX}${id}`)));
+    await Promise.all(evicted.map((id) => del(storeKey(userId, id))));
   }
-  await set(INDEX_KEY, updated);
+  await set(idx, updated);
 }
 
 /**
  * Returns the chat IDs stored in IndexedDB (most recent first), capped at `limit`.
  */
-export async function getCachedChatIds(limit = 10): Promise<string[]> {
+export async function getCachedChatIds(
+  userId: string,
+  limit = 10
+): Promise<string[]> {
   if (!isBrowser) return [];
-  const index = await get<string[]>(INDEX_KEY);
+  const index = await get<string[]>(indexKey(userId));
   if (!index) return [];
   return index.slice(0, limit);
+}
+
+/**
+ * Clears all IndexedDB chat cache for a specific user.
+ * Called on logout to prevent data leaking to the next session.
+ */
+export async function clearUserChatCache(userId: string): Promise<void> {
+  if (!isBrowser) return;
+  const idx = indexKey(userId);
+  const index = (await get<string[]>(idx)) ?? [];
+  await Promise.all(index.map((id) => del(storeKey(userId, id))));
+  await del(idx);
 }

--- a/apps/web/src/lib/chat/message-store.ts
+++ b/apps/web/src/lib/chat/message-store.ts
@@ -28,9 +28,12 @@ interface CachedChatMessages {
 const STORE_KEY_PREFIX = 'chat-msgs:';
 const INDEX_KEY = 'chat-msgs-index';
 
+const isBrowser = typeof window !== 'undefined';
+
 export async function getCachedMessages(
   chatId: string
 ): Promise<CachedChatMessages | null> {
+  if (!isBrowser) return null;
   const cached = await get<CachedChatMessages>(`${STORE_KEY_PREFIX}${chatId}`);
   return cached ?? null;
 }
@@ -39,6 +42,7 @@ export async function setCachedMessages(
   chatId: string,
   data: ChatMessagesData
 ): Promise<void> {
+  if (!isBrowser) return;
   const trimmed: CachedChatMessages = {
     chatId,
     messages: data.messages.slice(-MAX_CACHED_MESSAGES_PER_CHAT),
@@ -65,6 +69,7 @@ export async function setCachedMessages(
  * Returns the chat IDs stored in IndexedDB (most recent first), capped at `limit`.
  */
 export async function getCachedChatIds(limit = 10): Promise<string[]> {
+  if (!isBrowser) return [];
   const index = await get<string[]>(INDEX_KEY);
   if (!index) return [];
   return index.slice(0, limit);

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,6 @@
         "ioredis": "5.10.1",
         "js-tiktoken": "^1.0.21",
         "lightweight-charts": "^5.0.9",
-        "nanoid": "^5.1.7",
         "openai": "6.33.0",
         "pg": "8.20.0",
         "postgres": "3.4.8",
@@ -182,6 +181,7 @@
         "geist": "^1.5.1",
         "grammy": "^1.41.1",
         "html-to-image": "^1.11.13",
+        "idb-keyval": "^6.2.2",
         "ioredis": "^5.8.2",
         "lucide-react": "^0.555.0",
         "nanoid": "5.1.7",
@@ -618,6 +618,7 @@
     "ajv": "8.18.0",
     "axios": "1.14.0",
     "bn.js": "5.2.3",
+    "brace-expansion": "1.1.13",
     "cookie": "1.1.1",
     "crypto-browserify": "workspace:*",
     "diff": "4.0.4",
@@ -668,7 +669,7 @@
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@1.2.12", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.66", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.22", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZS6F39hDnxkCSANc4B+4/v4K3FeVYLkciBcLMAaRYH1m1TlUlja8jgkhGf2rn9aO0PdVUfgwxNvI54hW4FQwSA=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.65", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.22", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-yaWzvQQWgAzV0m3eidfpRub1+PggDOr2hLnSOI+L2ZispyJ/7EoSzhjKzNCADj6PHnnPaOMH933Xhl1Z/NSxJw=="],
 
     "@ai-sdk/groq": ["@ai-sdk/groq@2.0.36", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.22" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-rOn7b3VzebDIwY7/daSXEvYG/M4fNEQJ5cwJWTu8rImhf87P8FJaJNSlI5HUej8u+UVhQmi8ShtQdAGnoXD9pA=="],
 
@@ -708,7 +709,7 @@
 
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
-    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1022.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.26", "@aws-sdk/credential-provider-node": "^3.972.29", "@aws-sdk/middleware-bucket-endpoint": "^3.972.8", "@aws-sdk/middleware-expect-continue": "^3.972.8", "@aws-sdk/middleware-flexible-checksums": "^3.974.6", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-location-constraint": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.9", "@aws-sdk/middleware-sdk-s3": "^3.972.27", "@aws-sdk/middleware-ssec": "^3.972.8", "@aws-sdk/middleware-user-agent": "^3.972.28", "@aws-sdk/region-config-resolver": "^3.972.10", "@aws-sdk/signature-v4-multi-region": "^3.996.15", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.14", "@smithy/config-resolver": "^4.4.13", "@smithy/core": "^3.23.13", "@smithy/eventstream-serde-browser": "^4.2.12", "@smithy/eventstream-serde-config-resolver": "^4.3.12", "@smithy/eventstream-serde-node": "^4.2.12", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-blob-browser": "^4.2.13", "@smithy/hash-node": "^4.2.12", "@smithy/hash-stream-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/md5-js": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.28", "@smithy/middleware-retry": "^4.4.46", "@smithy/middleware-serde": "^4.2.16", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.5.1", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.44", "@smithy/util-defaults-mode-node": "^4.2.48", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.13", "@smithy/util-stream": "^4.5.21", "@smithy/util-utf8": "^4.2.2", "@smithy/util-waiter": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-PhdIW0LxjzcMlBiCldRefnyZk84wtYGnEV0sNGOD55DZTvZsibG2XHvQiL1aFliKugfAhuIpNmFkctI2n2I3Dg=="],
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1020.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.26", "@aws-sdk/credential-provider-node": "^3.972.28", "@aws-sdk/middleware-bucket-endpoint": "^3.972.8", "@aws-sdk/middleware-expect-continue": "^3.972.8", "@aws-sdk/middleware-flexible-checksums": "^3.974.6", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-location-constraint": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.9", "@aws-sdk/middleware-sdk-s3": "^3.972.27", "@aws-sdk/middleware-ssec": "^3.972.8", "@aws-sdk/middleware-user-agent": "^3.972.27", "@aws-sdk/region-config-resolver": "^3.972.10", "@aws-sdk/signature-v4-multi-region": "^3.996.15", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.13", "@smithy/config-resolver": "^4.4.13", "@smithy/core": "^3.23.13", "@smithy/eventstream-serde-browser": "^4.2.12", "@smithy/eventstream-serde-config-resolver": "^4.3.12", "@smithy/eventstream-serde-node": "^4.2.12", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-blob-browser": "^4.2.13", "@smithy/hash-node": "^4.2.12", "@smithy/hash-stream-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/md5-js": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.28", "@smithy/middleware-retry": "^4.4.45", "@smithy/middleware-serde": "^4.2.16", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.5.1", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.44", "@smithy/util-defaults-mode-node": "^4.2.48", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/util-stream": "^4.5.21", "@smithy/util-utf8": "^4.2.2", "@smithy/util-waiter": "^4.2.14", "tslib": "^2.6.2" } }, "sha512-ibfxjP5zLUqpujLE0OTgD+jZ3KStx9dTASL7d7Eekw4sv7ZHv1UN6CPDcKnCNXdPzlBWi5Wc5lWJ4sU1M8ygEQ=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.973.26", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@aws-sdk/xml-builder": "^3.972.16", "@smithy/core": "^3.23.13", "@smithy/node-config-provider": "^4.3.12", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/signature-v4": "^5.3.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.12", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ=="],
 
@@ -718,19 +719,19 @@
 
     "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.26", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/types": "^3.973.6", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/node-http-handler": "^4.5.1", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "@smithy/util-stream": "^4.5.21", "tslib": "^2.6.2" } }, "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA=="],
 
-    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.28", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/credential-provider-env": "^3.972.24", "@aws-sdk/credential-provider-http": "^3.972.26", "@aws-sdk/credential-provider-login": "^3.972.28", "@aws-sdk/credential-provider-process": "^3.972.24", "@aws-sdk/credential-provider-sso": "^3.972.28", "@aws-sdk/credential-provider-web-identity": "^3.972.28", "@aws-sdk/nested-clients": "^3.996.18", "@aws-sdk/types": "^3.973.6", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw=="],
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.27", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/credential-provider-env": "^3.972.24", "@aws-sdk/credential-provider-http": "^3.972.26", "@aws-sdk/credential-provider-login": "^3.972.27", "@aws-sdk/credential-provider-process": "^3.972.24", "@aws-sdk/credential-provider-sso": "^3.972.27", "@aws-sdk/credential-provider-web-identity": "^3.972.27", "@aws-sdk/nested-clients": "^3.996.17", "@aws-sdk/types": "^3.973.6", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Um26EsNSUfVUX0wUXnUA1W3wzKhVy6nviEElsh5lLZUYj9bk6DXOPnpte0gt+WHubcVfVsRk40bbm4KaroTEag=="],
 
-    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.28", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/nested-clients": "^3.996.18", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ=="],
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.27", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/nested-clients": "^3.996.17", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/protocol-http": "^5.3.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-t3ehEtHomGZwg5Gixw4fYbYtG9JBnjfAjSDabxhPEu/KLLUp0BB37/APX7MSKXQhX6ZH7pseuACFJ19NrAkNdg=="],
 
-    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.29", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.24", "@aws-sdk/credential-provider-http": "^3.972.26", "@aws-sdk/credential-provider-ini": "^3.972.28", "@aws-sdk/credential-provider-process": "^3.972.24", "@aws-sdk/credential-provider-sso": "^3.972.28", "@aws-sdk/credential-provider-web-identity": "^3.972.28", "@aws-sdk/types": "^3.973.6", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g=="],
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.28", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.24", "@aws-sdk/credential-provider-http": "^3.972.26", "@aws-sdk/credential-provider-ini": "^3.972.27", "@aws-sdk/credential-provider-process": "^3.972.24", "@aws-sdk/credential-provider-sso": "^3.972.27", "@aws-sdk/credential-provider-web-identity": "^3.972.27", "@aws-sdk/types": "^3.973.6", "@smithy/credential-provider-imds": "^4.2.12", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-rren+P6k5rShG5PX61iVi40kKdueyuMLBRTctQbyR5LooO9Ygr5L6R7ilG7RF1957NSH3KC3TU206fZuKwjSpQ=="],
 
     "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.24", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw=="],
 
-    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.28", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/nested-clients": "^3.996.18", "@aws-sdk/token-providers": "3.1021.0", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A=="],
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.27", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/nested-clients": "^3.996.17", "@aws-sdk/token-providers": "3.1020.0", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-CWXeGjlbBuHcm9appZUgXKP2zHDyTti0/+gXpSFJ2J3CnSwf1KWjicjN0qG2ozkMH6blrrzMrimeIOEYNl238Q=="],
 
-    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.28", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/nested-clients": "^3.996.18", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ=="],
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.27", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/nested-clients": "^3.996.17", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-CUY4hQIFswdQNEsRGEzGBUKGMK5KpqmNDdu2ROMgI+45PLFS8H0y3Tm7kvM16uvvw3n1pVxk85tnRVUTgtaa1w=="],
 
-    "@aws-sdk/lib-storage": ["@aws-sdk/lib-storage@3.1022.0", "", { "dependencies": { "@smithy/middleware-endpoint": "^4.4.28", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "buffer": "5.6.0", "events": "3.3.0", "stream-browserify": "3.0.0", "tslib": "^2.6.2" }, "peerDependencies": { "@aws-sdk/client-s3": "^3.1022.0" } }, "sha512-RozYW8R0O+Ld+qLYtIgOSt9iD31rC+G1vGmPkZN9aGf9FqGCwt0Fumsaa8CNLbzcI/O6PyL4g4OJgsCpmSTX4Q=="],
+    "@aws-sdk/lib-storage": ["@aws-sdk/lib-storage@3.1020.0", "", { "dependencies": { "@smithy/middleware-endpoint": "^4.4.28", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "buffer": "5.6.0", "events": "3.3.0", "stream-browserify": "3.0.0", "tslib": "^2.6.2" }, "peerDependencies": { "@aws-sdk/client-s3": "^3.1020.0" } }, "sha512-SvFM+jukgDkCCeszTtGTJ59kAvWeCI5vnBV0eMau4Uj1w0KItwahDVGDo+xQa+r7pp3kolZF1vDmdv37A5+J8A=="],
 
     "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/node-config-provider": "^4.3.12", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw=="],
 
@@ -750,15 +751,15 @@
 
     "@aws-sdk/middleware-ssec": ["@aws-sdk/middleware-ssec@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw=="],
 
-    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.28", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@smithy/core": "^3.23.13", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-retry": "^4.2.13", "tslib": "^2.6.2" } }, "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ=="],
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.27", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@smithy/core": "^3.23.13", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "@smithy/util-retry": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-TIRLO5UR2+FVUGmhYoAwVkKhcVzywEDX/5LzR9tjy1h8FQAXOtFg2IqgmwvxU7y933rkTn9rl6AdgcAUgQ1/Kg=="],
 
-    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.996.18", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.26", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.9", "@aws-sdk/middleware-user-agent": "^3.972.28", "@aws-sdk/region-config-resolver": "^3.972.10", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.14", "@smithy/config-resolver": "^4.4.13", "@smithy/core": "^3.23.13", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.28", "@smithy/middleware-retry": "^4.4.46", "@smithy/middleware-serde": "^4.2.16", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.5.1", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.44", "@smithy/util-defaults-mode-node": "^4.2.48", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.13", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA=="],
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.996.17", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.26", "@aws-sdk/middleware-host-header": "^3.972.8", "@aws-sdk/middleware-logger": "^3.972.8", "@aws-sdk/middleware-recursion-detection": "^3.972.9", "@aws-sdk/middleware-user-agent": "^3.972.27", "@aws-sdk/region-config-resolver": "^3.972.10", "@aws-sdk/types": "^3.973.6", "@aws-sdk/util-endpoints": "^3.996.5", "@aws-sdk/util-user-agent-browser": "^3.972.8", "@aws-sdk/util-user-agent-node": "^3.973.13", "@smithy/config-resolver": "^4.4.13", "@smithy/core": "^3.23.13", "@smithy/fetch-http-handler": "^5.3.15", "@smithy/hash-node": "^4.2.12", "@smithy/invalid-dependency": "^4.2.12", "@smithy/middleware-content-length": "^4.2.12", "@smithy/middleware-endpoint": "^4.4.28", "@smithy/middleware-retry": "^4.4.45", "@smithy/middleware-serde": "^4.2.16", "@smithy/middleware-stack": "^4.2.12", "@smithy/node-config-provider": "^4.3.12", "@smithy/node-http-handler": "^4.5.1", "@smithy/protocol-http": "^5.3.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.44", "@smithy/util-defaults-mode-node": "^4.2.48", "@smithy/util-endpoints": "^3.3.3", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-7B0HIX0tEFmOSJuWzdHZj1WhMXSryM+h66h96ZkqSncoY7J6wq61KOu4Kr57b/YnJP3J/EeQYVFulgR281h+7A=="],
 
     "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/config-resolver": "^4.4.13", "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ=="],
 
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.15", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.27", "@aws-sdk/types": "^3.973.6", "@smithy/protocol-http": "^5.3.12", "@smithy/signature-v4": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ=="],
 
-    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1021.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/nested-clients": "^3.996.18", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA=="],
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1020.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.26", "@aws-sdk/nested-clients": "^3.996.17", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-T61KA/VKl0zVUubdxigr1ut7SEpwE1/4CIKb14JDLyTAOne2yWKtQE1dDCSHl0UqrZNwW/bTt+EBHfQbslZJdw=="],
 
     "@aws-sdk/types": ["@aws-sdk/types@3.973.6", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw=="],
 
@@ -770,7 +771,7 @@
 
     "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/types": "^4.13.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA=="],
 
-    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.14", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.28", "@aws-sdk/types": "^3.973.6", "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw=="],
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.13", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.27", "@aws-sdk/types": "^3.973.6", "@smithy/node-config-provider": "^4.3.12", "@smithy/types": "^4.13.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-s1dCJ0J9WU9UPkT3FFqhKTSquYTkqWXGRaapHFyWwwJH86ZussewhNST5R5TwXVL1VSHq4aJVl9fWK+svaRVCQ=="],
 
     "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.16", "", { "dependencies": { "@smithy/types": "^4.13.1", "fast-xml-parser": "5.5.8", "tslib": "^2.6.2" } }, "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A=="],
 
@@ -948,7 +949,7 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@ecies/ciphers": ["@ecies/ciphers@0.2.6", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g=="],
+    "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.3.16", "", {}, "sha512-mZkZfOd9OqTMHsK+1cje8OSzfAQcpD7JmILXTl5ahdempjUDdmg4euf1biDex5/LfQIDJ3gvCu6qDgdnDxfJmA=="],
 
@@ -1088,7 +1089,7 @@
 
     "@farcaster/quick-auth": ["@farcaster/quick-auth@0.0.6", "", { "dependencies": { "jose": "^5.2.3", "zod": "^3.25.1" }, "peerDependencies": { "typescript": "5.8.3" } }, "sha512-tiZndhpfDtEhaKlkmS5cVDuS+A/tafqZT3y9I44rC69m3beJok6e8dIH2JhxVy3EvOWTyTBnrmNn6GOOh+qK6A=="],
 
-    "@fastify/otel": ["@fastify/otel@0.18.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.212.0", "@opentelemetry/semantic-conventions": "^1.28.0", "minimatch": "^10.2.4" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA=="],
+    "@fastify/otel": ["@fastify/otel@0.17.1", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.212.0", "@opentelemetry/semantic-conventions": "^1.28.0", "minimatch": "^10.2.4" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-K4wyxfUZx2ux5o+b6BtTqouYFVILohLZmSbA2tKUueJstNcBnoGPVhllCaOvbQ3ZrXdUxUC/fyrSWSCqHhdOPg=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
@@ -1320,7 +1321,7 @@
 
     "@marsidev/react-turnstile": ["@marsidev/react-turnstile@1.5.0", "", { "peerDependencies": { "react": "^17.0.2 || ^18.0.0 || ^19.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0" } }, "sha512-Ph6mcj8u9WBDsBO7s9jKPsyRDz1sBPBJwrk+Ngx09vFInvKsQ6U6kW5amEcGq4dHOreB6DgFrOJk7/fy318YlQ=="],
 
-    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.0.1", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ=="],
 
     "@metamask/eth-json-rpc-provider": ["@metamask/eth-json-rpc-provider@1.0.1", "", { "dependencies": { "@metamask/json-rpc-engine": "^7.0.0", "@metamask/safe-event-emitter": "^3.0.0", "@metamask/utils": "^5.0.1" } }, "sha512-whiUMPlAOrVGmX8aKYVPvlKyG4CpQXiNNyt74vE1xb5sPvmx5oA7B/kOi/JdBvhGQq97U1/AVdXEdk2zkP8qyA=="],
 
@@ -1350,7 +1351,7 @@
 
     "@metamask/superstruct": ["@metamask/superstruct@3.2.1", "", {}, "sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g=="],
 
-    "@metamask/utils": ["@metamask/utils@11.11.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "@types/lodash": "^4.17.20", "debug": "^4.3.4", "lodash": "^4.17.21", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-0nF2CWjWQr/m0Y2t2lJnBTU1/CZPPTvKvcESLplyWe/tyeb8zFOi/FeneDmaFnML6LYRIGZU6f+xR0jKAIUZfw=="],
+    "@metamask/utils": ["@metamask/utils@11.10.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "@types/lodash": "^4.17.20", "debug": "^4.3.4", "lodash": "^4.17.21", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-+bWmTOANx1MbBW6RFM8Se4ZoigFYGXiuIrkhjj4XnG5Aez8uWaTSZ76yn9srKKClv+PoEVoAuVtcUOogFEMUNA=="],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
@@ -1478,51 +1479,51 @@
 
     "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/sdk-logs": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg=="],
 
-    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.213.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.213.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w=="],
 
-    "@opentelemetry/instrumentation-amqplib": ["@opentelemetry/instrumentation-amqplib@0.61.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q=="],
+    "@opentelemetry/instrumentation-amqplib": ["@opentelemetry/instrumentation-amqplib@0.60.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg=="],
 
-    "@opentelemetry/instrumentation-connect": ["@opentelemetry/instrumentation-connect@0.57.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.27.0", "@types/connect": "3.4.38" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg=="],
+    "@opentelemetry/instrumentation-connect": ["@opentelemetry/instrumentation-connect@0.56.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.27.0", "@types/connect": "3.4.38" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-PKp+sSZ7AfzMvGgO3VCyo1inwNu+q7A1k9X88WK4PQ+S6Hp7eFk8pie+sWHDTaARovmqq5V2osav3lQej2B0nw=="],
 
-    "@opentelemetry/instrumentation-dataloader": ["@opentelemetry/instrumentation-dataloader@0.31.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g=="],
+    "@opentelemetry/instrumentation-dataloader": ["@opentelemetry/instrumentation-dataloader@0.30.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MXHP2Q38cd2OhzEBKAIXUi9uBlPEYzF6BNJbyjUXBQ6kLaf93kRC41vNMIz0Nl5mnuwK7fDvKT+/lpx7BXRwdg=="],
 
-    "@opentelemetry/instrumentation-express": ["@opentelemetry/instrumentation-express@0.62.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Tvx+vgAZKEQxU3Rx+xWLiR0mLxHwmk69/8ya04+VsV9WYh8w6Lhx5hm5yAMvo1wy0KqWgFKBLwSeo3sHCwdOww=="],
+    "@opentelemetry/instrumentation-express": ["@opentelemetry/instrumentation-express@0.61.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Xdmqo9RZuZlL29Flg8QdwrrX7eW1CZ7wFQPKHyXljNymgKhN1MCsYuqQ/7uxavhSKwAl7WxkTzKhnqpUApLMvQ=="],
 
-    "@opentelemetry/instrumentation-fs": ["@opentelemetry/instrumentation-fs@0.33.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA=="],
+    "@opentelemetry/instrumentation-fs": ["@opentelemetry/instrumentation-fs@0.32.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-koR6apx0g0wX6RRiPpjA4AFQUQUbXrK16kq4/SZjVp7u5cffJhNkY4TnITxcGA4acGSPYAfx3NHRIv4Khn1axQ=="],
 
-    "@opentelemetry/instrumentation-generic-pool": ["@opentelemetry/instrumentation-generic-pool@0.57.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow=="],
+    "@opentelemetry/instrumentation-generic-pool": ["@opentelemetry/instrumentation-generic-pool@0.56.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fg+Jffs6fqrf0uQS0hom7qBFKsbtpBiBl8+Vkc63Gx8xh6pVh+FhagmiO6oM0m3vyb683t1lP7yGYq22SiDnqg=="],
 
-    "@opentelemetry/instrumentation-graphql": ["@opentelemetry/instrumentation-graphql@0.62.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg=="],
+    "@opentelemetry/instrumentation-graphql": ["@opentelemetry/instrumentation-graphql@0.61.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-pUiVASv6nh2XrerTvlbVHh7vKFzscpgwiQ/xvnZuAIzQ5lRjWVdRPUuXbvZJ/Yq79QsE81TZdJ7z9YsXiss1ew=="],
 
-    "@opentelemetry/instrumentation-hapi": ["@opentelemetry/instrumentation-hapi@0.60.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w=="],
+    "@opentelemetry/instrumentation-hapi": ["@opentelemetry/instrumentation-hapi@0.59.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-33wa4mEr+9+ztwdgLor1SeBu4Opz4IsmpcLETXAd3VmBrOjez8uQtrsOhPCa5Vhbm5gzDlMYTgFRLQzf8/YHFA=="],
 
-    "@opentelemetry/instrumentation-http": ["@opentelemetry/instrumentation-http@0.214.0", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/instrumentation": "0.214.0", "@opentelemetry/semantic-conventions": "^1.29.0", "forwarded-parse": "2.1.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg=="],
+    "@opentelemetry/instrumentation-http": ["@opentelemetry/instrumentation-http@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/instrumentation": "0.213.0", "@opentelemetry/semantic-conventions": "^1.29.0", "forwarded-parse": "2.1.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-B978Xsm5XEPGhm1P07grDoaOFLHapJPkOG9h016cJsyWWxmiLnPu2M/4Nrm7UCkHSiLnkXgC+zVGUAIahy8EEA=="],
 
-    "@opentelemetry/instrumentation-ioredis": ["@opentelemetry/instrumentation-ioredis@0.62.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ=="],
+    "@opentelemetry/instrumentation-ioredis": ["@opentelemetry/instrumentation-ioredis@0.61.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-hsHDadUtAFbws1YSDc1XW0svGFKiUbqv2td1Cby+UAiwvojm1NyBo/taifH0t8CuFZ0x/2SDm0iuTwrM5pnVOg=="],
 
-    "@opentelemetry/instrumentation-kafkajs": ["@opentelemetry/instrumentation-kafkajs@0.23.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.30.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ=="],
+    "@opentelemetry/instrumentation-kafkajs": ["@opentelemetry/instrumentation-kafkajs@0.22.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.30.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-wJU4IBQMUikdJAcTChLFqK5lo+flo7pahqd8DSLv7uMxsdOdAHj6RzKYAm8pPfUS6ItKYutYyuicwKaFwQKsoA=="],
 
-    "@opentelemetry/instrumentation-knex": ["@opentelemetry/instrumentation-knex@0.58.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw=="],
+    "@opentelemetry/instrumentation-knex": ["@opentelemetry/instrumentation-knex@0.57.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-vMCSh8kolEm5rRsc+FZeTZymWmIJwc40hjIKnXH4O0Dv/gAkJJIRXCsPX5cPbe0c0j/34+PsENd0HqKruwhVYw=="],
 
-    "@opentelemetry/instrumentation-koa": ["@opentelemetry/instrumentation-koa@0.62.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.36.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA=="],
+    "@opentelemetry/instrumentation-koa": ["@opentelemetry/instrumentation-koa@0.61.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.36.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-lvrfWe9ShK/D2X4brmx8ZqqeWPfRl8xekU0FCn7C1dHm5k6+rTOOi36+4fnaHAP8lig9Ux6XQ1D4RNIpPCt1WQ=="],
 
-    "@opentelemetry/instrumentation-lru-memoizer": ["@opentelemetry/instrumentation-lru-memoizer@0.58.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q=="],
+    "@opentelemetry/instrumentation-lru-memoizer": ["@opentelemetry/instrumentation-lru-memoizer@0.57.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-cEqpUocSKJfwDtLYTTJehRLWzkZ2eoePCxfVIgGkGkb83fMB71O+y4MvRHJPbeV2bdoWdOVrl8uO0+EynWhTEA=="],
 
-    "@opentelemetry/instrumentation-mongodb": ["@opentelemetry/instrumentation-mongodb@0.67.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ=="],
+    "@opentelemetry/instrumentation-mongodb": ["@opentelemetry/instrumentation-mongodb@0.66.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-d7m9QnAY+4TCWI4q1QRkfrc6fo/92VwssaB1DzQfXNRvu51b78P+HJlWP7Qg6N6nkwdb9faMZNBCZJfftmszkw=="],
 
-    "@opentelemetry/instrumentation-mongoose": ["@opentelemetry/instrumentation-mongoose@0.60.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg=="],
+    "@opentelemetry/instrumentation-mongoose": ["@opentelemetry/instrumentation-mongoose@0.59.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-6/jWU+c1NgznkVLDU/2y0bXV2nJo3o9FWZ9mZ9nN6T/JBNRoMnVXZl2FdBmgH+a5MwaWLs5kmRJTP5oUVGIkPw=="],
 
-    "@opentelemetry/instrumentation-mysql": ["@opentelemetry/instrumentation-mysql@0.60.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/mysql": "2.15.27" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ=="],
+    "@opentelemetry/instrumentation-mysql": ["@opentelemetry/instrumentation-mysql@0.59.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/mysql": "2.15.27" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw=="],
 
-    "@opentelemetry/instrumentation-mysql2": ["@opentelemetry/instrumentation-mysql2@0.60.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@opentelemetry/sql-common": "^0.41.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw=="],
+    "@opentelemetry/instrumentation-mysql2": ["@opentelemetry/instrumentation-mysql2@0.59.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@opentelemetry/sql-common": "^0.41.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw=="],
 
-    "@opentelemetry/instrumentation-pg": ["@opentelemetry/instrumentation-pg@0.66.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.34.0", "@opentelemetry/sql-common": "^0.41.2", "@types/pg": "8.15.6", "@types/pg-pool": "2.0.7" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA=="],
+    "@opentelemetry/instrumentation-pg": ["@opentelemetry/instrumentation-pg@0.65.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.34.0", "@opentelemetry/sql-common": "^0.41.2", "@types/pg": "8.15.6", "@types/pg-pool": "2.0.7" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-W0zpHEIEuyZ8zvb3njaX9AAbHgPYOsSWVOoWmv1sjVRSF6ZpBqtlxBWbU+6hhq1TFWBeWJOXZ8nZS/PUFpLJYQ=="],
 
-    "@opentelemetry/instrumentation-redis": ["@opentelemetry/instrumentation-redis@0.62.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ=="],
+    "@opentelemetry/instrumentation-redis": ["@opentelemetry/instrumentation-redis@0.61.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-JnPexA034/0UJRsvH96B0erQoNOqKJZjE2ZRSw9hiTSC23LzE0nJE/u6D+xqOhgUhRnhhcPHq4MdYtmUdYTF+Q=="],
 
-    "@opentelemetry/instrumentation-tedious": ["@opentelemetry/instrumentation-tedious@0.33.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/tedious": "^4.0.14" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w=="],
+    "@opentelemetry/instrumentation-tedious": ["@opentelemetry/instrumentation-tedious@0.32.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/tedious": "^4.0.14" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-BQS6gG8RJ1foEqfEZ+wxoqlwfCAzb1ZVG0ad8Gfe4x8T658HJCLGLd4E4NaoQd8EvPfLqOXgzGaE/2U4ytDSWA=="],
 
-    "@opentelemetry/instrumentation-undici": ["@opentelemetry/instrumentation-undici@0.24.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.24.0" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0" } }, "sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ=="],
+    "@opentelemetry/instrumentation-undici": ["@opentelemetry/instrumentation-undici@0.23.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.24.0" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0" } }, "sha512-LL0VySzKVR2cJSFVZaTYpZl1XTpBGnfzoQPe2W7McS2267ldsaEIqtQY6VXs2KCXN0poFjze5110PIpxHDaDGg=="],
 
     "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA=="],
 
@@ -1618,13 +1619,13 @@
 
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
-    "@posthog/core": ["@posthog/core@1.24.5", "", {}, "sha512-umXx3kMjM+cTUTLDsdPFFU7aJa3uiH19EEoWKbE5QVME8WgVg7q1peMhK7y7n7xRmYJlA70eOrHQfWlzBQqeFQ=="],
+    "@posthog/core": ["@posthog/core@1.24.4", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-S+TolwBHSSJz7WWtgaELQWQqXviSm3uf1e+qorWUts0bZcgPwWzhnmhCUZAhvn0NVpTQHDJ3epv+hHbPLl5dHg=="],
 
     "@posthog/types": ["@posthog/types@1.364.1", "", {}, "sha512-COB9L+EF9gqGTcK06392yCPC1mbPtqStguFLDin57dxekJM6uwygfxciBi6f6XoFiNEkACpykZYIgjgk5FsuaQ=="],
 
     "@prb/math": ["@prb/math@4.1.1", "", {}, "sha512-3945t7yS+4M3S2+aO+H3+N4pFLQijyhHInmp9hiMXMRq9lyAMnAfrgGodwhaccCPcSNScSh7qIJO5aCa8fPh1Q=="],
 
-    "@prisma/instrumentation": ["@prisma/instrumentation@7.6.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.8" } }, "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ=="],
+    "@prisma/instrumentation": ["@prisma/instrumentation@7.4.2", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.8" } }, "sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg=="],
 
     "@privy-io/api-base": ["@privy-io/api-base@1.8.2", "", { "dependencies": { "zod": "^3.24.3" } }, "sha512-pEvZ73GnC2OB/w35MGCPhqZ8mnApXgUpXxM0t9qZmNzvDNoMKBLPgysUXouAx7E4jO8REJPuwX70Y1AqJ/51kg=="],
 
@@ -1928,7 +1929,7 @@
 
     "@sentry/browser": ["@sentry/browser@10.46.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.46.0", "@sentry-internal/feedback": "10.46.0", "@sentry-internal/replay": "10.46.0", "@sentry-internal/replay-canvas": "10.46.0", "@sentry/core": "10.46.0" } }, "sha512-80DmGlTk5Z2/OxVOzLNxwolMyouuAYKqG8KUcoyintZqHbF6kO1RulI610HmyUt3OagKeBCqt9S7w0VIfCRL+Q=="],
 
-    "@sentry/bun": ["@sentry/bun@10.47.0", "", { "dependencies": { "@sentry/core": "10.47.0", "@sentry/node": "10.47.0" } }, "sha512-DRvCC4yM8bxhWzHdDHgwRljihCXaoJ6uUhTbBxT9tqEuUC+qCnFPk88J4QTuYfKfB9H6T/4k3TpSA2AMckbaIg=="],
+    "@sentry/bun": ["@sentry/bun@10.46.0", "", { "dependencies": { "@sentry/core": "10.46.0", "@sentry/node": "10.46.0" } }, "sha512-B/TCIOyumtqnUbQKuJ8xQIrwAi8Fl5PJhMkmONbKpW/an/etSUaL1R3XVw2kl7uhwuG8ygGv7TqMd1irsyUzjw=="],
 
     "@sentry/bundler-plugin-core": ["@sentry/bundler-plugin-core@5.1.1", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/babel-plugin-component-annotate": "5.1.1", "@sentry/cli": "^2.58.5", "dotenv": "^16.3.1", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" } }, "sha512-F+itpwR9DyQR7gEkrXd2tigREPTvtF5lC8qu6e4anxXYRTui1+dVR0fXNwjpyAZMhIesLfXRN7WY7ggdj7hi0Q=="],
 
@@ -1950,7 +1951,7 @@
 
     "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.5", "", { "os": "win32", "cpu": "x64" }, "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg=="],
 
-    "@sentry/core": ["@sentry/core@10.47.0", "", {}, "sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA=="],
+    "@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
 
     "@sentry/hub": ["@sentry/hub@5.30.0", "", { "dependencies": { "@sentry/types": "5.30.0", "@sentry/utils": "5.30.0", "tslib": "^1.9.3" } }, "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ=="],
 
@@ -1960,7 +1961,7 @@
 
     "@sentry/node": ["@sentry/node@5.30.0", "", { "dependencies": { "@sentry/core": "5.30.0", "@sentry/hub": "5.30.0", "@sentry/tracing": "5.30.0", "@sentry/types": "5.30.0", "@sentry/utils": "5.30.0", "cookie": "^0.4.1", "https-proxy-agent": "^5.0.0", "lru_map": "^0.3.3", "tslib": "^1.9.3" } }, "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg=="],
 
-    "@sentry/node-core": ["@sentry/node-core@10.47.0", "", { "dependencies": { "@sentry/core": "10.47.0", "@sentry/opentelemetry": "10.47.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/resources": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/context-async-hooks", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/resources", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-qv6LsqHbkQmd0aQEUox/svRSz26J+l4gGjFOUNEay2armZu9XLD+Ct89jpFgZD5oIPNAj2jraodTRqydXiwS5w=="],
+    "@sentry/node-core": ["@sentry/node-core@10.46.0", "", { "dependencies": { "@sentry/core": "10.46.0", "@sentry/opentelemetry": "10.46.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/resources": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/context-async-hooks", "@opentelemetry/core", "@opentelemetry/instrumentation", "@opentelemetry/resources", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-gwLGXfkzmiCmUI1VWttyoZBaVp1ItpDKc8AV2mQblWPQGdLSD0c6uKV/FkU291yZA3rXsrLXVwcWoibwnjE2vw=="],
 
     "@sentry/opentelemetry": ["@sentry/opentelemetry@10.46.0", "", { "dependencies": { "@sentry/core": "10.46.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-dzzV2ovruGsx9jzusGGr6cNPvMgYRu2BIrF8aMZ3rkQ1OpPJjPStqtA1l1fw0aoxHOxIjFU7ml4emF+xdmMl3g=="],
 
@@ -2034,7 +2035,7 @@
 
     "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.28", "", { "dependencies": { "@smithy/core": "^3.23.13", "@smithy/middleware-serde": "^4.2.16", "@smithy/node-config-provider": "^4.3.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "@smithy/url-parser": "^4.2.12", "@smithy/util-middleware": "^4.2.12", "tslib": "^2.6.2" } }, "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ=="],
 
-    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.4.46", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/protocol-http": "^5.3.12", "@smithy/service-error-classification": "^4.2.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.13", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow=="],
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.4.45", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.12", "@smithy/protocol-http": "^5.3.12", "@smithy/service-error-classification": "^4.2.12", "@smithy/smithy-client": "^4.12.8", "@smithy/types": "^4.13.1", "@smithy/util-middleware": "^4.2.12", "@smithy/util-retry": "^4.2.12", "@smithy/uuid": "^1.1.2", "tslib": "^2.6.2" } }, "sha512-td1PxpwDIaw5/oP/xIRxBGxJKoF1L4DBAwbZ8wjMuXBYOP/r2ZE/Ocou+mBHx/yk9knFEtDBwhSrYVn+Mz4pHw=="],
 
     "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.16", "", { "dependencies": { "@smithy/core": "^3.23.13", "@smithy/protocol-http": "^5.3.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA=="],
 
@@ -2084,7 +2085,7 @@
 
     "@smithy/util-middleware": ["@smithy/util-middleware@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ=="],
 
-    "@smithy/util-retry": ["@smithy/util-retry@4.2.13", "", { "dependencies": { "@smithy/service-error-classification": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ=="],
+    "@smithy/util-retry": ["@smithy/util-retry@4.2.12", "", { "dependencies": { "@smithy/service-error-classification": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ=="],
 
     "@smithy/util-stream": ["@smithy/util-stream@4.5.21", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.15", "@smithy/node-http-handler": "^4.5.1", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-buffer-from": "^4.2.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q=="],
 
@@ -2230,77 +2231,77 @@
 
     "@stripe/stripe-js": ["@stripe/stripe-js@8.11.0", "", {}, "sha512-3fVF4z3efsgwgyj64nFK+6F4/vMw0mUXD2TBbOfftJtKVNx4JNv3CSfe1fY4DCtCk0JFp8/YPNcRkzgV0HJ8cg=="],
 
-    "@swagger-api/apidom-ast": ["@swagger-api/apidom-ast@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-error": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "unraw": "^3.0.0" } }, "sha512-K8LkkWqsrXT+i8UGIHZ4HOfQ+kEuMVf7JZnS7lgSPCSUeC25iP/nrsIMPmOtZ20cS40BSxp7PjF/umt4pfOKNg=="],
+    "@swagger-api/apidom-ast": ["@swagger-api/apidom-ast@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-error": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "unraw": "^3.0.0" } }, "sha512-K5bnDnR5ugoSyqPjRdxnXt2zMlVE/UTFQGwy6Slln2mb6PdQv+z0nIeybgb+pk0z/DfBGmc2LFHZSRXFUq7g0A=="],
 
-    "@swagger-api/apidom-core": ["@swagger-api/apidom-core@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@types/ramda": "~0.30.0", "minim": "~0.23.8", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "short-unique-id": "^5.3.2", "ts-mixer": "^6.0.3" } }, "sha512-1g8rH4D1K/TmL/uLbpQM2R2aF2Wzexm7QRAQn4PFvFQw6cLND0NZJ/9OaMxpI73xHJCMqSW93YnatoDvxISq6g=="],
+    "@swagger-api/apidom-core": ["@swagger-api/apidom-core@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@types/ramda": "~0.30.0", "minim": "~0.23.8", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "short-unique-id": "^5.3.2", "ts-mixer": "^6.0.3" } }, "sha512-CFrb0h6B4iz4G1c6/vjm63u5RaXYUTt4uejp1BBMiLHgE/nucomC8HOdtNI+X+5nOsXRXYu1pX97QDp/9C1rWQ=="],
 
-    "@swagger-api/apidom-error": ["@swagger-api/apidom-error@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.20.7" } }, "sha512-LpmCpom6duasPCghNzx1fNyZ7H7DBzBztDdqFoi+HfXZXp8mMS2JlxU3qWbVZZCadKtkE2gloSLEHAx4cugpNg=="],
+    "@swagger-api/apidom-error": ["@swagger-api/apidom-error@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.20.7" } }, "sha512-cqwUoqocRT406tx0wMwxbDUbqZKj0wnMdW9s/i30bhw3tyct7CLuj7RHeCePycsH2wnyGBGYLcwHeoE+e050FA=="],
 
-    "@swagger-api/apidom-json-pointer": ["@swagger-api/apidom-json-pointer@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@swaggerexpert/json-pointer": "^2.10.1" } }, "sha512-u66jDeHUpIRjaxi89pwTnGTfCDRd9rB5M90j3d4JEzUj+dXopIPQFTHoqAXmV9pjJu7wG8IA+m2D+Rf6VfP29A=="],
+    "@swagger-api/apidom-json-pointer": ["@swagger-api/apidom-json-pointer@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@swaggerexpert/json-pointer": "^2.10.1" } }, "sha512-y38Z0gaFkyHgdzxZ56WPnZavzfeg5x18C/Ju1N3ElB0GWxppSWwx3SfKp3klvqwwYrsZAsMZcrO0ZU67yIEj2g=="],
 
-    "@swagger-api/apidom-ns-api-design-systems": ["@swagger-api/apidom-ns-api-design-systems@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-0zR4omzt/5FrWgIvcp5pOYJCE5X3IKepaOr56UQe0/VYrsiVQN5rIp7fhqDdXt+6YbZ7QYYMpdyYwbIbqgxeDQ=="],
+    "@swagger-api/apidom-ns-api-design-systems": ["@swagger-api/apidom-ns-api-design-systems@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-ePYELhZOF+tGMMoi7fTuFdioQ5j4wcKGqSFTu09mq6wRJLfx/XjlXfCnH2mMvRaNEx6VC1Z6dPCEt2YBpz0WIA=="],
 
-    "@swagger-api/apidom-ns-arazzo-1": ["@swagger-api/apidom-ns-arazzo-1@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-fBpDYcVap3Hy74As2kuPpqiZagvDY9Ydq8be4bYhRwRPg14+ymB66jM8gf5CFOdCM0CLv7f4Clmmj2mt8gTwgQ=="],
+    "@swagger-api/apidom-ns-arazzo-1": ["@swagger-api/apidom-ns-arazzo-1@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-json-schema-2020-12": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-LDOevWmtIcC4ulEYvjodiFu0DMXK8okKJLoEMV6CPwM6vbuBrvp1YfCUtyhsfm6mH/CdAfhEuatYldYmHY/frQ=="],
 
-    "@swagger-api/apidom-ns-asyncapi-2": ["@swagger-api/apidom-ns-asyncapi-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-EYuSvDbtz937tqg/7It4WI8u2/uF1bKftwTpbbSp4xGqw7FNKhdccFRwx5lkGxyTj9thc+ueeH3gtjCM5BEexA=="],
+    "@swagger-api/apidom-ns-asyncapi-2": ["@swagger-api/apidom-ns-asyncapi-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-json-schema-draft-7": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-Pugxu7Oibjh7Ba54Z6HRJU+G7zysr1MZUDJ740KJ6TY37S/vN3h3QylWhAcPZ2gbmCEfDmU2LLznWmQhjO505g=="],
 
-    "@swagger-api/apidom-ns-asyncapi-3": ["@swagger-api/apidom-ns-asyncapi-3@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-asyncapi-2": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-Yn8kj/VfmyTb8hD5KUmsnUoHD7Z3ffuLrFYeO6ukYsAc5ooZjtxltIO9+S3IxcSMj8i8yuaRpaRrLxwcTX7Nqw=="],
+    "@swagger-api/apidom-ns-asyncapi-3": ["@swagger-api/apidom-ns-asyncapi-3@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-asyncapi-2": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-w7jrzKKvy4CeDC3jMrjn4EpsD3PIM+oY+QGYmCZB8QfQT8j9DwEcThFXwibTjP8bk2SspKNgxjOUHwahHRCEsA=="],
 
-    "@swagger-api/apidom-ns-json-schema-2019-09": ["@swagger-api/apidom-ns-json-schema-2019-09@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-orcoTZPOur/gG+zK5wznfPlp6H6HnD6euDLg5rM2iXokErDVC1XRKDOrr5MF1V+XRRcSI5K0Qe6oYUtQF4HrNA=="],
+    "@swagger-api/apidom-ns-json-schema-2019-09": ["@swagger-api/apidom-ns-json-schema-2019-09@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@swagger-api/apidom-ns-json-schema-draft-7": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-WoA4C4fhZag+zqhpcH9r5rqjReMQhpCoWM916iPwFzMdvxG1hXjRdxKyb/qjLdx8CWqTOk399fnbdQmUuiejDg=="],
 
-    "@swagger-api/apidom-ns-json-schema-2020-12": ["@swagger-api/apidom-ns-json-schema-2020-12@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@swagger-api/apidom-ns-json-schema-2019-09": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-esxMmAQJaHVC4EpVY3d/fuz0fesHLUUk0z2gsFuxdq3fqyWPhpr42jcTiC5X1BNaQfbOcOzIPD5+qS86+3W5VQ=="],
+    "@swagger-api/apidom-ns-json-schema-2020-12": ["@swagger-api/apidom-ns-json-schema-2020-12@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@swagger-api/apidom-ns-json-schema-2019-09": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-Cj2E1/f1NNDDPUWxeDQqtCRDPz2UNWLfUJvW1vrgS7gw/nC9Dn969xXXG88KNEjt4qL5I9au1lD6NVd6KU71tA=="],
 
-    "@swagger-api/apidom-ns-json-schema-draft-4": ["@swagger-api/apidom-ns-json-schema-draft-4@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.10.0", "@swagger-api/apidom-core": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-1Gel1cjWRyds+FXOqk9OccA8xDABQG6ieq3z+GkTfXip5tw1PB7ppApz/NXAQW2awrbNZFPMoq+iE8z1kfe3LQ=="],
+    "@swagger-api/apidom-ns-json-schema-draft-4": ["@swagger-api/apidom-ns-json-schema-draft-4@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.9.0", "@swagger-api/apidom-core": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-gib7byiNlU3Wrz1STSEr/9m/kj1Da7mDdUuEIh4qGOMuGORXJ/ed+9WP45Ho1Wkz87j8FrnyiJ1s5Q87/woWug=="],
 
-    "@swagger-api/apidom-ns-json-schema-draft-6": ["@swagger-api/apidom-ns-json-schema-draft-6@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-feAnwtuK4rZJpqtLZEfI8YT13KOLdGNobRWWty0adtgdx9kY0imRhV0lKwV+eKSEIZwNH515Di4dR01HZX6LTg=="],
+    "@swagger-api/apidom-ns-json-schema-draft-6": ["@swagger-api/apidom-ns-json-schema-draft-6@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@swagger-api/apidom-ns-json-schema-draft-4": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-Dzwi5/El/r9TKnI/xkWTwrPhHZ6rAcuOwmTEUfAmz/UttJnoIUF2BisPTKcVY2sUmpPtSTPYzDC/U0tRf9EiWQ=="],
 
-    "@swagger-api/apidom-ns-json-schema-draft-7": ["@swagger-api/apidom-ns-json-schema-draft-7@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@swagger-api/apidom-ns-json-schema-draft-6": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-GIBqkY7IJcsuVg2Awn+id1hOqap5u0YLadQGxracpxnJ/HLLpqeXxhNFhERSkgbRniq30zU6xzYNPKsK8kDqwQ=="],
+    "@swagger-api/apidom-ns-json-schema-draft-7": ["@swagger-api/apidom-ns-json-schema-draft-7@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@swagger-api/apidom-ns-json-schema-draft-6": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.4" } }, "sha512-Gutve6BB94a0JNaRYwwKcsCyxhWe0hMf6Up/zmslonegP11O4O3Dp2u446cDUfucyKBFsxjAwhIRBgXeuFYsZQ=="],
 
-    "@swagger-api/apidom-ns-openapi-2": ["@swagger-api/apidom-ns-openapi-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-Sfyv/io6QSjRyNDTC8+9lpM/hUxJ7RLuagDE+q1wOVbZ6lDfUMIqFQSc8aRvgS8lsIddiIlz/k7oEu8xEP4Pqw=="],
+    "@swagger-api/apidom-ns-openapi-2": ["@swagger-api/apidom-ns-openapi-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@swagger-api/apidom-ns-json-schema-draft-4": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-UtWDuTVV5g59eLWUoms4IUFWrP1jtiwUDbkqxnVWNcHOXwd+wsgrvxSUL3mIYgxQTK3jKxCSPyycreo2BlKK1w=="],
 
-    "@swagger-api/apidom-ns-openapi-3-0": ["@swagger-api/apidom-ns-openapi-3-0@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-NQG1TbbW3nhBArsIYwg+T2XhntmQ83E7SA3zFcKo4bBmBRif5EmbBYCnfbjIIoie8LMSqfsCKekw4J1PzVWSKQ=="],
+    "@swagger-api/apidom-ns-openapi-3-0": ["@swagger-api/apidom-ns-openapi-3-0@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@swagger-api/apidom-ns-json-schema-draft-4": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-BXUpIOlo76kkMLghmDNLEIynzy2WiRoPW/wu8WqYm1bX3L1Dd1vspPNnPgyS0SnRawvLCDVmWF6LJiwcXz46Yw=="],
 
-    "@swagger-api/apidom-ns-openapi-3-1": ["@swagger-api/apidom-ns-openapi-3-1@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.10.0", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-json-pointer": "^1.10.0", "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-mNVmHJFQkNtZtfz+ypDOG2Aq2CmTc3pteTzgNhiStyISjYWygN1QuI/9yiFGMQ2TMQp+KaYKATuMyspQkoM6ig=="],
+    "@swagger-api/apidom-ns-openapi-3-1": ["@swagger-api/apidom-ns-openapi-3-1@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.9.0", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-json-pointer": "^1.9.0", "@swagger-api/apidom-ns-json-schema-2020-12": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-LKF78h8kVmM8T9vUcD338VTG4FdWgMWokDy/vftQtckUL7Br98leVl4CSz+Vb1jAxle3wXsE40xxkek6UwKg5Q=="],
 
-    "@swagger-api/apidom-ns-openapi-3-2": ["@swagger-api/apidom-ns-openapi-3-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.10.0", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-json-pointer": "^1.10.0", "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-UWobtUVSU3+TKyS9yKgn3556P4kpu2jQlP8lViIbg9LTYTEimCM5rdKtqtMsEbemIRCJBrEQ4SUtqVV6EjOvug=="],
+    "@swagger-api/apidom-ns-openapi-3-2": ["@swagger-api/apidom-ns-openapi-3-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.9.0", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-json-pointer": "^1.9.0", "@swagger-api/apidom-ns-json-schema-2020-12": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "ts-mixer": "^6.0.3" } }, "sha512-Netfb7NPArDft5vFKdl48KLiSIA3cN4PiG27xhjt0oRgvYEaryALHyei9xv04Mlm+u8KTy8MmcWueUOq9SP1wg=="],
 
-    "@swagger-api/apidom-parser-adapter-api-design-systems-json": ["@swagger-api/apidom-parser-adapter-api-design-systems-json@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-api-design-systems": "^1.10.0", "@swagger-api/apidom-parser-adapter-json": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-t+T7MPcYUayDB9GlmKr6N9WnL2e1cfbke2s7YPsLoZbImz4SBrOvspCKMOs178GYBgqHURS0l/Z0BVEMQvS6uA=="],
+    "@swagger-api/apidom-parser-adapter-api-design-systems-json": ["@swagger-api/apidom-parser-adapter-api-design-systems-json@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-api-design-systems": "^1.9.0", "@swagger-api/apidom-parser-adapter-json": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-lWRPlyotW+djH6oEX7b2iYWAhj/+KaFJsOEooGGLCETvyCQsCdSfIT1y5EEIQHWNPmw/z4UlIGczyUBT+Lu9KA=="],
 
-    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": ["@swagger-api/apidom-parser-adapter-api-design-systems-yaml@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-api-design-systems": "^1.10.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-VaGtVkLQpuMWSFSbZ5WAle7lS4KWUTst5zgvSMOf7HfuBOR37X5Pi21mjlgTw+RPmZFPhp8s3yFENZixJTn23Q=="],
+    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": ["@swagger-api/apidom-parser-adapter-api-design-systems-yaml@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-api-design-systems": "^1.9.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-x6TWhxwi824tv9biRNZOlHew1x5rKLvKISBrDx3Nr7oo/G688hWTNkDMmLpHIxIhLV1hAmqOIr8C+gc3dPqS+A=="],
 
-    "@swagger-api/apidom-parser-adapter-arazzo-json-1": ["@swagger-api/apidom-parser-adapter-arazzo-json-1@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-arazzo-1": "^1.10.0", "@swagger-api/apidom-parser-adapter-json": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-CIoYkygeWNrZX5Bz36QDpfbkgaQcViWYbTA4m6wqat7hUd590frz1psfwcP2GPfWjFHhfmAX7sLAzztRB1ivVw=="],
+    "@swagger-api/apidom-parser-adapter-arazzo-json-1": ["@swagger-api/apidom-parser-adapter-arazzo-json-1@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-arazzo-1": "^1.9.0", "@swagger-api/apidom-parser-adapter-json": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-uKowJL9zhy4l7Fi+JlcPlErHa8Tt0IpVFmGPfINY1yJumUrIwPNa+hsjXqVwy3O/YVjjSYleDqqAyG8afyxs2w=="],
 
-    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": ["@swagger-api/apidom-parser-adapter-arazzo-yaml-1@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-arazzo-1": "^1.10.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-yvVH+UxbSD1FwzV+ZLdnpPCS9Zo/TznmKZM6PsYTfQ8qNaXBn9+78FtrxFP0A8PhE0CE6ZC8Uh7gm6ptiHFWwg=="],
+    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": ["@swagger-api/apidom-parser-adapter-arazzo-yaml-1@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-arazzo-1": "^1.9.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-FtwXvAkeOKuQopzmn2U+e+tm7cA3i8KEjyMXGIuE6ElutpHfZoFm+gXnFY0bEqKXlYtXhl87MpXQIrN8XMcuVg=="],
 
-    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": ["@swagger-api/apidom-parser-adapter-asyncapi-json-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-asyncapi-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-json": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-qTk4dh8EF4cuFFTRCvoc4HBe9j1hb1V3CFdpzaAu+9YGO9DN3qnpaAwME7P6HQUPp1vWiFZwGY6+IjEZD02mhQ=="],
+    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": ["@swagger-api/apidom-parser-adapter-asyncapi-json-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-asyncapi-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-json": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-kjuiAW8cwl5hjR/0yITm6kZRmv9PgeAqwANzrtqgAzNA9e19oBmQvTEW8rPPRgqFccglm1Oq1VyqTirJiD8XLw=="],
 
-    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": ["@swagger-api/apidom-parser-adapter-asyncapi-json-3@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-asyncapi-3": "^1.10.0", "@swagger-api/apidom-parser-adapter-json": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-QFYww+I/ArV9MGcnf6y9whgeF/mt0sQLns82frFTu64KAR2LgOQWjaFk6KwPx4ccYOMMHa+ZdXz/RPHl1jnueQ=="],
+    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": ["@swagger-api/apidom-parser-adapter-asyncapi-json-3@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-asyncapi-3": "^1.9.0", "@swagger-api/apidom-parser-adapter-json": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-doM/IJXaVwrqT2mAiXpaLqG7TnPGBvrl0dmRxUHh/JHIzdEUfkgC6L4lf89BWSemC72J2uThFoA9PqF6z+IRUg=="],
 
-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": ["@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-asyncapi-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-iJI+9IfXwbd/Uh/HdPBAlhTjBZm2uUY5FV9TPNGUJldNYAkv4/HBanKTroIqsbQpUlZyLXfROuaXgQkzOK65Vg=="],
+    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": ["@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-asyncapi-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-lqWuxkWwFK5dct+8NRh1N2w8dm/61oOq4hHSe9+PsINPwv3gEdU6G3dz/WOrD4hWBwzssB37uNl/UxbGbkmkGA=="],
 
-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": ["@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-asyncapi-3": "^1.10.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-r0m3k9SncMzBxqB1gWbEln8j+9CTL/2V/CG2gSQhl3Qb4jT/BL0s6wj0b0NJeN2mviOVF+2LjUt1Y1JRNeiwlQ=="],
+    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": ["@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-asyncapi-3": "^1.9.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-giy3nafwV7yVLuYQAztTTTg3N1Nw+EXFfQ7PdgLXKlAJUIrNJN2Aypfvvl1eirLNTyvaVDtO5saDUPNiO7S+zQ=="],
 
-    "@swagger-api/apidom-parser-adapter-json": ["@swagger-api/apidom-parser-adapter-json@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.10.0", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "tree-sitter": "=0.21.1", "tree-sitter-json": "=0.24.8", "web-tree-sitter": "=0.24.5" } }, "sha512-5nBiSd224SXrV80xVuKV69Ff9dsqX5we7OUERvgrko4KactSNS6lLaxTnmjHWNHhX/Pnqwexvcw8kfjJvKgCkw=="],
+    "@swagger-api/apidom-parser-adapter-json": ["@swagger-api/apidom-parser-adapter-json@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.9.0", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "tree-sitter": "=0.21.1", "tree-sitter-json": "=0.24.8", "web-tree-sitter": "=0.24.5" } }, "sha512-h/UkZiFXK69rYJgNtbVQ+LltVagZndtcVyjc20guF/HT7eWjwpmd3Kt2cOk0QkhmoHjDZfNYsBw1yGjfcHNhvQ=="],
 
-    "@swagger-api/apidom-parser-adapter-openapi-json-2": ["@swagger-api/apidom-parser-adapter-openapi-json-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-openapi-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-json": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-S6/VXE1/+QK8lHT5N4eUNXyS2mzD0v4C49riHkLZ0iTBh1FYYAhv+Nc/EiHxKw1+6UmZs2bBeOryetdNbHWq8w=="],
+    "@swagger-api/apidom-parser-adapter-openapi-json-2": ["@swagger-api/apidom-parser-adapter-openapi-json-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-openapi-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-json": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-aFyY950Np4Y69nsxtho8TdShIE6T9iGmbFWyo/RTxcE39ST97W5xOBrF0s7IX5o1MsuYTNJYOcrSRiwIcn8MxQ=="],
 
-    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": ["@swagger-api/apidom-parser-adapter-openapi-json-3-0@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.10.0", "@swagger-api/apidom-parser-adapter-json": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-XxHHKlTWoU9MGatMsPhLDbQPH/0FYu+jSu59+DWOgrporHsf6vjAdQAreSJAtRGW1PEQJ6VqYAe91EOexGR5Ow=="],
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": ["@swagger-api/apidom-parser-adapter-openapi-json-3-0@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.9.0", "@swagger-api/apidom-parser-adapter-json": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-7f7IvOh+BEd73K92jXVIPECGgGReLf/x6WP81osB7npc0MIosMRvkT031LuGB7OVUj7UlBeq9kWqF2h1YGt71w=="],
 
-    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": ["@swagger-api/apidom-parser-adapter-openapi-json-3-1@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.10.0", "@swagger-api/apidom-parser-adapter-json": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-Fqpr3dxE8AistDrfUHyIS1emlQc6a8dzlaWWnVDNqLr2W/kCCrUW2Lb6MRP34A9Ry9+JDv4x5Z4jBGtz7wbCyA=="],
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": ["@swagger-api/apidom-parser-adapter-openapi-json-3-1@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.9.0", "@swagger-api/apidom-parser-adapter-json": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-hHOKnNOf81cAqzra+PBS/t5lRMhpSAoMavjqDdpmH5ad06nbDEyr7RcQmQl+WM9lsfeU0fbYteMhvSo2neuIWg=="],
 
-    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": ["@swagger-api/apidom-parser-adapter-openapi-json-3-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-json": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-HYSE4jjHHrPe081hqLMny7R4A9FTThXVRICYSHXYsAJnpLpDhqRGos4zeEcWby0L6uIJcZ168V+ep4BpHrPobw=="],
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": ["@swagger-api/apidom-parser-adapter-openapi-json-3-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-json": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-ajuSbYNMqrcb3ZBkOEESp/D9ima4+mRowBsYRhCF6bg0rKC+Qd2UmdQ6rh/mwgt7h9Jad64FflfmaIt9IRGNYQ=="],
 
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": ["@swagger-api/apidom-parser-adapter-openapi-yaml-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-openapi-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-svi0djdmD+74uJR8OzN+kElyJoTzZ85aqyZDjZAOEfmoveJKmDZ6VAYWZvfBZYECFEdLrv7jsSzVkwLEGc37Ig=="],
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": ["@swagger-api/apidom-parser-adapter-openapi-yaml-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-openapi-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-1HIUcxF/prJWmACmkHrreX4aapHzexs+LrdJeTGo7Q5fXs2seZxF+CRynldigi7MXjuoQ0o+Ww0xTXAov7nqNg=="],
 
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": ["@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.10.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-9jy4dt4gni6Zt99sgyFFuBA4pWTUJxW6+2EJrR9AKiThpTzBlB4Nxdu7glCVtdCcR23Nhm9JoR3rbnXIO8kTjA=="],
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": ["@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.9.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-Ukzv15L3DX3K2xVZqCJerg3gU/qi+xVx6VpmjhGuibq03pGKuI6dM++HlczW3Vm7Xo5RwTuF2CFUJJie8QDLHw=="],
 
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": ["@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.10.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-rYE+XJhFOoCD818MGghIktuzXFNSiOt3Bdc0P+xBU9QtMP5eOITTSAt5+mBXPVi4hToV05rVEeNSXA4Z87f63w=="],
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": ["@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.9.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-XbVtS1LR8BdSI4iK9x6riA+BYLQkyCuKt3uWrlBUWgojiqm2FZC1s9Q3a5UVnbs77OrKQyFkNkiWhcX8ct7VVA=="],
 
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": ["@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-nYqHrltg8qV3vykxtrqWyq5GLJzh9RCQYFtGfH0PYYWXL2h2sshlgM2HrasbYdvoCw20bSemk+6PZ8aeCZ600w=="],
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": ["@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.9.0", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" } }, "sha512-A82nil8pszk6oIo23pAyXQuYtp5Rdrp0rDLS17jSg4ziC/i0biwlh2Hi+Sfrcy96jaCA2HIghOiVFSrSBwJPkQ=="],
 
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": ["@swagger-api/apidom-parser-adapter-yaml-1-2@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.10.0", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "tree-sitter": "=0.22.4", "web-tree-sitter": "=0.24.5" } }, "sha512-4OYiSygyFeHz5gDXzUuq+RGIa7ikqdFjm2CV8ET5iqahPpy5iNFi4q+IyK24xRHP1dcr0X151OCZJ+Cjay8Gdg=="],
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": ["@swagger-api/apidom-parser-adapter-yaml-1-2@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-ast": "^1.9.0", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1", "@types/ramda": "~0.30.0", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0", "tree-sitter": "=0.22.4", "web-tree-sitter": "=0.24.5" } }, "sha512-UvF2oyT3fBTyDXKvBMa96ODUD+qjWeVZwydZmGLZpa7Fo0gsc2cDByzmnLm8O9+DUZEpJgz7It5irL7FlR9Xvg=="],
 
-    "@swagger-api/apidom-reference": ["@swagger-api/apidom-reference@1.10.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.10.0", "@swagger-api/apidom-error": "^1.10.0", "@types/ramda": "~0.30.0", "axios": "^1.12.2", "minimatch": "^10.2.1", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" }, "optionalDependencies": { "@swagger-api/apidom-json-pointer": "^1.10.0", "@swagger-api/apidom-ns-arazzo-1": "^1.10.0", "@swagger-api/apidom-ns-asyncapi-2": "^1.10.0", "@swagger-api/apidom-ns-openapi-2": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.10.0", "@swagger-api/apidom-ns-openapi-3-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.10.0", "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.10.0", "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.10.0", "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.10.0", "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.10.0", "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.10.0", "@swagger-api/apidom-parser-adapter-json": "^1.10.0", "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.10.0", "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.10.0", "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.10.0", "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.10.0", "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.10.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.0" } }, "sha512-tJq3te29xgxLszcqhGeQHbEthDDUOve0/379RUei/00fjbEAKYgwf1aNFyaMUiTQ6TFpjd8j1AIoGLUt8+xyYw=="],
+    "@swagger-api/apidom-reference": ["@swagger-api/apidom-reference@1.9.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.26.10", "@swagger-api/apidom-core": "^1.9.0", "@swagger-api/apidom-error": "^1.9.0", "@types/ramda": "~0.30.0", "axios": "^1.12.2", "minimatch": "^10.2.1", "ramda": "~0.30.0", "ramda-adjunct": "^5.0.0" }, "optionalDependencies": { "@swagger-api/apidom-json-pointer": "^1.9.0", "@swagger-api/apidom-ns-arazzo-1": "^1.9.0", "@swagger-api/apidom-ns-asyncapi-2": "^1.9.0", "@swagger-api/apidom-ns-openapi-2": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-0": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-1": "^1.9.0", "@swagger-api/apidom-ns-openapi-3-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.9.0", "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.9.0", "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.9.0", "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.9.0", "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.9.0", "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.9.0", "@swagger-api/apidom-parser-adapter-json": "^1.9.0", "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.9.0", "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.9.0", "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.9.0", "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.9.0", "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.9.0", "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.9.0" } }, "sha512-dlJPZSg6G8TvmL7sFi5nJOTITJAZRZpWcVozvJCjwak5lkB+i95fPiH7O59fWYfg5U4fUUiAwG4+mVwSjBWpNA=="],
 
     "@swaggerexpert/cookie": ["@swaggerexpert/cookie@2.0.2", "", { "dependencies": { "apg-lite": "^1.0.3" } }, "sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg=="],
 
@@ -2342,9 +2343,9 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.17", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.17", "@tailwindcss/oxide": "4.1.17", "postcss": "^8.4.41", "tailwindcss": "4.1.17" } }, "sha512-+nKl9N9mN5uJ+M7dBOOCzINw94MPstNR/GtIhz1fpZysxL/4a+No64jCBD6CPN+bIHWFx3KWuu8XJRrj/572Dw=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.96.1", "", {}, "sha512-u1yBgtavSy+N8wgtW3PiER6UpxcplMje65yXnnVgiHTqiMwLlxiw4WvQDrXyn+UD6lnn8kHaxmerJUzQcV/MMg=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.95.2", "", {}, "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.96.1", "", { "dependencies": { "@tanstack/query-core": "5.96.1" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-2X7KYK5KKWUKGeWCVcqxXAkYefJtrKB7tSKWgeG++b0H6BRHxQaLSSi8AxcgjmUnnosHuh9WsFZqvE16P1WCzA=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.95.2", "", { "dependencies": { "@tanstack/query-core": "5.95.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.23", "", { "dependencies": { "@tanstack/virtual-core": "3.13.23" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ=="],
 
@@ -2770,7 +2771,7 @@
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
-    "ai": ["ai@5.0.162", "", { "dependencies": { "@ai-sdk/gateway": "2.0.66", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.22", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-GQbTYj80O9+bLmm4bqkKqQwJR/14iAZzfCqkh2h+k0nnokUCpn9Lm3difN0bxK0sPrygmmVUhZ9LCfSbxXSegg=="],
+    "ai": ["ai@5.0.161", "", { "dependencies": { "@ai-sdk/gateway": "2.0.65", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.22", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CVANs7auUNEi/hRhdJDKcPYaCLWXveIfmoiekNSRel3i8WUieB6iEncDS5smcubWsx7hGtTgXxNRTg0YG0ljtA=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -2848,13 +2849,13 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
-    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.13", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ=="],
 
     "better-promises": ["better-promises@0.4.1", "", { "dependencies": { "error-kid": "^0.0.7" } }, "sha512-cDW7eMvhvCoWzSih5o/OxsAgTUfP05yGMq77xNZUTmcZoNU9vEeFZJ+yJJi4lnocvxFrVFKsG0Yxt7ZnuYJEig=="],
 
@@ -2882,7 +2883,7 @@
 
     "boxen": ["boxen@5.1.2", "", { "dependencies": { "ansi-align": "^3.0.0", "camelcase": "^6.2.0", "chalk": "^4.1.0", "cli-boxes": "^2.2.1", "string-width": "^4.2.2", "type-fest": "^0.20.2", "widest-line": "^3.1.0", "wrap-ansi": "^7.0.0" } }, "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -2894,7 +2895,7 @@
 
     "browserify-aes": ["browserify-aes@1.2.0", "", { "dependencies": { "buffer-xor": "^1.0.3", "cipher-base": "^1.0.0", "create-hash": "^1.1.0", "evp_bytestokey": "^1.0.3", "inherits": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA=="],
 
-    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+    "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
@@ -2932,7 +2933,7 @@
 
     "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001784", "", {}, "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001782", "", {}, "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw=="],
 
     "canonicalize": ["canonicalize@2.1.0", "", { "bin": { "canonicalize": "bin/canonicalize.js" } }, "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ=="],
 
@@ -3030,6 +3031,8 @@
 
     "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
     "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
 
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
@@ -3050,7 +3053,7 @@
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
-    "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
+    "cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -3204,7 +3207,7 @@
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
-    "defu": ["defu@6.1.6", "", {}, "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug=="],
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
@@ -3282,7 +3285,7 @@
 
     "electron-fetch": ["electron-fetch@1.9.1", "", { "dependencies": { "encoding": "^0.1.13" } }, "sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.330", "", {}, "sha512-jFNydB5kFtYUobh4IkWUnXeyDbjf/r9gcUEXe1xcrcUxIGfTdzPXA+ld6zBRbwvgIGVzDll/LTIiDztEtckSnA=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.329", "", {}, "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ=="],
 
     "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
 
@@ -3646,7 +3649,7 @@
 
     "idb": ["idb@8.0.3", "", {}, "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="],
 
-    "idb-keyval": ["idb-keyval@6.2.1", "", {}, "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="],
+    "idb-keyval": ["idb-keyval@6.2.2", "", {}, "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -4092,7 +4095,7 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
-    "mermaid": ["mermaid@11.14.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g=="],
+    "mermaid": ["mermaid@11.13.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.0.1", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw=="],
 
     "metro": ["metro@0.83.5", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/core": "^7.25.2", "@babel/generator": "^7.29.1", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "accepts": "^2.0.0", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.33.3", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.5", "metro-cache": "0.83.5", "metro-cache-key": "0.83.5", "metro-config": "0.83.5", "metro-core": "0.83.5", "metro-file-map": "0.83.5", "metro-resolver": "0.83.5", "metro-runtime": "0.83.5", "metro-source-map": "0.83.5", "metro-symbolicate": "0.83.5", "metro-transform-plugins": "0.83.5", "metro-transform-worker": "0.83.5", "mime-types": "^3.0.1", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-BgsXevY1MBac/3ZYv/RfNFf/4iuW9X7f4H8ZNkiH+r667HD9sVujxcmu4jvEzGCAm4/WyKdZCuyhAcyhTHOucQ=="],
 
@@ -4200,7 +4203,7 @@
 
     "minimalistic-crypto-utils": ["minimalistic-crypto-utils@1.0.1", "", {}, "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="],
 
-    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+    "minimatch": ["minimatch@10.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -4478,7 +4481,7 @@
 
     "posthog-js": ["posthog-js@1.364.1", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.24.3", "@posthog/types": "1.364.1", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-7nR2lfxKKqv5SeC+OjeWkWXfK/4RbXxRiqmSAW214y+FuDFVS+Li0mPzTBC/V20uHPWtd92ptrctpY/jKj0F7w=="],
 
-    "posthog-node": ["posthog-node@5.28.10", "", { "dependencies": { "@posthog/core": "1.24.5" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-FxZFnX/3a7Edc2VIpiyne3BiqmzZRQv5nAItaO1urZDhC5fPWZeeo04aeKl0LWKBUp7M7x6a2sQYHpqVztT4GQ=="],
+    "posthog-node": ["posthog-node@5.28.9", "", { "dependencies": { "@posthog/core": "1.24.4" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-iZWyAYkIAq5QqcYz4q2nXOX+Ivn04Yh8AuKqfFVw0SvBpfli49bNAjyE97qbRTLr+irrzRUELgGIkDC14NgugA=="],
 
     "preact": ["preact@10.29.0", "", {}, "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg=="],
 
@@ -4502,7 +4505,7 @@
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
-    "progress-events": ["progress-events@1.1.0", "", {}, "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ=="],
+    "progress-events": ["progress-events@1.0.1", "", {}, "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw=="],
 
     "promise": ["promise@8.3.0", "", { "dependencies": { "asap": "~2.0.6" } }, "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg=="],
 
@@ -5308,13 +5311,21 @@
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@aws-crypto/sha1-browser/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/sha256-browser/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@aws-crypto/sha256-js/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@aws-crypto/supports-web-crypto/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/util/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@aws-sdk/client-s3/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@aws-sdk/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -5337,6 +5348,8 @@
     "@aws-sdk/credential-provider-web-identity/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@aws-sdk/lib-storage/buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
+
+    "@aws-sdk/lib-storage/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@aws-sdk/middleware-bucket-endpoint/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -5394,6 +5407,8 @@
 
     "@base-org/account/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "@base-org/account/idb-keyval": ["idb-keyval@6.2.1", "", {}, "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="],
+
     "@base-org/account/ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
 
     "@base-org/account/zustand": ["zustand@5.0.3", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg=="],
@@ -5422,11 +5437,11 @@
 
     "@elizaos/plugin-anthropic/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.64", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-rwLi/Rsuj2pYniQXIrvClHvXDzgM4UQHHnvHTWEF14efnlKclG/1ghpNC+adsRujAbCTr6gRsSbDE2vEqriV7g=="],
 
-    "@elizaos/plugin-anthropic/ai": ["ai@6.0.142", "", { "dependencies": { "@ai-sdk/gateway": "3.0.84", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZoxAsnTL/dFg5WdcwC8QNhKVlLtqwwT3I7p/4i8IJJP+6ZwqF1ljuwMsAsPYYvppZ+RzUxjxxFGb1cbEhNH3dg=="],
+    "@elizaos/plugin-anthropic/ai": ["ai@6.0.141", "", { "dependencies": { "@ai-sdk/gateway": "3.0.83", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-+GomGQWaId3xN0wcugUW/H7xMMaFkID2PiS7K/Wugj45G3efv0BXhQ3psRZoQVoRbOpdNoUqcK/KTB+FR4h6qg=="],
 
     "@elizaos/plugin-openai/@ai-sdk/openai": ["@ai-sdk/openai@3.0.49", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-U2f0pCyNn/jQH3wjgxr8o9VvCkuDFTtXbIhbFFtgXqCzMbed6rBnvzQcAMEK0/Pa44byL9zfcvCOFOflvkRA8w=="],
 
-    "@elizaos/plugin-openai/ai": ["ai@6.0.142", "", { "dependencies": { "@ai-sdk/gateway": "3.0.84", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZoxAsnTL/dFg5WdcwC8QNhKVlLtqwwT3I7p/4i8IJJP+6ZwqF1ljuwMsAsPYYvppZ+RzUxjxxFGb1cbEhNH3dg=="],
+    "@elizaos/plugin-openai/ai": ["ai@6.0.141", "", { "dependencies": { "@ai-sdk/gateway": "3.0.83", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-+GomGQWaId3xN0wcugUW/H7xMMaFkID2PiS7K/Wugj45G3efv0BXhQ3psRZoQVoRbOpdNoUqcK/KTB+FR4h6qg=="],
 
     "@elizaos/plugin-sql/drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
@@ -5628,7 +5643,7 @@
 
     "@multiformats/dns/@libp2p/interface": ["@libp2p/interface@3.1.1", "", { "dependencies": { "@multiformats/dns": "^1.0.6", "@multiformats/multiaddr": "^13.0.1", "main-event": "^1.0.1", "multiformats": "^13.4.0", "progress-events": "^1.0.1", "uint8arraylist": "^2.4.8" } }, "sha512-pQuReZeZUSqk27UXwXXdAVlxrgs08GrcPsd92Qv27IFBPICG8da3FmHg1bclUpMW/6GE6o4qDCVqR4cBMRVKyA=="],
 
-    "@multiformats/dns/p-queue": ["p-queue@9.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-yQS1vV2V7Q14MQrgD8jMNY5owPuGgVHVdSK8NqmKpOVajnjbaeMa6uLOzTALPtvJ7Vo4bw0BGsw7qfUT8z24Ig=="],
+    "@multiformats/dns/p-queue": ["p-queue@9.1.0", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw=="],
 
     "@multiformats/mafmt/@multiformats/multiaddr": ["@multiformats/multiaddr@12.5.1", "", { "dependencies": { "@chainsafe/is-ip": "^2.0.1", "@chainsafe/netmask": "^2.0.0", "@multiformats/dns": "^1.0.3", "abort-error": "^1.0.1", "multiformats": "^13.0.0", "uint8-varint": "^2.0.1", "uint8arrays": "^5.0.0" } }, "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ=="],
 
@@ -5646,9 +5661,11 @@
 
     "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
 
-    "@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
+    "@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.213.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw=="],
 
     "@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@3.0.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg=="],
+
+    "@opentelemetry/instrumentation-http/@opentelemetry/core": ["@opentelemetry/core@2.6.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg=="],
 
     "@opentelemetry/instrumentation-pg/@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
 
@@ -5722,7 +5739,7 @@
 
     "@privy-io/react-auth/viem": ["viem@2.47.4", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.5", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-h0Wp/SYmJO/HB4B/em1OZ3W1LaKrmr7jzaN7talSlZpo0LCn0V6rZ5g923j6sf4VUSrqp/gUuWuHFc7UcoIp8A=="],
 
-    "@privy-io/server-auth/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+    "@privy-io/server-auth/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@privy-io/server-auth/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -5844,23 +5861,13 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@scure/bip32/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@scure/bip39/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@sentry-internal/browser-utils/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
-
-    "@sentry-internal/feedback/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
-
-    "@sentry-internal/replay/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
-
-    "@sentry-internal/replay-canvas/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
-
-    "@sentry/browser/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
-
-    "@sentry/bun/@sentry/node": ["@sentry/node@10.47.0", "", { "dependencies": { "@fastify/otel": "0.18.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/context-async-hooks": "^2.6.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/instrumentation-amqplib": "0.61.0", "@opentelemetry/instrumentation-connect": "0.57.0", "@opentelemetry/instrumentation-dataloader": "0.31.0", "@opentelemetry/instrumentation-express": "0.62.0", "@opentelemetry/instrumentation-fs": "0.33.0", "@opentelemetry/instrumentation-generic-pool": "0.57.0", "@opentelemetry/instrumentation-graphql": "0.62.0", "@opentelemetry/instrumentation-hapi": "0.60.0", "@opentelemetry/instrumentation-http": "0.214.0", "@opentelemetry/instrumentation-ioredis": "0.62.0", "@opentelemetry/instrumentation-kafkajs": "0.23.0", "@opentelemetry/instrumentation-knex": "0.58.0", "@opentelemetry/instrumentation-koa": "0.62.0", "@opentelemetry/instrumentation-lru-memoizer": "0.58.0", "@opentelemetry/instrumentation-mongodb": "0.67.0", "@opentelemetry/instrumentation-mongoose": "0.60.0", "@opentelemetry/instrumentation-mysql": "0.60.0", "@opentelemetry/instrumentation-mysql2": "0.60.0", "@opentelemetry/instrumentation-pg": "0.66.0", "@opentelemetry/instrumentation-redis": "0.62.0", "@opentelemetry/instrumentation-tedious": "0.33.0", "@opentelemetry/instrumentation-undici": "0.24.0", "@opentelemetry/resources": "^2.6.1", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.6.0", "@sentry/core": "10.47.0", "@sentry/node-core": "10.47.0", "@sentry/opentelemetry": "10.47.0", "import-in-the-middle": "^3.0.0" } }, "sha512-R+btqPepv88o635G6HtVewLjqCLUedBg5HBs7Nq1qbbKvyti01uArUF2f+3DsLenk5B9LUNiRlE+frZA44Ahmw=="],
+    "@sentry/bun/@sentry/node": ["@sentry/node@10.46.0", "", { "dependencies": { "@fastify/otel": "0.17.1", "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^2.6.0", "@opentelemetry/core": "^2.6.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/instrumentation-amqplib": "0.60.0", "@opentelemetry/instrumentation-connect": "0.56.0", "@opentelemetry/instrumentation-dataloader": "0.30.0", "@opentelemetry/instrumentation-express": "0.61.0", "@opentelemetry/instrumentation-fs": "0.32.0", "@opentelemetry/instrumentation-generic-pool": "0.56.0", "@opentelemetry/instrumentation-graphql": "0.61.0", "@opentelemetry/instrumentation-hapi": "0.59.0", "@opentelemetry/instrumentation-http": "0.213.0", "@opentelemetry/instrumentation-ioredis": "0.61.0", "@opentelemetry/instrumentation-kafkajs": "0.22.0", "@opentelemetry/instrumentation-knex": "0.57.0", "@opentelemetry/instrumentation-koa": "0.61.0", "@opentelemetry/instrumentation-lru-memoizer": "0.57.0", "@opentelemetry/instrumentation-mongodb": "0.66.0", "@opentelemetry/instrumentation-mongoose": "0.59.0", "@opentelemetry/instrumentation-mysql": "0.59.0", "@opentelemetry/instrumentation-mysql2": "0.59.0", "@opentelemetry/instrumentation-pg": "0.65.0", "@opentelemetry/instrumentation-redis": "0.61.0", "@opentelemetry/instrumentation-tedious": "0.32.0", "@opentelemetry/instrumentation-undici": "0.23.0", "@opentelemetry/resources": "^2.6.0", "@opentelemetry/sdk-trace-base": "^2.6.0", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.4.2", "@sentry/core": "10.46.0", "@sentry/node-core": "10.46.0", "@sentry/opentelemetry": "10.46.0", "import-in-the-middle": "^3.0.0" } }, "sha512-vF+7FrUXEtmYWuVcnvBjlWKeyLw/kwHpwnGj9oUmO/a2uKjDmUr53ZVcapggNxCjivavGYr9uHOY64AGdeUyzA=="],
 
     "@sentry/hub/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
@@ -5868,21 +5875,13 @@
 
     "@sentry/nextjs/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
-    "@sentry/nextjs/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
-
     "@sentry/nextjs/@sentry/node": ["@sentry/node@10.46.0", "", { "dependencies": { "@fastify/otel": "0.17.1", "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^2.6.0", "@opentelemetry/core": "^2.6.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/instrumentation-amqplib": "0.60.0", "@opentelemetry/instrumentation-connect": "0.56.0", "@opentelemetry/instrumentation-dataloader": "0.30.0", "@opentelemetry/instrumentation-express": "0.61.0", "@opentelemetry/instrumentation-fs": "0.32.0", "@opentelemetry/instrumentation-generic-pool": "0.56.0", "@opentelemetry/instrumentation-graphql": "0.61.0", "@opentelemetry/instrumentation-hapi": "0.59.0", "@opentelemetry/instrumentation-http": "0.213.0", "@opentelemetry/instrumentation-ioredis": "0.61.0", "@opentelemetry/instrumentation-kafkajs": "0.22.0", "@opentelemetry/instrumentation-knex": "0.57.0", "@opentelemetry/instrumentation-koa": "0.61.0", "@opentelemetry/instrumentation-lru-memoizer": "0.57.0", "@opentelemetry/instrumentation-mongodb": "0.66.0", "@opentelemetry/instrumentation-mongoose": "0.59.0", "@opentelemetry/instrumentation-mysql": "0.59.0", "@opentelemetry/instrumentation-mysql2": "0.59.0", "@opentelemetry/instrumentation-pg": "0.65.0", "@opentelemetry/instrumentation-redis": "0.61.0", "@opentelemetry/instrumentation-tedious": "0.32.0", "@opentelemetry/instrumentation-undici": "0.23.0", "@opentelemetry/resources": "^2.6.0", "@opentelemetry/sdk-trace-base": "^2.6.0", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.4.2", "@sentry/core": "10.46.0", "@sentry/node-core": "10.46.0", "@sentry/opentelemetry": "10.46.0", "import-in-the-middle": "^3.0.0" } }, "sha512-vF+7FrUXEtmYWuVcnvBjlWKeyLw/kwHpwnGj9oUmO/a2uKjDmUr53ZVcapggNxCjivavGYr9uHOY64AGdeUyzA=="],
 
     "@sentry/node/@sentry/core": ["@sentry/core@5.30.0", "", { "dependencies": { "@sentry/hub": "5.30.0", "@sentry/minimal": "5.30.0", "@sentry/types": "5.30.0", "@sentry/utils": "5.30.0", "tslib": "^1.9.3" } }, "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg=="],
 
     "@sentry/node/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
-    "@sentry/node-core/@sentry/opentelemetry": ["@sentry/opentelemetry@10.47.0", "", { "dependencies": { "@sentry/core": "10.47.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-f6Hw2lrpCjlOksiosP0Z2jK/+l+21SIdoNglVeG/sttMyx8C8ywONKh0Ha50sFsvB1VaB8n94RKzzf3hkh9V3g=="],
-
     "@sentry/node-core/import-in-the-middle": ["import-in-the-middle@3.0.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg=="],
-
-    "@sentry/opentelemetry/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
-
-    "@sentry/react/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
 
     "@sentry/tracing/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
@@ -5890,13 +5889,9 @@
 
     "@sentry/vercel-edge/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
-    "@sentry/vercel-edge/@sentry/core": ["@sentry/core@10.46.0", "", {}, "sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q=="],
-
     "@sentry/webpack-plugin/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@serwist/build/source-map": ["source-map@0.8.0-beta.0", "", { "dependencies": { "whatwg-url": "^7.0.0" } }, "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="],
-
-    "@serwist/next/browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "@serwist/next/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -6058,7 +6053,7 @@
 
     "@solana/rpc-api/@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
 
-    "@solana/rpc-transport-http/undici-types": ["undici-types@7.24.7", "", {}, "sha512-XA+gOBkzYD3C74sZowtCLTpgtaCdqZhqCvR6y9LXvrKTt/IVU6bz49T4D+BPi475scshCCkb0IklJRw6T1ZlgQ=="],
+    "@solana/rpc-transport-http/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
 
@@ -6146,7 +6141,7 @@
 
     "@walletconnect/jsonrpc-utils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
-    "@walletconnect/keyvaluestorage/idb-keyval": ["idb-keyval@6.2.2", "", {}, "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="],
+    "@walletconnect/keyvaluestorage/idb-keyval": ["idb-keyval@6.2.1", "", {}, "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="],
 
     "@walletconnect/relay-auth/@noble/curves": ["@noble/curves@1.8.0", "", { "dependencies": { "@noble/hashes": "1.7.0" } }, "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ=="],
 
@@ -6450,7 +6445,7 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "porto/idb-keyval": ["idb-keyval@6.2.2", "", {}, "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="],
+    "porto/idb-keyval": ["idb-keyval@6.2.1", "", {}, "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="],
 
     "porto/ox": ["ox@0.9.17", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg=="],
 
@@ -6491,6 +6486,8 @@
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.12", "", {}, "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw=="],
+
+    "rollup/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "rxjs/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -6604,11 +6601,7 @@
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "@aws-crypto/sha1-browser/@smithy/util-utf8/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
-
-    "@aws-crypto/sha256-browser/@smithy/util-utf8/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
@@ -6628,7 +6621,7 @@
 
     "@elizaos/plugin-anthropic/@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
-    "@elizaos/plugin-anthropic/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.84", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-RnUw6UNvkaw9MEaJU9cIjA+WBP+ZR5+M/9nfbfJHcGKtTbcWXijJuYKx9nYRnm+qU+iiakb0XvQA/vvho6lTsw=="],
+    "@elizaos/plugin-anthropic/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.83", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ=="],
 
     "@elizaos/plugin-anthropic/ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
@@ -6638,7 +6631,7 @@
 
     "@elizaos/plugin-openai/@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
-    "@elizaos/plugin-openai/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.84", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-RnUw6UNvkaw9MEaJU9cIjA+WBP+ZR5+M/9nfbfJHcGKtTbcWXijJuYKx9nYRnm+qU+iiakb0XvQA/vvho6lTsw=="],
+    "@elizaos/plugin-openai/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.83", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ=="],
 
     "@elizaos/plugin-openai/ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
@@ -6818,61 +6811,7 @@
 
     "@sentry/bun/@sentry/node/@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
-    "@sentry/bun/@sentry/node/@sentry/opentelemetry": ["@sentry/opentelemetry@10.47.0", "", { "dependencies": { "@sentry/core": "10.47.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-f6Hw2lrpCjlOksiosP0Z2jK/+l+21SIdoNglVeG/sttMyx8C8ywONKh0Ha50sFsvB1VaB8n94RKzzf3hkh9V3g=="],
-
     "@sentry/bun/@sentry/node/import-in-the-middle": ["import-in-the-middle@3.0.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg=="],
-
-    "@sentry/nextjs/@sentry/node/@fastify/otel": ["@fastify/otel@0.17.1", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.212.0", "@opentelemetry/semantic-conventions": "^1.28.0", "minimatch": "^10.2.4" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-K4wyxfUZx2ux5o+b6BtTqouYFVILohLZmSbA2tKUueJstNcBnoGPVhllCaOvbQ3ZrXdUxUC/fyrSWSCqHhdOPg=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.213.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.213.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-amqplib": ["@opentelemetry/instrumentation-amqplib@0.60.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-connect": ["@opentelemetry/instrumentation-connect@0.56.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.27.0", "@types/connect": "3.4.38" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-PKp+sSZ7AfzMvGgO3VCyo1inwNu+q7A1k9X88WK4PQ+S6Hp7eFk8pie+sWHDTaARovmqq5V2osav3lQej2B0nw=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-dataloader": ["@opentelemetry/instrumentation-dataloader@0.30.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MXHP2Q38cd2OhzEBKAIXUi9uBlPEYzF6BNJbyjUXBQ6kLaf93kRC41vNMIz0Nl5mnuwK7fDvKT+/lpx7BXRwdg=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-express": ["@opentelemetry/instrumentation-express@0.61.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Xdmqo9RZuZlL29Flg8QdwrrX7eW1CZ7wFQPKHyXljNymgKhN1MCsYuqQ/7uxavhSKwAl7WxkTzKhnqpUApLMvQ=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-fs": ["@opentelemetry/instrumentation-fs@0.32.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-koR6apx0g0wX6RRiPpjA4AFQUQUbXrK16kq4/SZjVp7u5cffJhNkY4TnITxcGA4acGSPYAfx3NHRIv4Khn1axQ=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-generic-pool": ["@opentelemetry/instrumentation-generic-pool@0.56.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fg+Jffs6fqrf0uQS0hom7qBFKsbtpBiBl8+Vkc63Gx8xh6pVh+FhagmiO6oM0m3vyb683t1lP7yGYq22SiDnqg=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-graphql": ["@opentelemetry/instrumentation-graphql@0.61.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-pUiVASv6nh2XrerTvlbVHh7vKFzscpgwiQ/xvnZuAIzQ5lRjWVdRPUuXbvZJ/Yq79QsE81TZdJ7z9YsXiss1ew=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-hapi": ["@opentelemetry/instrumentation-hapi@0.59.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-33wa4mEr+9+ztwdgLor1SeBu4Opz4IsmpcLETXAd3VmBrOjez8uQtrsOhPCa5Vhbm5gzDlMYTgFRLQzf8/YHFA=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-http": ["@opentelemetry/instrumentation-http@0.213.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/instrumentation": "0.213.0", "@opentelemetry/semantic-conventions": "^1.29.0", "forwarded-parse": "2.1.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-B978Xsm5XEPGhm1P07grDoaOFLHapJPkOG9h016cJsyWWxmiLnPu2M/4Nrm7UCkHSiLnkXgC+zVGUAIahy8EEA=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-ioredis": ["@opentelemetry/instrumentation-ioredis@0.61.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-hsHDadUtAFbws1YSDc1XW0svGFKiUbqv2td1Cby+UAiwvojm1NyBo/taifH0t8CuFZ0x/2SDm0iuTwrM5pnVOg=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-kafkajs": ["@opentelemetry/instrumentation-kafkajs@0.22.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.30.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-wJU4IBQMUikdJAcTChLFqK5lo+flo7pahqd8DSLv7uMxsdOdAHj6RzKYAm8pPfUS6ItKYutYyuicwKaFwQKsoA=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-knex": ["@opentelemetry/instrumentation-knex@0.57.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-vMCSh8kolEm5rRsc+FZeTZymWmIJwc40hjIKnXH4O0Dv/gAkJJIRXCsPX5cPbe0c0j/34+PsENd0HqKruwhVYw=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-koa": ["@opentelemetry/instrumentation-koa@0.61.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.36.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-lvrfWe9ShK/D2X4brmx8ZqqeWPfRl8xekU0FCn7C1dHm5k6+rTOOi36+4fnaHAP8lig9Ux6XQ1D4RNIpPCt1WQ=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-lru-memoizer": ["@opentelemetry/instrumentation-lru-memoizer@0.57.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-cEqpUocSKJfwDtLYTTJehRLWzkZ2eoePCxfVIgGkGkb83fMB71O+y4MvRHJPbeV2bdoWdOVrl8uO0+EynWhTEA=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-mongodb": ["@opentelemetry/instrumentation-mongodb@0.66.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-d7m9QnAY+4TCWI4q1QRkfrc6fo/92VwssaB1DzQfXNRvu51b78P+HJlWP7Qg6N6nkwdb9faMZNBCZJfftmszkw=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-mongoose": ["@opentelemetry/instrumentation-mongoose@0.59.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-6/jWU+c1NgznkVLDU/2y0bXV2nJo3o9FWZ9mZ9nN6T/JBNRoMnVXZl2FdBmgH+a5MwaWLs5kmRJTP5oUVGIkPw=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-mysql": ["@opentelemetry/instrumentation-mysql@0.59.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/mysql": "2.15.27" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-mysql2": ["@opentelemetry/instrumentation-mysql2@0.59.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@opentelemetry/sql-common": "^0.41.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-pg": ["@opentelemetry/instrumentation-pg@0.65.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.34.0", "@opentelemetry/sql-common": "^0.41.2", "@types/pg": "8.15.6", "@types/pg-pool": "2.0.7" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-W0zpHEIEuyZ8zvb3njaX9AAbHgPYOsSWVOoWmv1sjVRSF6ZpBqtlxBWbU+6hhq1TFWBeWJOXZ8nZS/PUFpLJYQ=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-redis": ["@opentelemetry/instrumentation-redis@0.61.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-JnPexA034/0UJRsvH96B0erQoNOqKJZjE2ZRSw9hiTSC23LzE0nJE/u6D+xqOhgUhRnhhcPHq4MdYtmUdYTF+Q=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-tedious": ["@opentelemetry/instrumentation-tedious@0.32.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/tedious": "^4.0.14" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-BQS6gG8RJ1foEqfEZ+wxoqlwfCAzb1ZVG0ad8Gfe4x8T658HJCLGLd4E4NaoQd8EvPfLqOXgzGaE/2U4ytDSWA=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-undici": ["@opentelemetry/instrumentation-undici@0.23.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.213.0", "@opentelemetry/semantic-conventions": "^1.24.0" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0" } }, "sha512-LL0VySzKVR2cJSFVZaTYpZl1XTpBGnfzoQPe2W7McS2267ldsaEIqtQY6VXs2KCXN0poFjze5110PIpxHDaDGg=="],
-
-    "@sentry/nextjs/@sentry/node/@prisma/instrumentation": ["@prisma/instrumentation@7.4.2", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.8" } }, "sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg=="],
-
-    "@sentry/nextjs/@sentry/node/@sentry/node-core": ["@sentry/node-core@10.46.0", "", { "dependencies": { "@sentry/core": "10.46.0", "@sentry/opentelemetry": "10.46.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/resources": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/context-async-hooks", "@opentelemetry/core", "@opentelemetry/instrumentation", "@opentelemetry/resources", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-gwLGXfkzmiCmUI1VWttyoZBaVp1ItpDKc8AV2mQblWPQGdLSD0c6uKV/FkU291yZA3rXsrLXVwcWoibwnjE2vw=="],
 
     "@sentry/nextjs/@sentry/node/import-in-the-middle": ["import-in-the-middle@3.0.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg=="],
 
@@ -6936,6 +6875,8 @@
 
     "@wagmi/connectors/@base-org/account/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
+    "@wagmi/connectors/@base-org/account/idb-keyval": ["idb-keyval@6.2.1", "", {}, "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="],
+
     "@wagmi/connectors/@base-org/account/ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
 
     "@wagmi/connectors/@base-org/account/zustand": ["zustand@5.0.3", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg=="],
@@ -6945,6 +6886,8 @@
     "@wagmi/connectors/@coinbase/wallet-sdk/clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
 
     "@wagmi/connectors/@coinbase/wallet-sdk/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "@wagmi/connectors/@coinbase/wallet-sdk/idb-keyval": ["idb-keyval@6.2.1", "", {}, "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="],
 
     "@wagmi/connectors/@coinbase/wallet-sdk/ox": ["ox@0.6.9", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug=="],
 
@@ -7110,7 +7053,11 @@
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "web/@aws-sdk/client-s3/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "web/@aws-sdk/lib-storage/buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
+
+    "web/@aws-sdk/lib-storage/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "webpack/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -7263,16 +7210,6 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/uint8arrays": ["uint8arrays@3.1.1", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.36.0", "", { "dependencies": { "@noble/curves": "1.9.6", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.9.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ=="],
-
-    "@sentry/nextjs/@sentry/node/@fastify/otel/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.212.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.212.0", "import-in-the-middle": "^2.0.6", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.213.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-http/@opentelemetry/core": ["@opentelemetry/core@2.6.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg=="],
-
-    "@sentry/nextjs/@sentry/node/@opentelemetry/instrumentation-pg/@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
-
-    "@sentry/nextjs/@sentry/node/@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
 
     "@serwist/build/source-map/whatwg-url/tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
 
@@ -7433,14 +7370,6 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox": ["ox@0.9.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.8", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-NVI0cajROntJWtFnxZQ1aXDVy+c6DLEXJ3wwON48CgbPhmMJrpRTfVbuppR+47RmXm3lZ/uMaKiFSkLdAO1now=="],
-
-    "@sentry/nextjs/@sentry/node/@fastify/otel/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.212.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg=="],
-
-    "@sentry/nextjs/@sentry/node/@fastify/otel/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
-
-    "@sentry/nextjs/@sentry/node/@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
-
-    "@sentry/nextjs/@sentry/node/@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "@vercel/postgres/@neondatabase/serverless/@types/pg/pg-types/postgres-array": ["postgres-array@3.0.4", "", {}, "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ=="],
 
@@ -7698,6 +7627,8 @@
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox": ["ox@0.6.7", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA=="],
 
+    "@wagmi/connectors/@walletconnect/ethereum-provider/@walletconnect/utils/viem/ox/@scure/bip32/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
@@ -7725,6 +7656,8 @@
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils/viem/ox/@scure/bip32/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode/yargs/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }

--- a/docs/message-cache-plan.md
+++ b/docs/message-cache-plan.md
@@ -1,0 +1,750 @@
+# Message Cache Plan — Client-Side Persistence
+
+**Date:** 2026-04-02
+**Goal:** Cache messages locally in the browser so conversations load instantly on revisit, eliminating the full-fetch-from-API pattern that currently shows a loading spinner every time a user opens or switches chats.
+
+---
+
+## Current State
+
+### How Messages Work Today
+
+```
+User opens chat → spinner → GET /api/chats/{id}?limit=50 → render messages
+User switches to another chat → clear all messages → spinner → full fetch again
+User switches back → clear again → spinner → same 50 messages re-fetched
+```
+
+**Frontend state:** `useChatMessages` hook (`apps/web/src/hooks/useChatMessages.ts`)
+- Messages stored in `useState<ChatMessage[]>([])` — React component state only
+- On chat switch: `setMessages([])` then full refetch (line 482-484)
+- `hasLoadedRef` tracks loaded chats, but is cleared on switch (line 478-479)
+- No persistent storage — messages vanish on navigation, tab close, or chat switch
+
+**Real-time updates:** SSE via `useSSEChannel` pushes `new_message` and `message_reaction` events. This works well for live conversations but doesn't help with initial load.
+
+**Polling fallback:** 15s interval re-fetches latest 50 messages (lines 496-591). This means the API serves the same 50 messages every 15 seconds even when nothing has changed.
+
+### The UX Problem
+
+1. **Every chat switch = full spinner + 50-message fetch.** Open Chat A, switch to Chat B, switch back to Chat A = three full API round-trips. Chat A's messages were in memory 2 seconds ago but got discarded.
+
+2. **Page refresh / tab close = total amnesia.** Close the tab, reopen → every conversation starts from scratch. No local persistence at all.
+
+3. **Polling re-fetches unchanged data.** The 15s polling interval fetches the same 50 messages repeatedly even when the conversation is idle. Pure waste when SSE is working.
+
+4. **Conversation list refetches on every mount.** `loadChats()` in `useChatPage` (line 107) fetches the full chat list from the API on every page load.
+
+### What React Query Already Provides
+
+React Query (`@tanstack/react-query` v5.90.8) is already installed (`apps/web/package.json:75`). The leaderboard plan (WI-L1) uses it for client caching. We should use the same pattern here, plus IndexedDB for cross-session persistence.
+
+---
+
+## Plan
+
+### Architecture
+
+```
+                    ┌─────────────────────────┐
+                    │     React Component      │
+                    │   useChatMessages hook   │
+                    └────────┬────────────────┘
+                             │ reads from
+                    ┌────────▼────────────────┐
+                    │     React Query Cache    │
+                    │  (in-memory, per-chat)   │
+                    │  staleTime: 2 min        │
+                    │  gcTime: 30 min          │
+                    └────────┬────────────────┘
+                             │ hydrates from / persists to
+                    ┌────────▼────────────────┐
+                    │      IndexedDB           │
+                    │  (idb-keyval or Dexie)   │
+                    │  per-chat message store  │
+                    │  survives tab close      │
+                    └────────┬────────────────┘
+                             │ revalidates against
+                    ┌────────▼────────────────┐
+                    │     API + SSE            │
+                    │  GET /api/chats/{id}     │
+                    │  SSE new_message events  │
+                    └─────────────────────────┘
+```
+
+**Flow on chat open:**
+1. Check React Query cache → if fresh, render instantly (no fetch)
+2. If stale or missing, check IndexedDB → render cached messages immediately (no spinner)
+3. Fetch latest from API in background → merge new messages into cache
+4. SSE pushes live messages → appended to cache in real-time
+
+**Key insight:** Messages are append-only (new messages always have newer IDs/timestamps). We never need to re-fetch old messages — we only need to fetch messages newer than our last cached message.
+
+---
+
+### WI-M1: React Query for In-Memory Chat Message Caching
+
+**Priority:** P0 — eliminates spinner on chat switch
+**Files:** `apps/web/src/hooks/useChatMessages.ts`
+
+#### Problem
+
+`useChatMessages` uses raw `useState`. Switching chats clears messages and refetches. No deduplication, no background revalidation, no caching.
+
+#### Solution
+
+Wrap the message fetch in React Query. Keep the SSE subscription and optimistic updates intact — React Query handles the fetch/cache layer, SSE handles the live append layer.
+
+**Key design decision:** The query key is `['chat-messages', chatId]`. Messages are fetched via the existing API. SSE updates are applied via `queryClient.setQueryData()` to mutate the cache directly.
+
+**Required prerequisite:** `replaceOptimisticMessage` (line 119) and `isMatchingOptimistic` (line 92) are currently **private functions** inside `useChatMessages.ts` — not exported. They must be exported (or extracted to a shared utility like `apps/web/src/hooks/chatMessageUtils.ts`) so they can be used in the `queryClient.setQueryData` callbacks. The function signatures and logic stay identical; only the export visibility changes.
+
+**Global default note:** The app-wide QueryClient (`Providers.tsx:233`) sets `staleTime: 60_000` (1 min) and `refetchOnWindowFocus: false`. The per-query `staleTime` below overrides this for messages specifically.
+
+```typescript
+// apps/web/src/hooks/useChatMessages.ts — new approach
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+const MESSAGES_STALE_TIME = 2 * 60 * 1000;  // 2 min — overrides global 1 min default
+const MESSAGES_GC_TIME = 30 * 60 * 1000;    // 30 min — keep old chats in memory
+
+interface ChatMessagesData {
+  messages: ChatMessage[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+// The query fetches initial messages from the API
+const query = useQuery<ChatMessagesData>({
+  queryKey: ['chat-messages', chatId],
+  queryFn: async ({ signal }) => {
+    const token = await getSafeAccessToken();
+    const response = await fetch(
+      `/api/chats/${chatId}?limit=${CHAT_PAGE_SIZE}`,
+      { headers: { Authorization: `Bearer ${token}` }, signal }
+    );
+    const data = await response.json();
+    const formatted = (data.messages as RawApiMessage[]).map((msg) =>
+      formatMessage(msg, chatId!)
+    );
+    return {
+      messages: formatted,
+      hasMore: data.pagination?.hasMore ?? false,
+      nextCursor: data.pagination?.nextCursor ?? null,
+    };
+  },
+  enabled: !!chatId,
+  staleTime: MESSAGES_STALE_TIME,
+  gcTime: MESSAGES_GC_TIME,
+  // Show previous chat's data while loading new chat (prevents flash)
+  placeholderData: (prev) => prev,
+});
+```
+
+**SSE updates mutate the query cache directly:**
+```typescript
+const queryClient = useQueryClient();
+
+function handleNewMessage(newMessage: ChatMessage) {
+  queryClient.setQueryData<ChatMessagesData>(
+    ['chat-messages', chatId],
+    (old) => {
+      if (!old) return old;
+      // Dedup / replace optimistic
+      const updatedMessages = replaceOptimisticMessage(old.messages, newMessage);
+      return { ...old, messages: updatedMessages };
+    }
+  );
+}
+```
+
+**Optimistic messages also mutate the cache:**
+```typescript
+function addOptimisticMessage(message: ChatMessage) {
+  queryClient.setQueryData<ChatMessagesData>(
+    ['chat-messages', chatId],
+    (old) => {
+      if (!old) return { messages: [message], hasMore: false, nextCursor: null };
+      return { ...old, messages: [...old.messages, message] };
+    }
+  );
+}
+```
+
+#### What Changes
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Chat switch | Clear + refetch + spinner | Instant from React Query cache |
+| Back to previous chat | Full refetch | Instant (gcTime: 30 min) |
+| SSE new message | `setMessages(prev => ...)` | `queryClient.setQueryData(...)` |
+| Optimistic message | `setMessages(prev => [...prev, msg])` | `queryClient.setQueryData(...)` |
+| Polling fallback | Every 15s regardless | React Query `refetchInterval` only when stale |
+| Load more (pagination) | Separate `loadMore` state | Stays as imperative fetch, prepends to cache |
+
+#### What Stays the Same
+
+- `useSSEChannel` subscription — untouched
+- Optimistic message matching logic (`replaceOptimisticMessage`) — untouched, just exported
+- Reaction delta handling — untouched, just targets queryClient.setQueryData instead
+- Message formatting (`formatMessage`) — untouched
+
+#### Dual Fetch Problem
+
+Currently, `useChatPage.loadChatDetails()` (line 171) AND `useChatMessages.loadMessages()` (line 256) BOTH call `GET /api/chats/{id}` for the same chat — a wasteful duplicate fetch. With React Query, this resolves naturally:
+
+- `useChatMessages` owns the React Query cache for `['chat-messages', chatId]`
+- `useChatPage.loadChatDetails()` should be refactored to **read messages from the React Query cache** instead of fetching them separately. It still needs to fetch `chat` metadata and `participants`, but the messages come from the shared cache.
+
+Concretely, in `useChatPage.ts` line 178-183, replace:
+```typescript
+setChatDetails({ ...data, chat: data.chat, messages: data.messages, participants: data.participants });
+```
+with:
+```typescript
+setChatDetails({ ...data, chat: data.chat, messages: [], participants: data.participants });
+// messages are managed by useChatMessages via React Query — don't duplicate
+```
+
+The sync effect at lines 552-559 that copies `realtimeMessages` into `chatDetails` already handles this — it overwrites `chatDetails.messages` with the realtime messages from `useChatMessages`. So removing the initial `data.messages` population is safe.
+
+#### Load More (Pagination)
+
+`loadMore` prepends older messages to the list. With React Query, this becomes:
+
+```typescript
+const loadMore = useCallback(async () => {
+  const currentData = queryClient.getQueryData<ChatMessagesData>(['chat-messages', chatId]);
+  if (!chatId || !currentData?.nextCursor || isLoadingMore) return;
+
+  setIsLoadingMore(true);
+  const token = await getSafeAccessToken();
+  const response = await fetch(
+    `/api/chats/${chatId}?cursor=${currentData.nextCursor}&limit=${CHAT_PAGE_SIZE}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  const data = await response.json();
+  const formatted = (data.messages as RawApiMessage[]).map((msg) => formatMessage(msg, chatId));
+
+  queryClient.setQueryData<ChatMessagesData>(['chat-messages', chatId], (old) => {
+    if (!old) return old;
+    return {
+      messages: [...formatted, ...old.messages], // prepend older messages
+      hasMore: data.pagination?.hasMore ?? false,
+      nextCursor: data.pagination?.nextCursor ?? null,
+    };
+  });
+  setIsLoadingMore(false);
+}, [chatId, isLoadingMore, getSafeAccessToken, queryClient]);
+```
+
+This atomically updates messages + pagination state in a single `setQueryData` call. `isLoadingMore` remains a local `useState` since it's a transient UI concern, not cached data.
+
+#### Polling Simplification
+
+The 15s polling interval (lines 496-591) can be replaced with React Query's `refetchInterval`:
+
+```typescript
+refetchInterval: isConnected ? false : 15_000, // Only poll when SSE is disconnected
+```
+
+When SSE is connected, live updates come through the channel. When SSE drops, React Query polls. This eliminates the manual `setInterval` + cleanup logic.
+
+---
+
+### WI-M2: IndexedDB Persistence for Cross-Session Cache
+
+**Priority:** P1 — eliminates spinner on page refresh / return visit
+**Files:** New file `apps/web/src/lib/chat/message-store.ts`, modify `useChatMessages.ts`
+
+#### Problem
+
+React Query's in-memory cache doesn't survive page refresh or tab close. Users who close and reopen the app still see spinners for every conversation.
+
+#### Solution
+
+Use IndexedDB to persist the latest messages per chat. On chat open, hydrate React Query from IndexedDB (instant render), then revalidate from API in background.
+
+**Library:** `idb-keyval` — 600 bytes gzipped, zero dependencies, simple get/set/del API over IndexedDB.
+
+**Verified: NOT currently installed.** Must be added:
+```bash
+cd apps/web && bun add idb-keyval
+```
+
+```typescript
+// apps/web/src/lib/chat/message-store.ts
+
+import { get, set, del } from 'idb-keyval';
+
+const MAX_CACHED_MESSAGES_PER_CHAT = 100; // Keep last 100 messages per chat
+const MAX_CACHED_CHATS = 50;              // Limit total stored chats
+
+interface CachedChatMessages {
+  chatId: string;
+  messages: ChatMessage[];
+  hasMore: boolean;
+  nextCursor: string | null;
+  cachedAt: number; // timestamp for LRU eviction
+}
+
+const STORE_KEY_PREFIX = 'chat-msgs:';
+const INDEX_KEY = 'chat-msgs-index'; // tracks which chats are cached
+
+export async function getCachedMessages(
+  chatId: string
+): Promise<CachedChatMessages | null> {
+  const cached = await get<CachedChatMessages>(`${STORE_KEY_PREFIX}${chatId}`);
+  return cached ?? null;
+}
+
+export async function setCachedMessages(
+  chatId: string,
+  data: CachedChatMessages
+): Promise<void> {
+  // Trim to max messages
+  const trimmed = {
+    ...data,
+    messages: data.messages.slice(-MAX_CACHED_MESSAGES_PER_CHAT),
+    cachedAt: Date.now(),
+  };
+  await set(`${STORE_KEY_PREFIX}${chatId}`, trimmed);
+
+  // Update index and evict old chats if over limit
+  const index = (await get<string[]>(INDEX_KEY)) ?? [];
+  const updated = [chatId, ...index.filter((id) => id !== chatId)];
+  if (updated.length > MAX_CACHED_CHATS) {
+    const evicted = updated.splice(MAX_CACHED_CHATS);
+    await Promise.all(evicted.map((id) => del(`${STORE_KEY_PREFIX}${id}`)));
+  }
+  await set(INDEX_KEY, updated);
+}
+
+export async function appendCachedMessages(
+  chatId: string,
+  newMessages: ChatMessage[]
+): Promise<void> {
+  const existing = await getCachedMessages(chatId);
+  if (!existing) return;
+
+  const existingIds = new Set(existing.messages.map((m) => m.id));
+  const deduped = newMessages.filter((m) => !existingIds.has(m.id));
+  if (deduped.length === 0) return;
+
+  await setCachedMessages(chatId, {
+    ...existing,
+    messages: [...existing.messages, ...deduped],
+  });
+}
+```
+
+#### Integration with React Query
+
+**Timing constraint:** React Query's `initialData` is read synchronously on first render. IndexedDB is async. Using `useState` + `useEffect` to set `initialData` would cause: render 1 (no data, spinner) → render 2 (IndexedDB data) → render 3 (API data). This defeats the "instant render" goal.
+
+**Solution:** Seed the React Query cache from IndexedDB BEFORE the component mounts, using a top-level prefetch. This happens once on app init, not per-chat.
+
+```typescript
+// apps/web/src/lib/chat/hydrateChatCache.ts
+// Called once during app startup (e.g., in Providers.tsx or a layout effect)
+
+import { QueryClient } from '@tanstack/react-query';
+import { getCachedMessages } from './message-store';
+import { get } from 'idb-keyval';
+
+const INDEX_KEY = 'chat-msgs-index';
+
+export async function hydrateChatCacheFromIndexedDB(queryClient: QueryClient) {
+  const index = await get<string[]>(INDEX_KEY);
+  if (!index || index.length === 0) return;
+
+  // Hydrate the 10 most recent chats (don't block startup with all 50)
+  const recentChatIds = index.slice(0, 10);
+  await Promise.all(
+    recentChatIds.map(async (chatId) => {
+      const cached = await getCachedMessages(chatId);
+      if (!cached) return;
+      queryClient.setQueryData(['chat-messages', chatId], {
+        messages: cached.messages,
+        hasMore: cached.hasMore,
+        nextCursor: cached.nextCursor,
+      });
+      // Mark as stale so React Query revalidates in background
+      queryClient.invalidateQueries({
+        queryKey: ['chat-messages', chatId],
+        refetchType: 'none', // don't trigger refetch, just mark stale
+      });
+    })
+  );
+}
+```
+
+Call during app init:
+```typescript
+// In Providers.tsx, after QueryClient creation:
+const [queryClient] = useState(() => {
+  const client = new QueryClient({ /* ... */ });
+  // Fire-and-forget — doesn't block render
+  void hydrateChatCacheFromIndexedDB(client);
+  return client;
+});
+```
+
+Now when `useChatMessages` renders for a previously-visited chat, React Query already has data in its cache (from IndexedDB hydration). The component renders instantly with cached messages, then revalidates in background.
+
+**Persist to IndexedDB on data changes:**
+
+```typescript
+// In useChatMessages, after the useQuery:
+useEffect(() => {
+  if (chatId && query.data && query.data.messages.length > 0) {
+    // Fire-and-forget — don't block renders
+    void setCachedMessages(chatId, {
+      chatId,
+      ...query.data,
+      cachedAt: Date.now(),
+    });
+  }
+}, [chatId, query.data]);
+```
+
+#### UX Flow
+
+```
+1. User opens Chat A:
+   → IndexedDB has 80 cached messages from last session
+   → Render immediately (no spinner)
+   → React Query fetches latest 50 from API in background
+   → Merge: keep cached history + append any new messages
+   → User sees seamless conversation with no loading state
+
+2. User closes tab, reopens next day:
+   → Same flow — IndexedDB still has the messages
+   → API fetch brings in messages since last visit
+   → Old messages are already rendered, new ones appear at bottom
+```
+
+#### Eviction
+
+- **Per-chat limit:** 100 most recent messages per chat (older ones available via pagination from API)
+- **Total chats limit:** 50 most recently accessed chats (LRU eviction via index key)
+- **No expiry:** Messages don't expire — they're always valid historical data. Freshness is handled by the API revalidation layer, not by discarding old data.
+
+**Multi-tab note:** The LRU index is a single `idb-keyval` key (`chat-msgs-index`). If two tabs write simultaneously, last-write-wins may lose an entry from the index. This is acceptable — the per-chat data keys still exist in IndexedDB and would be found on next direct access. The index is only used for startup hydration (WI-M2) and eviction. Worst case: a chat gets evicted slightly early or a stale entry lingers. Not worth the complexity of IndexedDB transactions for this edge case.
+
+---
+
+### WI-M3: Incremental Sync Instead of Full Refetch
+
+**Priority:** P1 — eliminates redundant data transfer
+**Files:** `apps/web/src/hooks/useChatMessages.ts`, `apps/web/src/app/api/chats/[id]/route.ts`
+
+#### Problem
+
+Every refetch (polling, stale revalidation, chat reopen) fetches the latest 50 messages from scratch. If the conversation has 200 messages cached locally and 3 new messages arrived, we still fetch 50 and diff client-side. The polling fallback (every 15s) is especially wasteful.
+
+#### Solution: `after` Parameter (New API Code Path)
+
+Add an `after` query parameter to `GET /api/chats/{id}` that returns only messages created after the given ISO timestamp. This is a **separate code path** from the existing cursor pagination — `cursor` fetches older messages (DESC, `lt`), while `after` fetches newer messages (ASC, `gt`).
+
+**Validated:** The current cursor pagination works by looking up a message ID, getting its `createdAt`, then filtering `lt(messages.createdAt, cursorMessage.createdAt)` with `DESC` ordering (lines 192-227 of `route.ts`). The `after` parameter is the inverse — it filters `gt(messages.createdAt, sinceDate)` with `ASC` ordering and does NOT use the `limit+1` pagination trick (since we want ALL new messages, not a paginated window).
+
+**API change** (`apps/web/src/app/api/chats/[id]/route.ts`):
+
+```typescript
+// New query parameter alongside existing cursor/limit (around line 105)
+const after = searchParams.get('after'); // ISO timestamp
+
+// New code path — MUTUALLY EXCLUSIVE with cursor pagination
+if (after) {
+  const afterDate = new Date(after);
+  // Validate the date
+  if (isNaN(afterDate.getTime())) {
+    return NextResponse.json({ error: 'Invalid after timestamp' }, { status: 400 });
+  }
+
+  // Fetch messages AFTER the given timestamp, ordered ASC (oldest first)
+  // Cap at limit to prevent unbounded result sets
+  messagesList = await db
+    .select()
+    .from(messages)
+    .where(
+      and(
+        eq(messages.chatId, chatId),
+        gt(messages.createdAt, afterDate)
+      )
+    )
+    .orderBy(asc(messages.createdAt))
+    .limit(effectiveLimit);
+
+  // No pagination trick needed — we want all new messages up to limit
+  hasMore = false; // caller should re-fetch if they got exactly `limit` results
+  nextCursor = null;
+
+  // Response includes a flag so the client knows this is a sync response
+  // and should APPEND rather than REPLACE
+} else if (cursor) {
+  // ... existing cursor pagination code unchanged ...
+}
+```
+
+The response shape stays identical — `{ chat, messages, participants, pagination }`. The client differentiates sync responses by checking whether it passed `after` in the request, not by a response flag. This is simpler and doesn't require API schema changes.
+
+**Frontend change — separate sync function, NOT inside queryFn:**
+
+The React Query `queryFn` always does a full fetch (for initial load and stale revalidation). A separate `syncNewMessages` function handles incremental sync. This avoids the complexity of a queryFn that behaves differently depending on cache state.
+
+```typescript
+// Called by refetchInterval callback or SSE reconnect
+async function syncNewMessages(chatId: string) {
+  const currentData = queryClient.getQueryData<ChatMessagesData>(['chat-messages', chatId]);
+  const lastMessage = currentData?.messages?.at(-1);
+  if (!lastMessage) return; // no cache = do a full refetch instead
+
+  const token = await getSafeAccessToken();
+  const response = await fetch(
+    `/api/chats/${chatId}?after=${encodeURIComponent(lastMessage.createdAt)}&limit=${CHAT_PAGE_SIZE}`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!response.ok) return;
+
+  const data = await response.json();
+  const newMessages = (data.messages as RawApiMessage[]).map((msg) =>
+    formatMessage(msg, chatId)
+  );
+
+  if (newMessages.length === 0) return; // nothing new
+
+  queryClient.setQueryData<ChatMessagesData>(['chat-messages', chatId], (old) => {
+    if (!old) return old;
+    // Dedup: skip any messages already in cache
+    const existingIds = new Set(old.messages.map((m) => m.id));
+    const deduped = newMessages.filter((m) => !existingIds.has(m.id));
+    if (deduped.length === 0) return old;
+    return { ...old, messages: [...old.messages, ...deduped] };
+  });
+}
+```
+
+Replace the 15s polling `setInterval` with a call to `syncNewMessages`:
+```typescript
+// Only when SSE is disconnected
+useEffect(() => {
+  if (isConnected || !chatId) return;
+  const interval = setInterval(() => syncNewMessages(chatId), 15_000);
+  return () => clearInterval(interval);
+}, [isConnected, chatId]);
+```
+
+**Impact:**
+- Polling: Instead of 50 messages every 15s, fetches 0-2 new messages (typically empty when SSE is working)
+- Revalidation: Background refresh after staleTime sends only delta
+- Bandwidth: ~95% reduction in data transferred for idle conversations
+
+---
+
+### WI-M4: Cache Conversation List
+
+**Priority:** P2 — instant inbox load
+**Files:** `apps/web/src/components/chats/hooks/useChatPage.ts`
+
+#### Problem
+
+`loadChats()` in `useChatPage` (line 107) fetches the full chat list from `/api/chats` on every mount. This shows a spinner every time the user navigates to the chat page.
+
+#### Solution
+
+Wrap `loadChats` in React Query with client-side caching.
+
+```typescript
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+const chatListQuery = useQuery({
+  queryKey: ['chat-list'],
+  queryFn: async () => {
+    const token = await getAccessToken();
+    const response = await fetch('/api/chats', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await response.json();
+    return [
+      ...(data.groupChats || []),
+      ...(data.directChats || []),
+    ].sort((a, b) => {
+      const aTime = a.lastMessage?.createdAt || a.updatedAt;
+      const bTime = b.lastMessage?.createdAt || b.updatedAt;
+      return new Date(bTime).getTime() - new Date(aTime).getTime();
+    });
+  },
+  staleTime: 30_000,  // 30s — chat list changes when new messages arrive
+  gcTime: 10 * 60_000, // 10 min
+  refetchOnWindowFocus: true,
+});
+```
+
+**SSE-driven chat list updates (limited scope):**
+
+**Constraint:** The current SSE architecture subscribes to individual chat channels (`chat:${chatId}`), not a global "all my chats" channel. The user only receives SSE events for the chat they're currently viewing. This means SSE cannot update the chat list for messages arriving in OTHER chats.
+
+**What we CAN do:** When a `new_message` SSE event arrives for the currently-viewed chat, update the chat list optimistically:
+
+```typescript
+// In the SSE handler for the current chat:
+queryClient.setQueryData<Chat[]>(['chat-list'], (old) => {
+  if (!old) return old;
+  return old
+    .map((chat) =>
+      chat.id === incomingMessage.chatId
+        ? { ...chat, lastMessage: { content: incomingMessage.content, createdAt: incomingMessage.createdAt, senderId: incomingMessage.senderId } }
+        : chat
+    )
+    .sort((a, b) => {
+      const aTime = a.lastMessage?.createdAt || a.updatedAt;
+      const bTime = b.lastMessage?.createdAt || b.updatedAt;
+      return new Date(bTime).getTime() - new Date(aTime).getTime();
+    });
+});
+```
+
+For messages in OTHER chats (not currently viewed), the chat list refreshes via React Query's staleTime (30s) or `refetchOnWindowFocus`. This is acceptable — the chat list is a low-frequency concern.
+
+**Future improvement (out of scope):** Subscribe to a global `user:${userId}` SSE channel that broadcasts notification-level events (new message in any chat, unread count changes). This would enable real-time chat list reordering for all chats, not just the active one.
+
+---
+
+### WI-M5: Smart Polling — Only When SSE Is Down
+
+**Priority:** P2 — reduces unnecessary API calls
+**Files:** `apps/web/src/hooks/useChatMessages.ts`
+
+#### Problem
+
+The current 15s polling interval (lines 496-591) runs unconditionally, even when SSE is delivering messages in real-time. This is pure redundancy when SSE is healthy.
+
+#### Solution
+
+Already addressed in WI-M1's React Query integration:
+
+```typescript
+refetchInterval: isConnected ? false : 15_000,
+```
+
+When SSE is connected (`isConnected` from `useSSEChannel`), disable polling entirely. When SSE drops, React Query's `refetchInterval` kicks in as fallback.
+
+**Additional refinement:** When SSE reconnects after a gap, do a single `since`-based sync (WI-M3) to catch any messages missed during the disconnect:
+
+```typescript
+// In useSSEChannel reconnect handler:
+useEffect(() => {
+  if (isConnected && chatId) {
+    // SSE just reconnected — sync any missed messages
+    queryClient.invalidateQueries({ queryKey: ['chat-messages', chatId] });
+  }
+}, [isConnected, chatId]);
+```
+
+---
+
+## Implementation Order
+
+```
+Phase 1 (Core — eliminates chat-switch spinners):
+  WI-M1: React Query for in-memory message caching
+    ↓
+Phase 2 (Persistence + Efficiency):
+  WI-M2: IndexedDB for cross-session persistence  ← parallel
+  WI-M3: Incremental sync (since parameter)       ← parallel
+    ↓
+Phase 3 (Polish):
+  WI-M4: Cache conversation list
+  WI-M5: Smart polling (SSE-aware)
+```
+
+---
+
+## Expected UX Impact
+
+| Interaction | Before | After |
+|-------------|--------|-------|
+| Open Chat A | Spinner (200-500ms) | Spinner (first time only) |
+| Switch to Chat B then back to A | Spinner → Spinner | Spinner → **Instant** |
+| Close tab, reopen, open Chat A | Spinner (full refetch) | **Instant** (IndexedDB) + silent background sync |
+| Idle conversation (15s poll) | Fetch 50 messages every 15s | **No fetch** (SSE handles live updates) |
+| SSE reconnect after drop | Wait for next 15s poll | **Immediate sync** of missed messages |
+| Open chat page (inbox) | Spinner (full list fetch) | **Instant** (React Query cache) |
+| New message in another chat | Not visible until next poll | **Real-time** chat list reorder |
+
+---
+
+## Key Design Decisions
+
+### Why React Query + IndexedDB (not just React Query)?
+
+React Query's in-memory cache doesn't survive page refresh. For messaging, users expect conversations to be "there" when they return — like any native chat app. IndexedDB gives us cross-session persistence with zero UX cost.
+
+### Why not persist the full React Query cache to IndexedDB?
+
+React Query has an official `persistQueryClient` adapter, but it serializes the entire query cache — all queries, all data. For messaging, we only want to persist message data, not leaderboard data or other cached API responses. A targeted IndexedDB store per chat gives us precise control over eviction and storage limits.
+
+### Why `since` parameter instead of just diffing client-side?
+
+We could fetch 50 messages and diff client-side (the current polling approach). But this transfers ~15KB per poll for idle conversations. The `since` parameter returns 0 bytes for idle conversations and only the new messages for active ones. At 15s intervals across thousands of users, this is a meaningful bandwidth and DB load reduction.
+
+### Why keep SSE + polling?
+
+SSE is the primary real-time channel. Polling exists only as a fallback for when SSE drops (Vercel serverless can kill long-running connections). With WI-M5, polling is disabled when SSE is healthy — it's a safety net, not the primary mechanism.
+
+---
+
+## Files Modified Per Work Item
+
+| WI | New Files | Modified Files |
+|----|-----------|---------------|
+| **WI-M1** | (none) | `apps/web/src/hooks/useChatMessages.ts` (major rewrite: useState→useQuery, export `replaceOptimisticMessage`+`isMatchingOptimistic`), `apps/web/src/components/chats/hooks/useChatPage.ts` (remove duplicate message fetch from `loadChatDetails`) |
+| **WI-M2** | `apps/web/src/lib/chat/message-store.ts`, `apps/web/src/lib/chat/hydrateChatCache.ts` | `apps/web/src/hooks/useChatMessages.ts` (add persist effect), `apps/web/src/components/providers/Providers.tsx` (add hydration call), `apps/web/package.json` (add `idb-keyval`) |
+| **WI-M3** | (none) | `apps/web/src/app/api/chats/[id]/route.ts` (add `after` query param — new code path with `gt`+`asc`), `apps/web/src/hooks/useChatMessages.ts` (add `syncNewMessages` function) |
+| **WI-M4** | (none) | `apps/web/src/components/chats/hooks/useChatPage.ts` (wrap `loadChats` in useQuery) |
+| **WI-M5** | (none) | `apps/web/src/hooks/useChatMessages.ts` (SSE-aware polling toggle — mostly handled by WI-M1 already) |
+
+---
+
+## Validation Checklist
+
+```bash
+# Quality gate
+bun run check && bun run typecheck && bun run lint
+
+# Tests
+bun run test:unit
+
+# Build
+bun run build
+
+# Manual validation
+# 1. Open Chat A → spinner on first load → messages appear
+# 2. Switch to Chat B → spinner (first visit)
+# 3. Switch back to Chat A → INSTANT (React Query cache, no spinner)
+# 4. Send a message in Chat A → appears immediately (optimistic)
+# 5. Receive a message via SSE → appears in real-time
+# 6. Close the browser tab completely
+# 7. Reopen, navigate to Chat A → INSTANT (IndexedDB) + background sync
+# 8. Check Network tab: background revalidation uses ?since= parameter
+# 9. Disconnect SSE (throttle network) → polling starts at 15s
+# 10. Reconnect SSE → immediate sync of missed messages, polling stops
+# 11. Open chat page (inbox) → INSTANT on second visit (cached list)
+# 12. Receive message in Chat B while viewing Chat A → Chat B moves to top of list
+```
+
+---
+
+## Storage Estimates
+
+| Data | Size per item | Items | Total |
+|------|--------------|-------|-------|
+| Message (avg) | ~300 bytes | 100 per chat | 30 KB per chat |
+| Cached chats | 30 KB per chat | 50 chats max | **1.5 MB total** |
+| Chat list | ~500 bytes per chat | 100 chats | **50 KB** |
+| **Total IndexedDB** | | | **~1.6 MB** |
+
+Well within IndexedDB limits (typically 50MB+ per origin). No risk of hitting storage quotas.


### PR DESCRIPTION
## Summary

Eliminates loading spinners when switching between chats or returning to previously-viewed conversations. Messages are cached client-side in React Query (in-memory) and IndexedDB (cross-session), with incremental sync via a new `?after=` API parameter.

- **WI-M1: React Query cache for messages** — `useChatMessages` now stores messages in `queryClient` instead of `useState`. Switching Chat A → B → A renders A instantly from cache (30min gcTime). SSE and optimistic updates write directly to the query cache. Polling only activates when SSE is disconnected.

- **WI-M2: IndexedDB persistence** — Last 100 messages per chat (50 chats max, ~1.5MB) survive page refresh and browser restart via `idb-keyval`. On app startup, the 10 most recently accessed chats are hydrated into React Query before components mount, so opening any cached chat renders instantly with no spinner.

- **WI-M3: Incremental sync (`?after=` param)** — New API code path: `GET /api/chats/{id}?after={ISO timestamp}` returns only messages created after the given time (ASC order, `gt()` instead of cursor's `lt()`). Polling fallback fetches 0 messages for idle conversations instead of 50. On SSE reconnect, a single sync call catches missed messages.

- **WI-M4: Chat list caching** — `loadChats()` in `useChatPage` wrapped in `queryClient.fetchQuery` with 30s staleTime. Navigating to the chat page after initial load is instant.

- **WI-M5: Smart polling** — Handled by WI-M1 + WI-M3: polling disabled when SSE is connected, uses incremental sync when active.

## Test plan

- [x] `bun run typecheck` — All workspace typechecks pass
- [x] `bun run check` — Biome clean
- [x] `bun run lint` — Zero warnings
- [x] `bun run test:unit` — 397/397 pass
- [ ] Open Chat A → loads with spinner (first visit)
- [ ] Switch to Chat B → loads with spinner (first visit)
- [ ] Switch back to Chat A → **instant** (React Query cache, no spinner)
- [ ] Close browser tab, reopen, open Chat A → **instant** (IndexedDB hydration)
- [ ] Send message → appears immediately (optimistic update in query cache)
- [ ] Receive SSE message → appears in real-time (setQueryData)
- [ ] Check Network tab: polling uses `?after=` param (not full 50-message fetch)
- [ ] Navigate away from chat page and back → chat list loads instantly