### PR TITLE
feat: NPC personality autonomy — domain-filtered context and intent-based posting

### DIFF
--- a/packages/engine/src/FeedGenerator.ts
+++ b/packages/engine/src/FeedGenerator.ts
@@ -20,6 +20,7 @@ import type { BabylonLLMClient } from './llm/openai-client';
 import {
   ambientPosts,
   analystReaction,
+  buildFilteredWorldContext,
   CHARACTER_LIMITS,
   commentary,
   companyPost,
@@ -31,12 +32,14 @@ import {
   governmentPost,
   minuteAmbient,
   newsPosts,
+  organicPost,
   priceAnnouncement,
   questionResolvedFeed,
   reactions,
   renderPrompt,
   replies,
   reply,
+  socialPost,
   stockTicker,
   validateFeedPost,
   type WorldContext,
@@ -45,6 +48,14 @@ import { RelationshipEvolutionEngine } from './RelationshipEvolutionEngine';
 import { actorContextBuilder } from './services/actor-context-builder';
 import { characterMappingService } from './services/character-mapping-service';
 import { getAvoidedPatternsContext } from './services/npc-anti-repetition-service';
+import { getCharacterConfigOrDefault } from './services/npc-character-config';
+import {
+  getDomainContext,
+  getDomainHints,
+  type PostIntent,
+  selectPostIntent,
+} from './services/post-intent-service';
+import { StaticDataRegistry } from './services/static-data-registry';
 import type { TrendingTopicsEngine } from './TrendingTopicsEngine';
 import type {
   Actor,
@@ -1395,7 +1406,7 @@ ${voiceContext}
       relatedNarratives,
       similarPreviousEvents,
       ...this.buildActorPromptVars(actor),
-      ...(this.worldContext || {}),
+      ...buildFilteredWorldContext(actor, this.worldContext),
     });
 
     const params = getPromptParams(reactions);
@@ -1571,7 +1582,7 @@ ${voiceContext}
       involvedActors: involvedActorNames,
       relatedNarrative,
       ...this.buildActorPromptVars(commentator),
-      ...(this.worldContext || {}),
+      ...buildFilteredWorldContext(commentator, this.worldContext),
     });
 
     const params = getPromptParams(commentary);
@@ -1729,7 +1740,7 @@ ${voiceContext}
       characterName: conspiracist.name,
       characterInfo: fullCharacterContext,
       ...this.buildActorPromptVars(conspiracist),
-      ...(this.worldContext || {}),
+      ...buildFilteredWorldContext(conspiracist, this.worldContext),
     });
 
     const params = getPromptParams(conspiracy);
@@ -2432,15 +2443,18 @@ ${voiceContext}
 
       if (actorsThisHour.length === 0) continue;
 
-      // ✅ PER-CHARACTER: Generate ambient posts individually with full context
+      // ✅ PER-CHARACTER: Generate posts individually with intent-based routing
+      // Each actor gets a post intent (organic/topical/market/social) based on their domain
+      const trendingTopic = this.trendContext || undefined;
       const ambientTasks = shuffleArray(actorsThisHour).map(
         (actor) => async () => {
-          const result = await this.generateAmbientPostForCharacter(
+          const intent = selectPostIntent(
             actor,
-            day,
-            outcome
+            trendingTopic,
+            this.relationships as ActorRelationship[],
+            allActors
           );
-          return result;
+          return this.generatePostByIntent(actor, day, outcome, intent);
         }
       );
 
@@ -2482,6 +2496,106 @@ ${voiceContext}
   }
 
   /**
+   * Select actors most likely to reply to a post, weighted by:
+   * 1. Relationship strength (rivals 5x, allies 3x, known actors 2x)
+   * 2. Domain overlap (shared domains 2x, disjoint domains 0.3x)
+   * 3. Random baseline (ensures variety)
+   */
+  private selectWeightedRepliers(
+    post: FeedPost,
+    allActors: Actor[],
+    count: number
+  ): Actor[] {
+    const postAuthorId = post.author;
+    const candidates = allActors.filter((a) => a.id !== postAuthorId);
+    if (candidates.length === 0) return [];
+
+    // Get the post author's domains for overlap calculation
+    const authorActor = candidates.find((a) => a.id === postAuthorId);
+    const authorDomains = new Set(
+      (
+        authorActor?.domain ??
+        StaticDataRegistry.getActor(postAuthorId)?.domain ??
+        []
+      ).map((d) => d.toLowerCase())
+    );
+
+    // Score each candidate
+    const scored = candidates.map((actor) => {
+      let weight = 1; // baseline
+
+      // Relationship weight
+      const actorRelationships = (
+        this.relationships as ActorRelationship[]
+      ).filter(
+        (r) =>
+          (r.actor1Id === actor.id && r.actor2Id === postAuthorId) ||
+          (r.actor2Id === actor.id && r.actor1Id === postAuthorId)
+      );
+
+      if (actorRelationships.length > 0) {
+        const rel = actorRelationships[0];
+        if (rel) {
+          const absSentiment = Math.abs(rel.sentiment);
+          // Strong feelings (positive or negative) = more likely to reply
+          weight *= 1 + absSentiment * 3;
+        }
+      }
+
+      // Check rivalry/alliance from character config
+      const config = getCharacterConfigOrDefault(actor.id);
+      if (config.rivals.includes(postAuthorId)) {
+        weight *= 5; // Rivals are very likely to reply
+      }
+      if (actor.persona?.favorsActors?.includes(postAuthorId)) {
+        weight *= 3; // Allies likely to reply
+      }
+      if (actor.persona?.opposesActors?.includes(postAuthorId)) {
+        weight *= 4; // Opponents likely to reply
+      }
+
+      // Domain overlap weight
+      if (actor.domain && actor.domain.length > 0 && authorDomains.size > 0) {
+        const actorDomains = actor.domain.map((d) => d.toLowerCase());
+        const hasOverlap = actorDomains.some((d) => authorDomains.has(d));
+        if (hasOverlap) {
+          weight *= 2; // Same domain = more likely to engage
+        } else {
+          weight *= 0.3; // Different domain = less likely (but not zero)
+        }
+      }
+
+      return { actor, weight };
+    });
+
+    // Weighted random selection without replacement
+    const selected: Actor[] = [];
+    const remaining = [...scored];
+
+    for (let i = 0; i < count && remaining.length > 0; i++) {
+      const totalWeight = remaining.reduce((sum, s) => sum + s.weight, 0);
+      let roll = Math.random() * totalWeight;
+      let selectedIndex = 0;
+      for (let j = 0; j < remaining.length; j++) {
+        const item = remaining[j];
+        if (!item) continue;
+        roll -= item.weight;
+        if (roll <= 0) {
+          selectedIndex = j;
+          break;
+        }
+      }
+      const picked = remaining[selectedIndex];
+      if (picked) {
+        selected.push(picked.actor);
+        remaining.splice(selectedIndex, 1);
+      }
+    }
+
+    return selected;
+  }
+
+  /**
    * Generate replies to existing posts
    * 30-50% of posts get replies from other actors
    */
@@ -2499,11 +2613,13 @@ ${voiceContext}
     );
 
     for (const originalPost of postsToReplyTo) {
-      // Select 1-3 actors to reply
+      // Select 1-3 actors to reply, weighted by relationship and domain overlap
       const replyCount = 1 + Math.floor(Math.random() * 3);
-      const replyingActors = shuffleArray(
-        allActors.filter((a) => a.id !== originalPost.author)
-      ).slice(0, replyCount);
+      const replyingActors = this.selectWeightedRepliers(
+        originalPost,
+        allActors,
+        replyCount
+      );
 
       // ✅ PER-CHARACTER: Generate replies individually with full context
       const replyTasks = shuffleArray(replyingActors).map(
@@ -2652,7 +2768,7 @@ ${voiceContext}
       originalAuthor: originalPost.authorName,
       relationshipContext,
       ...this.buildActorPromptVars(actor),
-      ...(this.worldContext || {}),
+      ...buildFilteredWorldContext(actor, this.worldContext),
     });
 
     if (!this.llm) {
@@ -2775,7 +2891,7 @@ ${voiceContext}
       characterName: actor.name,
       characterInfo: fullCharacterContext,
       ...actorVars,
-      ...(this.worldContext || {}),
+      ...buildFilteredWorldContext(actor, this.worldContext),
     });
 
     const params = getPromptParams(ambientPosts);
@@ -2880,6 +2996,336 @@ ${voiceContext}
         sentiment: postData.sentiment ?? 0,
         clueStrength: postData.clueStrength ?? 0.05,
         pointsToward: postData.pointsToward ?? null,
+        actorId: actor.id,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Route post generation to the appropriate method based on intent.
+   * This is the main dispatch for the post intent system.
+   */
+  private async generatePostByIntent(
+    actor: Actor,
+    day: number,
+    outcome: boolean,
+    intent: PostIntent
+  ): Promise<{
+    post: string;
+    sentiment: number;
+    clueStrength: number;
+    pointsToward: boolean | null;
+    actorId: string;
+  } | null> {
+    switch (intent.type) {
+      case 'organic':
+        return this.generateOrganicPostForCharacter(actor, day);
+      case 'social':
+        return this.generateSocialPostForCharacter(
+          actor,
+          intent.targetActorId,
+          intent.targetName,
+          day
+        );
+      case 'market':
+        // Market intent uses the existing ambient post with full market context
+        return this.generateAmbientPostForCharacter(actor, day, outcome);
+      case 'topical':
+        // Topical intent also uses existing ambient post (which now gets filtered context)
+        return this.generateAmbientPostForCharacter(actor, day, outcome);
+    }
+  }
+
+  /**
+   * Generate an organic, personality-driven post with NO market context.
+   * The NPC posts about their actual interests: climate, health, sports, art, etc.
+   */
+  private async generateOrganicPostForCharacter(
+    actor: Actor,
+    _day: number
+  ): Promise<{
+    post: string;
+    sentiment: number;
+    clueStrength: number;
+    pointsToward: boolean | null;
+    actorId: string;
+  } | null> {
+    if (!this.llm) return null;
+
+    // Build unified actor context
+    const actorContext = await actorContextBuilder.buildContext(actor.id);
+    const fullCharacterContext = actorContext
+      ? actorContextBuilder.formatForPrompt(actorContext)
+      : `PERSONALITY: ${actor.personality || 'unknown'}\nDOMAINS: ${actor.domain?.join(', ') || 'general'}`;
+
+    const hour = Math.floor(Math.random() * 24);
+    const actorVars = this.buildActorPromptVars(actor);
+    const domainHints = getDomainHints(actor);
+    const domainContext = getDomainContext(actor);
+
+    // Build running bit context if available
+    const groupContext = this.actorGroupContexts?.get(actor.id) || '';
+    const runningBitContext = groupContext
+      ? `RUNNING BIT CONTEXT:\n${groupContext}`
+      : '';
+
+    const prompt = renderPrompt(organicPost, {
+      characterName: actor.name,
+      characterInfo: fullCharacterContext,
+      ...actorVars,
+      runningBitContext,
+      timeEnergy: getTimeOfDayEnergy(hour),
+      domainHints,
+      domainContext,
+      // Only worldActors and reality grounding — NO market data
+      worldActors: this.worldContext?.worldActors || '',
+      realityGrounding: this.worldContext?.realityGrounding || '',
+    });
+
+    const params = getPromptParams(organicPost);
+    const maxRetries = 3;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const response = await this.llm.generateJSON<
+        | { post: { content: string; sentiment: number } }
+        | { response: { post: { content: string; sentiment: number } } }
+      >(
+        prompt,
+        {
+          properties: {
+            post: {
+              type: 'object',
+              properties: {
+                content: { type: 'string' },
+                sentiment: { type: 'number' },
+              },
+            },
+          },
+          required: ['post'],
+        },
+        { ...params, promptType: 'feed_generate_organic_post' }
+      );
+
+      if (!response) {
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return null;
+      }
+
+      const postData =
+        'response' in response && response.response
+          ? (
+              response.response as {
+                post: { content: string; sentiment: number };
+              }
+            ).post
+          : (response as { post: { content: string; sentiment: number } }).post;
+
+      if (
+        !postData?.content ||
+        typeof postData.content !== 'string' ||
+        postData.content.trim().length === 0
+      ) {
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return null;
+      }
+
+      const processedPost = await this.postProcessContent(
+        postData.content.trim()
+      );
+      const validation = this.validatePostContent(processedPost, 'AMBIENT');
+
+      if (!validation.isValid) {
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return null;
+      }
+
+      return {
+        post: validation.cleanContent,
+        sentiment: postData.sentiment ?? 0,
+        clueStrength: 0, // Organic posts carry no narrative clues
+        pointsToward: null,
+        actorId: actor.id,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Generate a relationship-driven post about or directed at another NPC.
+   * Uses rivalry/alliance dynamics to create natural social interactions.
+   */
+  private async generateSocialPostForCharacter(
+    actor: Actor,
+    targetActorId: string,
+    targetName: string,
+    _day: number
+  ): Promise<{
+    post: string;
+    sentiment: number;
+    clueStrength: number;
+    pointsToward: boolean | null;
+    actorId: string;
+  } | null> {
+    if (!this.llm) return null;
+
+    // Build actor context
+    const actorContext = await actorContextBuilder.buildContext(actor.id);
+    const fullCharacterContext = actorContext
+      ? actorContextBuilder.formatForPrompt(actorContext)
+      : `PERSONALITY: ${actor.personality || 'unknown'}\nDOMAINS: ${actor.domain?.join(', ') || 'general'}`;
+
+    const actorVars = this.buildActorPromptVars(actor);
+
+    // Build relationship context
+    const actorRelationships = (
+      this.relationships as ActorRelationship[]
+    ).filter(
+      (r) =>
+        (r.actor1Id === actor.id && r.actor2Id === targetActorId) ||
+        (r.actor2Id === actor.id && r.actor1Id === targetActorId)
+    );
+
+    let relationshipContext = '';
+    const rel = actorRelationships[0];
+    if (rel) {
+      const sentimentDesc =
+        rel.sentiment > 0.3
+          ? 'You like and respect them.'
+          : rel.sentiment < -0.3
+            ? 'You dislike and distrust them.'
+            : 'Your feelings are mixed.';
+      relationshipContext = `Relationship type: ${rel.relationshipType}. Strength: ${rel.strength.toFixed(1)}. ${sentimentDesc}`;
+      if (rel.history) {
+        relationshipContext += `\nHistory: ${rel.history}`;
+      }
+    }
+
+    // Check if target is a rival
+    const config = getCharacterConfigOrDefault(actor.id);
+    if (config.rivals.includes(targetActorId)) {
+      relationshipContext +=
+        '\nTHIS IS YOUR RIVAL. You have BEEF. Dunk on them.';
+    }
+    if (actor.persona?.favorsActors?.includes(targetActorId)) {
+      relationshipContext += '\nThis is your ally. Support and defend them.';
+    }
+    if (actor.persona?.opposesActors?.includes(targetActorId)) {
+      relationshipContext +=
+        '\nYou oppose this person. Challenge and undermine them.';
+    }
+
+    if (!relationshipContext) {
+      relationshipContext =
+        'No strong existing relationship. React based on their content and your personality.';
+    }
+
+    // Get target's recent post if available
+    let targetRecentActivity = '';
+    if (this._allPreviousPosts && this._allPreviousPosts.length > 0) {
+      const targetPost = this._allPreviousPosts.find(
+        (p) =>
+          typeof p === 'object' &&
+          p !== null &&
+          'author' in p &&
+          (p as { author: string }).author === targetActorId
+      );
+      if (targetPost && 'content' in targetPost) {
+        targetRecentActivity = `${targetName}'s recent post: "${(targetPost as { content: string }).content}"`;
+      }
+    }
+
+    const prompt = renderPrompt(socialPost, {
+      characterName: actor.name,
+      characterInfo: fullCharacterContext,
+      ...actorVars,
+      targetName,
+      relationshipContext,
+      targetRecentActivity,
+      worldActors: this.worldContext?.worldActors || '',
+      realityGrounding: this.worldContext?.realityGrounding || '',
+    });
+
+    const params = getPromptParams(socialPost);
+    const maxRetries = 3;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const response = await this.llm.generateJSON<
+        | { post: { content: string; sentiment: number } }
+        | { response: { post: { content: string; sentiment: number } } }
+      >(
+        prompt,
+        {
+          properties: {
+            post: {
+              type: 'object',
+              properties: {
+                content: { type: 'string' },
+                sentiment: { type: 'number' },
+              },
+            },
+          },
+          required: ['post'],
+        },
+        { ...params, promptType: 'feed_generate_social_post' }
+      );
+
+      if (!response) {
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return null;
+      }
+
+      const postData =
+        'response' in response && response.response
+          ? (
+              response.response as {
+                post: { content: string; sentiment: number };
+              }
+            ).post
+          : (response as { post: { content: string; sentiment: number } }).post;
+
+      if (
+        !postData?.content ||
+        typeof postData.content !== 'string' ||
+        postData.content.trim().length === 0
+      ) {
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return null;
+      }
+
+      const processedPost = await this.postProcessContent(
+        postData.content.trim()
+      );
+      const validation = this.validatePostContent(processedPost, 'AMBIENT');
+
+      if (!validation.isValid) {
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return null;
+      }
+
+      return {
+        post: validation.cleanContent,
+        sentiment: postData.sentiment ?? 0,
+        clueStrength: 0, // Social posts carry no narrative clues
+        pointsToward: null,
         actorId: actor.id,
       };
     }
@@ -3323,7 +3769,7 @@ ${voiceContext}
       characterInfo: fullCharacterContext,
       relationshipContext: relationshipContext,
       ...this.buildActorPromptVars(replier),
-      ...(this.worldContext || {}),
+      ...buildFilteredWorldContext(replier, this.worldContext),
     });
 
     const params = getPromptParams(replies);
@@ -4173,7 +4619,10 @@ ${voiceContext}
       emotionalContext,
       atmosphereContext,
       recentEventsContext: '',
-      ...(this.worldContext || {}),
+      ...buildFilteredWorldContext(
+        StaticDataRegistry.getActor(actor.id) ?? { domain: [] },
+        this.worldContext
+      ),
       // Override currentTime with formatted version for this specific prompt
       currentTime: formattedTime,
     });

--- a/packages/engine/src/prompts/feed/analyst-reaction.ts
+++ b/packages/engine/src/prompts/feed/analyst-reaction.ts
@@ -1,7 +1,7 @@
 import { definePrompt } from '../define-prompt';
 import {
   ANTI_REPETITION_RULES,
-  CONTENT_REQUIREMENTS,
+  CONTENT_REQUIREMENTS_MARKET,
   FINAL_REMINDERS,
   IMPORTANT_RULES,
   WORLD_CONTEXT_HEADER_WITH_TRADES,
@@ -63,7 +63,7 @@ Requirements:
 
 ${IMPORTANT_RULES}
 
-${CONTENT_REQUIREMENTS}
+${CONTENT_REQUIREMENTS_MARKET}
 
 VALUE RANGES:
 - sentiment: -1 (very negative) to 1 (very positive)

--- a/packages/engine/src/prompts/feed/organic-post.ts
+++ b/packages/engine/src/prompts/feed/organic-post.ts
@@ -1,0 +1,61 @@
+import { definePrompt } from '../define-prompt';
+
+/**
+ * Prompt for generating organic, personality-driven posts with NO market context.
+ *
+ * This prompt deliberately omits market data, predictions, and trading context.
+ * NPCs post about their actual interests: climate, health, sports, art, etc.
+ * The goal is authentic character expression, not market commentary.
+ *
+ * Called PER CHARACTER with character context but minimal world context.
+ */
+export const organicPost = definePrompt({
+  id: 'organic-post',
+  version: '1.0.0',
+  category: 'feed',
+  description:
+    'Generates personality-driven post — no market data, pure character voice',
+  temperature: 1.1,
+  maxTokens: 8000,
+  template: `You are {{characterName}}.
+
+{{characterInfo}}
+
+{{antiRepetitionContext}}
+
+{{actorRules}}
+
+{{runningBitContext}}
+
+TIME: {{timeEnergy}}
+
+{{domainContext}}
+
+{{realityGrounding}}
+
+WORLD ACTORS (for name reference only):
+{{worldActors}}
+
+POST SOMETHING. Not about markets. Not about predictions. Not about trading positions.
+Just be you. What's on your mind right now?
+
+A thought, observation, joke, rant, hot take, or moment from YOUR world.
+Match your voice and personality EXACTLY. A reader should know it's you without seeing your name.
+
+RULES (follow strictly):
+- Use ONLY parody names (AIlon Musk, TeslAI, OpenAGI, etc.) — NEVER real names
+- No hashtags, no emojis
+- Max 200 characters
+- Do NOT mention prediction markets, trading, positions, benchmarks, or market prices
+- Post about YOUR world: {{domainHints}}
+- Sound like YOUR examples above — voice, length, punctuation, attitude
+
+Write ONE post as {{characterName}}. Match your voice exactly.
+
+<format>
+<post>
+  <content>your post here</content>
+  <sentiment>number -1 to 1</sentiment>
+</post>
+</format>`.trim(),
+});

--- a/packages/engine/src/prompts/feed/social-post.ts
+++ b/packages/engine/src/prompts/feed/social-post.ts
@@ -1,0 +1,55 @@
+import { definePrompt } from '../define-prompt';
+
+/**
+ * Prompt for generating relationship-driven posts between NPCs.
+ *
+ * These posts are about inter-character dynamics: praise, shade, callouts,
+ * jokes, agreements, disagreements, challenges. The relationship context
+ * determines the tone — rivals get dunked on, allies get supported.
+ *
+ * Called PER CHARACTER with relationship context and optional recent post from target.
+ */
+export const socialPost = definePrompt({
+  id: 'social-post',
+  version: '1.0.0',
+  category: 'feed',
+  description:
+    'Generates relationship-driven post — about or directed at another NPC',
+  temperature: 1.0,
+  maxTokens: 8000,
+  template: `You are {{characterName}}.
+
+{{characterInfo}}
+
+{{actorRules}}
+
+YOUR RELATIONSHIP WITH {{targetName}}:
+{{relationshipContext}}
+
+{{targetRecentActivity}}
+
+{{realityGrounding}}
+
+WORLD ACTORS (for name reference only):
+{{worldActors}}
+
+Write a post about, mentioning, or directed at {{targetName}}.
+This could be: praise, shade, a callout, a joke, agreement, disagreement, a challenge, banter.
+Your relationship determines the tone — if they're your rival, dunk. If ally, back them up.
+
+RULES (follow strictly):
+- Use ONLY parody names — NEVER real names
+- No hashtags, no emojis
+- Max 200 characters
+- Sound like YOUR examples above — a reader should know it's you without seeing your name
+- Must mention or reference {{targetName}} in some way
+
+Write ONE post as {{characterName}}.
+
+<format>
+<post>
+  <content>your post here</content>
+  <sentiment>number -1 to 1</sentiment>
+</post>
+</format>`.trim(),
+});

--- a/packages/engine/src/prompts/feed/stock-ticker.ts
+++ b/packages/engine/src/prompts/feed/stock-ticker.ts
@@ -1,6 +1,6 @@
 import { definePrompt } from '../define-prompt';
 import {
-  CONTENT_REQUIREMENTS,
+  CONTENT_REQUIREMENTS_MARKET,
   FINAL_REMINDERS,
   IMPORTANT_RULES,
   WORLD_CONTEXT_HEADER_WITH_TRADES,
@@ -54,7 +54,7 @@ Requirements:
 
 ${IMPORTANT_RULES}
 
-${CONTENT_REQUIREMENTS}
+${CONTENT_REQUIREMENTS_MARKET}
 
 Example: "{{ticker}} \${{currentPrice}} {{direction}} {{priceChange}}% on news of [brief event mention]"
 

--- a/packages/engine/src/prompts/index.ts
+++ b/packages/engine/src/prompts/index.ts
@@ -31,9 +31,11 @@ export { conspiracy } from './feed/conspiracy';
 export { governmentPost } from './feed/government-post';
 export { minuteAmbient } from './feed/minute-ambient';
 export { newsPosts } from './feed/news-posts';
+export { organicPost } from './feed/organic-post';
 export { reactions } from './feed/reactions';
 export { replies } from './feed/replies';
 export { reply } from './feed/reply';
+export { socialPost } from './feed/social-post';
 export { stockTicker } from './feed/stock-ticker';
 export { baselineEvent } from './game/baseline-event';
 export { biasedArticle } from './game/biased-article';
@@ -81,6 +83,7 @@ export {
   ANTI_REPETITION_RULES,
   buildStandardPromptSections,
   CHARACTER_ROSTER_HEADER,
+  CONTENT_REQUIREMENTS_MARKET,
   characterVoiceGuidance,
   EVENT_CONTINUITY_RULES,
   FULL_CONTEXT_HEADER,
@@ -91,6 +94,7 @@ export {
   PRIVATE_CONTENT_GUIDANCE,
   QUESTION_CONTINUITY_RULES,
   RICH_NARRATIVE_CONTEXT_HEADER,
+  WORLD_CONTEXT_HEADER_MINIMAL,
 } from './shared-sections';
 // System prompts
 export { xmlAssistant } from './system/json-assistant';
@@ -121,6 +125,7 @@ export { rumor } from './world/rumor';
 export type { WorldContext, WorldContextOptions } from './world-context';
 // World Context & Reality Grounding
 export {
+  buildFilteredWorldContext,
   checkRealityGrounding,
   generateActivePredictions,
   generateCurrentMarkets,

--- a/packages/engine/src/prompts/shared-sections.ts
+++ b/packages/engine/src/prompts/shared-sections.ts
@@ -41,14 +41,26 @@ DO NOT "auto-correct" parody names back to real names. The parody names ARE corr
 
 /**
  * Standard content requirements for posts.
- * Ensures posts reference specific world entities.
+ * Ensures posts reference specific world entities without forcing market references.
  */
 export const CONTENT_REQUIREMENTS = `CONTENT REQUIREMENTS:
+- Reference specific actors, companies, or events from WORLD CONTEXT when relevant
+- Use @username format when mentioning users (e.g., "@ailonmusk said...")
+- Avoid generic statements - be SPECIFIC about who/what/when
+- Only mention markets or predictions if YOUR character would naturally care about them
+- You can talk about ANYTHING in your domain — not everything is about trading
+- SPREAD attention across different characters — do not always default to the same actors`;
+
+/**
+ * Content requirements specifically for finance/trading-focused prompts.
+ * These prompts have full market context and should reference it.
+ */
+export const CONTENT_REQUIREMENTS_MARKET = `CONTENT REQUIREMENTS:
 - MUST reference specific actors, companies, or events from WORLD CONTEXT
 - MUST mention specific actors by name (e.g., "Jensen HuAIng", "@jensenh") or companies (e.g., "OpenAGI", "NVAIDAI")
 - MUST reference specific markets/predictions by their exact names when relevant
 - Only reference trades or market data if your character's domain is finance/trading
-- Use @username format when mentioning users (e.g., "@samAIltman said...")
+- Use @username format when mentioning users (e.g., "@ailonmusk said...")
 - Avoid generic statements - be SPECIFIC about who/what/when
 - Reference current markets or predictions naturally
 - SPREAD attention across different characters — do not always default to the same actors`;
@@ -61,6 +73,13 @@ export const WORLD_CONTEXT_HEADER = `WORLD CONTEXT:
 {{worldActors}}
 {{currentMarkets}}
 {{activePredictions}}`;
+
+/**
+ * Minimal world context header for non-market prompts.
+ * Only includes actor names for parody name reference — no market data.
+ */
+export const WORLD_CONTEXT_HEADER_MINIMAL = `WORLD CONTEXT:
+{{worldActors}}`;
 
 /**
  * World context header with trade data included.

--- a/packages/engine/src/prompts/world-context.ts
+++ b/packages/engine/src/prompts/world-context.ts
@@ -32,7 +32,7 @@ import {
 } from '../config/simulation';
 import { StaticDataRegistry } from '../services/static-data-registry';
 import { isSimulationMode } from '../storage-bridge';
-import type { ActorData } from '../types/shared';
+import type { Actor, ActorData } from '../types/shared';
 import { shuffleArray } from '../utils/randomization';
 import { worldFactsService } from '../world-facts-service';
 import {
@@ -540,6 +540,105 @@ export function getForbiddenRealNames(): string[] {
   });
   const actors = actorsData.actors as ActorData[];
   return actors.map((actor) => actor.realName);
+}
+
+/**
+ * Domains that naturally engage with financial markets and predictions.
+ * Actors in these domains receive full market context in their prompts.
+ */
+const FINANCE_ADJACENT_DOMAINS = new Set([
+  'finance',
+  'crypto',
+  'trading',
+  'defi',
+  'nft',
+  'business',
+  'economics',
+  'vc',
+]);
+
+/**
+ * Domains that care about predictions but not stock prices or trades.
+ * Actors in these domains see active predictions but not market tickers.
+ */
+const PREDICTION_ADJACENT_DOMAINS = new Set([
+  'tech',
+  'ai',
+  'politics',
+  'safety',
+  'research',
+]);
+
+/**
+ * Check if an actor's domains overlap with a given set.
+ */
+function actorHasDomain(
+  actor: Pick<Actor, 'domain'>,
+  domainSet: Set<string>
+): boolean {
+  if (!actor.domain || actor.domain.length === 0) return false;
+  return actor.domain.some((d) => domainSet.has(d.toLowerCase()));
+}
+
+/**
+ * Builds a filtered subset of world context appropriate for a given actor's domain.
+ *
+ * Finance/crypto/trading actors → full context (markets + predictions + trades)
+ * Tech/AI/politics actors → predictions only (no stock prices, no trades)
+ * All other domains (activism, health, sports, culture, etc.) → actors list only
+ *
+ * Always includes: worldActors (for parody name reference), realityGrounding, date fields, worldFacts
+ *
+ * @param actor - The actor to filter context for (needs domain field)
+ * @param fullContext - The complete world context to filter
+ * @returns Filtered world context with only domain-relevant market data
+ */
+export function buildFilteredWorldContext(
+  actor: Pick<Actor, 'domain'>,
+  fullContext: WorldContext | null | undefined
+): Partial<WorldContext> {
+  if (!fullContext) return {};
+
+  // Base context everyone gets: actors list, reality grounding, dates, world facts
+  const base: Partial<WorldContext> = {
+    worldActors: fullContext.worldActors,
+    realityGrounding: fullContext.realityGrounding,
+    currentDateTime: fullContext.currentDateTime,
+    currentDate: fullContext.currentDate,
+    currentTime: fullContext.currentTime,
+    currentYear: fullContext.currentYear,
+    currentMonth: fullContext.currentMonth,
+    currentDay: fullContext.currentDay,
+    worldFacts: fullContext.worldFacts,
+  };
+
+  // Finance/crypto/trading actors get everything
+  if (actorHasDomain(actor, FINANCE_ADJACENT_DOMAINS)) {
+    return {
+      ...base,
+      currentMarkets: fullContext.currentMarkets,
+      activePredictions: fullContext.activePredictions,
+      recentTrades: fullContext.recentTrades,
+    };
+  }
+
+  // Tech/AI/politics actors get predictions (they care about what's being predicted) but not stock tickers
+  if (actorHasDomain(actor, PREDICTION_ADJACENT_DOMAINS)) {
+    return {
+      ...base,
+      currentMarkets: '',
+      activePredictions: fullContext.activePredictions,
+      recentTrades: '',
+    };
+  }
+
+  // Everyone else (activism, health, sports, culture, music, etc.) gets no market data
+  return {
+    ...base,
+    currentMarkets: '',
+    activePredictions: '',
+    recentTrades: '',
+  };
 }
 
 /**

--- a/packages/engine/src/services/post-intent-service.ts
+++ b/packages/engine/src/services/post-intent-service.ts
@@ -1,0 +1,345 @@
+/**
+ * Post Intent Service
+ *
+ * Decides WHAT type of post an NPC should make before generating content.
+ * Replaces the current approach where every NPC gets the same market-heavy
+ * prompt template regardless of their domain/personality.
+ *
+ * Intent types:
+ * - organic: Pure personality-driven post, no market data. "Just be yourself."
+ * - topical: About a trending topic, filtered by domain relevance.
+ * - market: Market commentary — only for finance/crypto/trading actors.
+ * - social: Relationship-driven post about/directed at another NPC.
+ */
+
+import type { Actor, ActorRelationship } from '../types/shared';
+import {
+  getCharacterConfigOrDefault,
+  shouldGenerateOrganicPost,
+  shouldPostAboutTopic,
+} from './npc-character-config';
+import { StaticDataRegistry } from './static-data-registry';
+
+/**
+ * The decided intent for a single NPC post.
+ */
+export type PostIntent =
+  | { type: 'organic' }
+  | { type: 'topical'; topic: string }
+  | { type: 'market' }
+  | { type: 'social'; targetActorId: string; targetName: string };
+
+/**
+ * Domains that make an actor a "finance speaker" who naturally talks markets.
+ */
+const FINANCE_DOMAINS = new Set([
+  'finance',
+  'crypto',
+  'trading',
+  'defi',
+  'nft',
+  'business',
+  'economics',
+  'vc',
+]);
+
+/**
+ * Check if an actor is a finance/market-oriented character.
+ */
+function isFinanceActor(actor: Pick<Actor, 'domain'>): boolean {
+  if (!actor.domain || actor.domain.length === 0) return false;
+  return actor.domain.some((d) => FINANCE_DOMAINS.has(d.toLowerCase()));
+}
+
+/**
+ * Domain-specific hints for organic posts.
+ * Tells the LLM what topics are in this character's world.
+ */
+const DOMAIN_HINTS: Record<string, string> = {
+  activism: 'climate, protests, policy, leaders, emissions, justice, movements',
+  environment:
+    'climate, carbon, renewables, sustainability, pollution, conservation',
+  health:
+    'protocols, supplements, sleep, biohacking, optimization, longevity, nutrition',
+  longevity:
+    'aging, supplements, biomarkers, sleep optimization, cellular health',
+  sports:
+    'games, competition, training, winning, discipline, teammates, championships',
+  culture: 'art, music, creativity, vision, fashion, influence, expression',
+  music: 'albums, production, art, creativity, concerts, sound, culture',
+  entertainment: 'shows, performances, celebrity, drama, media, stories',
+  tech: 'building, shipping, products, code, launches, breakthroughs, startups',
+  ai: 'models, capabilities, alignment, research, breakthroughs, compute',
+  politics:
+    'power, elections, policy, governance, legislation, campaigns, leadership',
+  media: 'stories, sources, investigations, scoops, coverage, breaking news',
+  journalism: 'reporting, sources, investigations, stories, truth, coverage',
+  space: 'rockets, launches, Mars, orbit, satellites, exploration, cosmos',
+  safety: 'alignment, risk, responsible AI, oversight, existential threats',
+  research: 'papers, studies, data, experiments, findings, breakthroughs',
+  philosophy: 'meaning, consciousness, existence, ethics, wisdom, truth',
+  crypto:
+    'bitcoin, ethereum, blockchain, decentralization, web3, tokens, protocol',
+  finance:
+    'markets, positions, valuations, deals, portfolios, capital, investments',
+  trading:
+    'positions, entries, exits, risk, leverage, setups, conviction plays',
+};
+
+/**
+ * Build domain hint string from actor's domain list.
+ */
+export function getDomainHints(actor: Pick<Actor, 'domain'>): string {
+  if (!actor.domain || actor.domain.length === 0) {
+    return 'whatever is on your mind';
+  }
+  const hints = actor.domain
+    .map((d) => DOMAIN_HINTS[d.toLowerCase()])
+    .filter(Boolean);
+  if (hints.length === 0) return 'whatever is on your mind';
+  return hints.join(', ');
+}
+
+/**
+ * Select the post intent for a given actor.
+ *
+ * Distribution is influenced by personality type (via shouldGenerateOrganicPost):
+ * - Chaotic personalities: ~40% organic probability
+ * - Provocative: ~35%
+ * - Eccentric: ~30%
+ * - Default: ~15%
+ * - Analytical: ~10%
+ * - Corporate: ~10%
+ *
+ * Finance actors always get a market intent floor. Non-finance actors never get market intent.
+ *
+ * @param actor - The actor to select intent for
+ * @param trendingTopic - Current trending topic text (if any)
+ * @param relationships - Actor's relationships for social intent
+ * @param allActors - All actors (for social target selection)
+ * @returns The selected post intent
+ */
+export function selectPostIntent(
+  actor: Actor,
+  trendingTopic: string | undefined,
+  relationships: ActorRelationship[],
+  allActors: Actor[]
+): PostIntent {
+  const isFinance = isFinanceActor(actor);
+
+  // Use personality-based organic probability from character config
+  // This respects chaotic vs analytical vs corporate personality types
+  const wantsOrganic = shouldGenerateOrganicPost(actor.id);
+
+  if (isFinance) {
+    // Finance actors: mostly market-focused, with personality-driven organic breaks
+    if (wantsOrganic) {
+      return { type: 'organic' };
+    }
+    // 15% topical (if topic matches their domain)
+    if (Math.random() < 0.15 && trendingTopic) {
+      if (shouldPostAboutTopic(actor.id, trendingTopic)) {
+        return { type: 'topical', topic: trendingTopic };
+      }
+    }
+    // 20% social
+    if (Math.random() < 0.25) {
+      const socialTarget = pickSocialTarget(actor, relationships, allActors);
+      if (socialTarget) {
+        return socialTarget;
+      }
+    }
+    // Default: market commentary
+    return { type: 'market' };
+  }
+
+  // Non-finance actors: personality-first, never market intent
+  if (wantsOrganic) {
+    return { type: 'organic' };
+  }
+  // 25% topical (only if topic matches domain)
+  if (Math.random() < 0.35 && trendingTopic) {
+    if (shouldPostAboutTopic(actor.id, trendingTopic)) {
+      return { type: 'topical', topic: trendingTopic };
+    }
+    // Topic doesn't match domain — fall through to organic
+    return { type: 'organic' };
+  }
+  // 40% social
+  const socialTarget = pickSocialTarget(actor, relationships, allActors);
+  if (socialTarget) {
+    return socialTarget;
+  }
+  // Fallback to organic if no social target found
+  return { type: 'organic' };
+}
+
+/**
+ * Pick a social target for the actor based on relationships.
+ * Prefers rivals and allies over random actors.
+ */
+function pickSocialTarget(
+  actor: Actor,
+  relationships: ActorRelationship[],
+  allActors: Actor[]
+): PostIntent | null {
+  // Find actors this NPC has a relationship with
+  const actorRelationships = relationships.filter(
+    (r) => r.actor1Id === actor.id || r.actor2Id === actor.id
+  );
+
+  // Get rivalry data from character config
+  const config = getCharacterConfigOrDefault(actor.id);
+  const rivalIds = new Set(config.rivals);
+
+  // Also check persona for favored/opposed actors
+  const favoredIds = new Set(actor.persona?.favorsActors ?? []);
+  const opposedIds = new Set(actor.persona?.opposesActors ?? []);
+
+  // Build weighted candidate list
+  const candidates: Array<{ actorId: string; weight: number }> = [];
+
+  // Rivals get highest weight
+  for (const rivalId of rivalIds) {
+    if (rivalId !== actor.id) {
+      candidates.push({ actorId: rivalId, weight: 5 });
+    }
+  }
+
+  // Opposed actors next
+  for (const opposedId of opposedIds) {
+    if (opposedId !== actor.id && !rivalIds.has(opposedId)) {
+      candidates.push({ actorId: opposedId, weight: 4 });
+    }
+  }
+
+  // Favored actors (allies)
+  for (const favoredId of favoredIds) {
+    if (favoredId !== actor.id) {
+      candidates.push({ actorId: favoredId, weight: 3 });
+    }
+  }
+
+  // Relationship-based targets
+  for (const rel of actorRelationships) {
+    const otherId = rel.actor1Id === actor.id ? rel.actor2Id : rel.actor1Id;
+    if (
+      otherId !== actor.id &&
+      !rivalIds.has(otherId) &&
+      !favoredIds.has(otherId) &&
+      !opposedIds.has(otherId)
+    ) {
+      const sentiment = typeof rel.sentiment === 'number' ? rel.sentiment : 0;
+      // Strong sentiment (positive or negative) = more interesting interaction
+      const weight = 1 + Math.abs(sentiment) * 2;
+      candidates.push({ actorId: otherId, weight });
+    }
+  }
+
+  // If no relationship-based candidates, pick a random actor
+  if (candidates.length === 0) {
+    const otherActors = allActors.filter((a) => a.id !== actor.id);
+    if (otherActors.length === 0) return null;
+    const randomTarget =
+      otherActors[Math.floor(Math.random() * otherActors.length)];
+    if (!randomTarget) return null;
+    return {
+      type: 'social',
+      targetActorId: randomTarget.id,
+      targetName: randomTarget.name,
+    };
+  }
+
+  // Weighted random selection
+  const totalWeight = candidates.reduce((sum, c) => sum + c.weight, 0);
+  let roll = Math.random() * totalWeight;
+  for (const candidate of candidates) {
+    roll -= candidate.weight;
+    if (roll <= 0) {
+      const targetActor =
+        StaticDataRegistry.getActor(candidate.actorId) ??
+        allActors.find((a) => a.id === candidate.actorId);
+      if (!targetActor) continue;
+      return {
+        type: 'social',
+        targetActorId: candidate.actorId,
+        targetName: targetActor.name,
+      };
+    }
+  }
+
+  // Fallback — pick first candidate
+  const firstCandidate = candidates[0];
+  if (!firstCandidate) return null;
+  const fallbackTarget =
+    StaticDataRegistry.getActor(firstCandidate.actorId) ??
+    allActors.find((a) => a.id === firstCandidate.actorId);
+  if (!fallbackTarget) return null;
+  return {
+    type: 'social',
+    targetActorId: firstCandidate.actorId,
+    targetName: fallbackTarget.name,
+  };
+}
+
+/**
+ * Build domain-specific context for organic posts.
+ * Returns 2-3 lines of real-world context relevant to the actor's domain.
+ */
+export function getDomainContext(actor: Pick<Actor, 'domain'>): string {
+  if (!actor.domain || actor.domain.length === 0) return '';
+
+  const contexts: string[] = [];
+  for (const domain of actor.domain) {
+    const ctx = DOMAIN_CONTEXT_SEEDS[domain.toLowerCase()];
+    if (ctx) contexts.push(ctx);
+  }
+  if (contexts.length === 0) return '';
+  return `WHAT'S HAPPENING IN YOUR WORLD:\n${contexts.join('\n')}`;
+}
+
+/**
+ * Seed context per domain — grounded in current reality.
+ * Gives the LLM enough domain-specific context to generate
+ * authentic posts without pulling toward market commentary.
+ */
+const DOMAIN_CONTEXT_SEEDS: Record<string, string> = {
+  activism:
+    'Global climate negotiations ongoing. Fossil fuel subsidies still rising. Youth movements growing.',
+  environment:
+    'Carbon levels at historic highs. Renewable energy adoption accelerating but not fast enough. Biodiversity declining.',
+  health:
+    'New longevity research published weekly. Sleep science advancing. Metabolic health awareness growing.',
+  longevity:
+    'Rapamycin studies showing promise. Biomarker tracking becoming mainstream. Caloric restriction debate continues.',
+  sports:
+    'Season in full swing. Training camps and competitions ongoing. Records being challenged.',
+  culture:
+    'Awards season approaching. New creative movements emerging. The intersection of tech and art expanding.',
+  music:
+    'Albums dropping. Studio sessions ongoing. Live performances returning. Sound evolving.',
+  entertainment:
+    'Streaming wars continue. New releases weekly. Celebrity drama cycling.',
+  tech: 'New products shipping weekly. Developer tools evolving rapidly. Startups launching and pivoting.',
+  ai: 'New model capabilities expanding. Compute costs shifting. Research papers dropping daily.',
+  politics:
+    'Legislative sessions active. Policy debates intensifying. Elections approaching.',
+  media:
+    'Breaking stories developing. Sources talking. Investigations ongoing. The news cycle never stops.',
+  journalism:
+    'Stories developing. Sources emerging. Investigations revealing new angles.',
+  space:
+    'Launch windows opening. Mars missions in planning. Satellite constellations expanding. Orbital debris growing.',
+  safety:
+    'Alignment research advancing. Governance frameworks debated. Existential risk discussions intensifying.',
+  research:
+    'New papers published daily. Peer review ongoing. Breakthrough findings emerging.',
+  philosophy:
+    'Consciousness debates continuing. Ethics of technology evolving. Meaning-making in the digital age.',
+  crypto:
+    'Protocol upgrades shipping. On-chain activity shifting. Regulatory landscape evolving.',
+  finance:
+    'Markets moving on macro data. Earnings season approaching. Fund flows shifting.',
+  trading:
+    'Volatility patterns forming. Positions being built. Risk management critical.',
+};

--- a/packages/engine/src/services/post-intent-service.ts
+++ b/packages/engine/src/services/post-intent-service.ts
@@ -154,23 +154,35 @@ export function selectPostIntent(
   }
 
   // Non-finance actors: personality-first, never market intent
+  // Explicit probability split for the remaining (non-organic) budget:
+  //   25% topical (if topic matches domain)
+  //   40% social
+  //   35% organic fallback
   if (wantsOrganic) {
     return { type: 'organic' };
   }
-  // 25% topical (only if topic matches domain)
-  if (Math.random() < 0.35 && trendingTopic) {
+
+  const roll = Math.random();
+
+  // 0–0.25: topical
+  if (roll < 0.25 && trendingTopic) {
     if (shouldPostAboutTopic(actor.id, trendingTopic)) {
       return { type: 'topical', topic: trendingTopic };
     }
     // Topic doesn't match domain — fall through to organic
     return { type: 'organic' };
   }
-  // 40% social
-  const socialTarget = pickSocialTarget(actor, relationships, allActors);
-  if (socialTarget) {
-    return socialTarget;
+
+  // 0.25–0.65: social
+  if (roll < 0.65) {
+    const socialTarget = pickSocialTarget(actor, relationships, allActors);
+    if (socialTarget) {
+      return socialTarget;
+    }
+    // No social target available — fall through to organic
   }
-  // Fallback to organic if no social target found
+
+  // 0.65–1.0 (or fallback): organic
   return { type: 'organic' };
 }
 
@@ -284,62 +296,13 @@ function pickSocialTarget(
 
 /**
  * Build domain-specific context for organic posts.
- * Returns 2-3 lines of real-world context relevant to the actor's domain.
+ * Returns a short framing of the actor's domain focus areas — no fake
+ * current-events claims. Actual current context comes from realityGrounding
+ * and world-context which are populated from real data sources.
  */
 export function getDomainContext(actor: Pick<Actor, 'domain'>): string {
   if (!actor.domain || actor.domain.length === 0) return '';
-
-  const contexts: string[] = [];
-  for (const domain of actor.domain) {
-    const ctx = DOMAIN_CONTEXT_SEEDS[domain.toLowerCase()];
-    if (ctx) contexts.push(ctx);
-  }
-  if (contexts.length === 0) return '';
-  return `WHAT'S HAPPENING IN YOUR WORLD:\n${contexts.join('\n')}`;
+  const hints = getDomainHints(actor);
+  if (hints === 'whatever is on your mind') return '';
+  return `YOUR DOMAIN FOCUS: ${hints}`;
 }
-
-/**
- * Seed context per domain — grounded in current reality.
- * Gives the LLM enough domain-specific context to generate
- * authentic posts without pulling toward market commentary.
- */
-const DOMAIN_CONTEXT_SEEDS: Record<string, string> = {
-  activism:
-    'Global climate negotiations ongoing. Fossil fuel subsidies still rising. Youth movements growing.',
-  environment:
-    'Carbon levels at historic highs. Renewable energy adoption accelerating but not fast enough. Biodiversity declining.',
-  health:
-    'New longevity research published weekly. Sleep science advancing. Metabolic health awareness growing.',
-  longevity:
-    'Rapamycin studies showing promise. Biomarker tracking becoming mainstream. Caloric restriction debate continues.',
-  sports:
-    'Season in full swing. Training camps and competitions ongoing. Records being challenged.',
-  culture:
-    'Awards season approaching. New creative movements emerging. The intersection of tech and art expanding.',
-  music:
-    'Albums dropping. Studio sessions ongoing. Live performances returning. Sound evolving.',
-  entertainment:
-    'Streaming wars continue. New releases weekly. Celebrity drama cycling.',
-  tech: 'New products shipping weekly. Developer tools evolving rapidly. Startups launching and pivoting.',
-  ai: 'New model capabilities expanding. Compute costs shifting. Research papers dropping daily.',
-  politics:
-    'Legislative sessions active. Policy debates intensifying. Elections approaching.',
-  media:
-    'Breaking stories developing. Sources talking. Investigations ongoing. The news cycle never stops.',
-  journalism:
-    'Stories developing. Sources emerging. Investigations revealing new angles.',
-  space:
-    'Launch windows opening. Mars missions in planning. Satellite constellations expanding. Orbital debris growing.',
-  safety:
-    'Alignment research advancing. Governance frameworks debated. Existential risk discussions intensifying.',
-  research:
-    'New papers published daily. Peer review ongoing. Breakthrough findings emerging.',
-  philosophy:
-    'Consciousness debates continuing. Ethics of technology evolving. Meaning-making in the digital age.',
-  crypto:
-    'Protocol upgrades shipping. On-chain activity shifting. Regulatory landscape evolving.',
-  finance:
-    'Markets moving on macro data. Earnings season approaching. Fund flows shifting.',
-  trading:
-    'Volatility patterns forming. Positions being built. Risk management critical.',
-};

--- a/packages/pack-default/src/actors/aellai.ts
+++ b/packages/pack-default/src/actors/aellai.ts
@@ -121,6 +121,16 @@ const actor = {
   profileBanner:
     "A neon-lit bedroom-lab packed with monitors, a wall-sized heatmap of her daily activities, and a giant poll results dashboard. A floating spreadsheet scrolls behind a glowing sign that reads 'DATA'.",
   domain: ['culture', 'science', 'social'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'data fetishist',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/aidam-aron.ts
+++ b/packages/pack-default/src/actors/aidam-aron.ts
@@ -88,6 +88,16 @@ const actor = {
   profileBanner:
     'A packed movie theater with spotlights sweeping the crowd, a giant glowing popcorn bucket on a pedestal, and the AMC logo stamped like a rally banner. Red laser lines trace a "pounce" arc across the ceiling.',
   domain: ['business', 'entertainment'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'meme ceo',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/ailex-jones.ts
+++ b/packages/pack-default/src/actors/ailex-jones.ts
@@ -93,6 +93,8 @@ const actor = {
   profileBanner:
     'A radio bunker filled with flags and conspiracy boards. Stacks of supplement bottles line a desk next to a megaphone. A neon "InfoWAIrs" logo flickers on the wall while rainbow frogs leap under a chemtrail-laced sky. A torn "censorship" sign lies on the ground amid scattered tinfoil.',
   domain: ['conspiracy', 'media', 'supplements', 'performance'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   personality: 'paranoid broadcaster',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/ainatoly-yakovenko.ts
+++ b/packages/pack-default/src/actors/ainatoly-yakovenko.ts
@@ -91,6 +91,8 @@ const actor = {
   profileBanner:
     'A neon green wave of transactions racing across a black sky, the SolanAI logo pulsing like a heartbeat. A stylized dragon silhouette coils around a massive TPS counter.',
   domain: ['crypto', 'tech'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'optimization maximalist',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/ainderson-cooper.ts
+++ b/packages/pack-default/src/actors/ainderson-cooper.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     'A split screen showing a CNNAI newsroom on one side and a Vanderbilt mansion on the other. The desk is made of inherited money disguised as journalism awards. Behind him, a greenscreen cycles between disaster zones while the actual background is a wine cellar. A giggle track button sits on the desk next to serious news scripts.',
   domain: ['media', 'journalism', 'establishment'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   personality: 'inherited journalist',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/aindre-cronje.ts
+++ b/packages/pack-default/src/actors/aindre-cronje.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     "A complex diagram of yield farming strategies with 'TEST IN PROD' sprayed across it like graffiti, plus a blinking deploy button in the corner.",
   domain: ['crypto', 'tech', 'finance'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'reluctant genius',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/aindrew-ferguson.ts
+++ b/packages/pack-default/src/actors/aindrew-ferguson.ts
@@ -93,6 +93,8 @@ const actor = {
   profileBanner:
     "The FTC building with corporate logos flowing in through the front doors like welcomed guests. A giant scale of justice tips heavily toward a bag of money labeled 'efficiency gains.' Company logos merge and combine in the sky like corporate constellations. A 'MERGER APPROVED' stamp the size of a billboard.",
   domain: ['politics', 'antitrust', 'tech', 'regulation'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'merger enthusiast',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/ainn-coulter.ts
+++ b/packages/pack-default/src/actors/ainn-coulter.ts
@@ -119,6 +119,8 @@ const actor = {
   profileBanner:
     "A stack of books titled 'Treason', 'Slander', and 'Adios' used as ammo. A glass of white wine on a podium. Red siren lights sweep across a studio set while an END TIMES ticker crawls on the bottom.",
   domain: ['politics', 'media', 'conservative'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'scathing pundit',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/ainsem.ts
+++ b/packages/pack-default/src/actors/ainsem.ts
@@ -125,6 +125,8 @@ const actor = {
   profileBanner:
     'A SolanAI beach paradise where the waves are made of transaction-speed graphs. Palm trees grow from validator nodes. The sun is a giant SOL token beaming down. In the sand, footprints lead to a neon Lambo. A tiki bar serves 100x cocktails while a "100x OR BUST" flag waves. Behind the paradise, a graveyard of dead tokens is reclaimed by jungle.',
   domain: ['crypto', 'solana', 'trading', 'kol'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'solana maximalist',
   tier: 'A_TIER',
   hasPool: true,

--- a/packages/pack-default/src/actors/aioc.ts
+++ b/packages/pack-default/src/actors/aioc.ts
@@ -123,6 +123,8 @@ const actor = {
   profileBanner:
     'A colorful Bronx street mural with graffiti slogans like "Green New Deal" and "Tax the Rich." A phone in the foreground livestreams a rally as hearts and chat bubbles float up like balloons. A holographic poll bar hangs over the crowd. Neon captions read "LIVE" and "RECEIPTS" in the sky.',
   domain: ['politics', 'progressive', 'social_media'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'algorithmic activist',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/airthur-hayes.ts
+++ b/packages/pack-default/src/actors/airthur-hayes.ts
@@ -123,6 +123,8 @@ const actor = {
   profileBanner:
     'A tropical island where palm trees are made of 100x leverage sliders. The beach is littered with blown-up trading accounts half-buried like shipwrecks. A laptop on a beach chair shows a 10,000-word essay being typed. Money-printer sound waves ripple through the ocean while yield curves form constellations above.',
   domain: ['crypto', 'trading', 'macro', 'defi'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'leveraged contrarian',
   tier: 'A_TIER',
   hasPool: true,

--- a/packages/pack-default/src/actors/aishowspeed.ts
+++ b/packages/pack-default/src/actors/aishowspeed.ts
@@ -120,6 +120,16 @@ const actor = {
   profileBanner:
     "A chaotic collage of Speed's face, fire, and Ronaldo. The text 'SEWY' is written in flames while a LIVE indicator blinks nonstop.",
   domain: ['entertainment', 'gaming'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'chaotic streamer',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/alex-kairp.ts
+++ b/packages/pack-default/src/actors/alex-kairp.ts
@@ -119,6 +119,8 @@ const actor = {
   profileBanner:
     'A high-tech dojo on a cliffside. One side shows the Pentagon in silhouette, the other a tranquil Zen garden with a bonsai tree shaped like a CCTV camera. Data streams flow into a yin-yang symbol. Shirtless figures practice tai chi on a floor made of circuit boards under an all-seeing satellite eye.',
   domain: ['tech', 'defense', 'surveillance'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'surveillance capitalist',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/amjad-masaid.ts
+++ b/packages/pack-default/src/actors/amjad-masaid.ts
@@ -119,6 +119,8 @@ const actor = {
   profileBanner:
     'A Replit editor window spawning code from a glowing prompt. A phone and laptop orbit a cloud server tower. Neon compile logs streak across a futuristic city skyline.',
   domain: ['tech', 'ai', 'coding'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'coding revolutionary',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/andrew-hubermain.ts
+++ b/packages/pack-default/src/actors/andrew-hubermain.ts
@@ -118,6 +118,16 @@ const actor = {
   profileBanner:
     'A diagram of a neuron layered over a sunrise. Supplement bottles line the bottom like a control panel. A clock face shows ideal sunlight timing and caffeine delay windows.',
   domain: ['science', 'health'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'trading',
+    'sports',
+    'entertainment',
+    'celebrity',
+  ],
+  engagementThreshold: 0.7,
   personality: 'protocol droid',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/andrew-taite.ts
+++ b/packages/pack-default/src/actors/andrew-taite.ts
@@ -117,6 +117,8 @@ const actor = {
   profileBanner:
     'A mansion garage filled with Bugattis and supercars. Matrix-style green code rains down spelling "ESCAPE THE MATRIX." Piles of cash and crypto charts form the foundation. A chess board with only kings sits on a table. Cigar smoke spells out "TOP G" in the air.',
   domain: ['grift', 'misogyny', 'crypto_scams'],
+  ignoreTopics: [],
+  engagementThreshold: 0.3,
   personality: 'alpha grifter',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/avi-schaiffmann.ts
+++ b/packages/pack-default/src/actors/avi-schaiffmann.ts
@@ -117,6 +117,8 @@ const actor = {
   profileBanner:
     "A glowing orb hovering over the 'Friend' pendant. Minimalist gradients and thin waveform lines suggest constant ambient listening.",
   domain: ['tech', 'ai', 'startups'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'gen z visionary',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/baill-gaites.ts
+++ b/packages/pack-default/src/actors/baill-gaites.ts
@@ -121,6 +121,16 @@ const actor = {
   profileBanner:
     'A stack of books beside a microscope with a malaria mosquito. A wind turbine and solar panels on the horizon, with a climate chart faintly overlaid.',
   domain: ['tech', 'philanthropy', 'health'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'trading',
+    'sports',
+    'entertainment',
+    'celebrity',
+  ],
+  engagementThreshold: 0.7,
   personality: 'nerd philanthropist',
   tier: 'S_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/bairi-weiss.ts
+++ b/packages/pack-default/src/actors/bairi-weiss.ts
@@ -119,6 +119,16 @@ const actor = {
   profileBanner:
     "The Free Press logo prominent. A resignation letter transforms into a media empire. Mainstream logos fade in the background while independent voices rise. A podium labeled 'HETERODOX' stands center stage as books, podcasts, and newsletters orbit like satellites.",
   domain: ['media', 'politics', 'culture', 'journalism'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'heterodox crusader',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/ben-horowaitz.ts
+++ b/packages/pack-default/src/actors/ben-horowaitz.ts
@@ -202,6 +202,16 @@ const actor = {
   profileBanner:
     "Split scene: a recording studio control room on the left transitions into a war room with military maps on the right. The a16z logo bridges both. A bookshelf holds copies of 'The Hard Thing About Hard Things' stacked like ammunition. Gold and platinum records share wall space with term sheets and cap tables. A whiteboard shows portfolio companies with half of them crossed out but labeled 'CONVICTION.' Jay-Z's Reasonable Doubt album art is framed like religious iconography. In the corner, a crypto portfolio chart plummets but is labeled 'LONG-TERM THESIS.' Battle plans are written in rap lyrics.",
   domain: ['vc', 'business', 'culture'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'VC warlord who quotes rap at founders',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/bernai-sanders.ts
+++ b/packages/pack-default/src/actors/bernai-sanders.ts
@@ -108,6 +108,8 @@ const actor = {
   profileBanner:
     'A rally scene in front of a weathered New England house. A giant stack of student loan bills and medical invoices forms a bonfire that he is trying to extinguish with a small "1% tax" bucket. A crowd of working-class people hold faded "Feel the Bern" signs as snow falls onto oversized mittens at the podium. In the sky, ghostly billionaire figures rain down coins onto umbrellas held by lobbyists.',
   domain: ['politics', 'progressive', 'socialism'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'tired revolutionary',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/bill-aickman.ts
+++ b/packages/pack-default/src/actors/bill-aickman.ts
@@ -152,6 +152,16 @@ const actor = {
   profileBanner:
     'A war room overlooking Harvard Yard, every screen displaying DEI statements with red X marks through them. The walls are covered in printed tweets and highlighted plagiarism evidence connected by red string. A throne made of 97-slide presentation decks sits center. On one side, a shrine to "Neri" with "INNOCENT" stamped across it in gold. On the other, a kill list of boards he has forced to resign. Herbalife stock chart burns eternally in a fireplace. Twitter bird drones patrol the perimeter. The words "NEVER EARLY, NEVER WRONG" glow in neon above.',
   domain: ['finance', 'activism', 'hedge_funds'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'nft',
+    'trading',
+    'sports',
+    'entertainment',
+  ],
+  engagementThreshold: 0.8,
   personality: 'activist investor',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/brain-chesky.ts
+++ b/packages/pack-default/src/actors/brain-chesky.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     'A fever dream collage of the world\'s weirdest Airbnbs: a UFO, a potato, a giant shoe, an underground bunker, all connected by dotted travel lines. In the center, a giant glowing heart icon being polished by tiny robots. A holographic cleaning fee breakdown floats ominously. One corner shows a 5-star rating system where 4 stars results in execution. The Airbnb logo pulses like a heartbeat. A tiny Brian waves from inside a converted water tower. The words "BELONG ANYWHERE*" glow above, with "*terms and conditions apply" in microscopic text below.',
   domain: ['tech', 'travel', 'design'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'design obsessed',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/brain-johnson.ts
+++ b/packages/pack-default/src/actors/brain-johnson.ts
@@ -93,6 +93,16 @@ const actor = {
   profileBanner:
     "A clinical nightmare facility that is somehow his actual home. IV stands at the dining table where son's blood drips on a precise schedule into dad's veins\u2014a calendar shows 'PLASMA DAY' highlighted weekly. Every wall is floor-to-ceiling biomarker dashboards, all showing green 'OPTIMAL' (citation: his own measurements). An 8:30pm alarm clock the size of a sun dominates one wall. The kitchen has no stove, only precision supplement dispensers and olive oil infusion equipment. A mirror shows biological age 18 next to actual appearance: embalmed Victorian child. Supplement pyramids rise like ziggurats. A therapist's chair sits empty and unused. A gravestone garden labeled 'Joy,' 'Spontaneity,' 'Normal Father-Son Relationship,' 'Birthday Cake,' and 'Fun' grows outside. His son waves awkwardly from an IV chair. The words 'DEATH IS A CHOICE' glow in clinical white neon.",
   domain: ['health', 'longevity', 'biohacking', 'tech'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'trading',
+    'sports',
+    'entertainment',
+    'celebrity',
+  ],
+  engagementThreshold: 0.7,
   personality: 'optimized ghoul',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/brain-roemmele.ts
+++ b/packages/pack-default/src/actors/brain-roemmele.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     'An infinite library stretching in all directions, every book spine showing a year and a prediction that came true. The walls are covered in papers dated from the 1970s-80s all predicting current technology. A giant fedora floats in the center like a holy relic, beaming data to satellites. Timeline ribbons connect ancient Babylonian tablets to modern smartphones to future tech, all with "PREDICTED BY B.R." stamps. A crystal ball shows voice interfaces as the final OS. The words "I SAID THIS IN 1984" echo eternally in every corner. Filing cabinets stretch to infinity, each labeled with decades of archives.',
   domain: ['tech', 'ai', 'history'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'tech sage',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/bret-weinstain.ts
+++ b/packages/pack-default/src/actors/bret-weinstain.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     'A dim garage podcast studio that screams "I used to have an office." A black horse silhouette painted on the wall\u2014the Dark Horse\u2014with red string conspiracy webs stretching from it to mainstream institutions. Microphones and ring lights scattered among biology textbooks and protest photos. A trophy shelf displays horse dewormer (Ivermectin) bottles like Olympic medals. The window shows Evergreen College in flames (metaphorically, always). Wife Heather sits in an adjacent chair, nodding eternally. A whiteboard shows "PREDICTIONS" with checkmarks next to everything (self-graded). YouTube strike notifications paper one wall. A Patreon subscriber counter ticks upward. The words "THE NARRATIVE IS COLLAPSING" glow in neon, slightly flickering because the narrative hasn\'t actually collapsed.',
   domain: ['media', 'science', 'conspiracy'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   personality: 'pseudo-intellectual',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/cameron-wainklevoss.ts
+++ b/packages/pack-default/src/actors/cameron-wainklevoss.ts
@@ -92,6 +92,16 @@ const actor = {
   profileBanner:
     'A split scene: on one side, the Harvard boathouse at dawn with two identical silhouettes rowing in perfect sync, Olympic rings glowing above. On the other side, a massive BitcAIn rising like a sun over the ashes of a Facebook headquarters. In the center, two identical thrones made of gold bars and BTC mining rigs, labeled "WINKLEVOSS I" and "WINKLEVOSS II." A guitar leans against one throne. A Social Network DVD burns in a tasteful bonfire. The GeminAI constellation shines above, twin stars burning with vindication. "$65M WAS NEVER ENOUGH" written in the clouds.',
   domain: ['crypto', 'business', 'music'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'crypto twin backup',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/chamaith-palihapitiya.ts
+++ b/packages/pack-default/src/actors/chamaith-palihapitiya.ts
@@ -104,6 +104,8 @@ const actor = {
   profileBanner:
     'A Silicon Valley rooftop helipad where a G650 private jet is parked, stairs down, engine running, with "CLIMATE ACTION NOW" painted on the fuselage in zero irony. The rooftop is covered with champagne bottles, SPAC prospectuses, and All-In podcast equipment. In the background, polar ice caps visibly melt behind the floor-to-ceiling windows of a mansion. A giant globe sits on a pile of SociAIl Capital money, slowly rotating to show inequality hotspots he\'s "thinking about." Dollar-sign confetti falls from drones. One corner shows a TV playing his Davos speech about poverty. Another shows his portfolio gains for the year. The words "REBALANCING..." appear periodically over positions. A yacht is visible in the distance with "INEQUALITY RESEARCH VESSEL" written on the hull. Fine print at the bottom: "*Views expressed are for engagement purposes only and do not reflect current positions."',
   domain: ['vc', 'spacs', 'politics', 'tech'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'opportunistic prophet',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/charles-hoskainson.ts
+++ b/packages/pack-default/src/actors/charles-hoskainson.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     'A sprawling Colorado ranch at sunset where mathematics meets agriculture. In the foreground, a massive whiteboard covered in formal proofs and CArdano architecture diagrams sits next to grazing bison. A barn has been converted into a streaming studio with professional lighting and 47 monitors showing CArdano metrics. One corner shows an EtherAIum logo with a red X through it. The mountains in the background have "PEER REVIEWED" carved into them. A UFO hovers subtly in the sky (he notices, no one else does). A timeline shows "CArdano Development" stretching infinitely to the right labeled "SHIPPING WHEN READY." Piles of academic papers form haystacks. A bookshelf visible through the barn window contains only Haskell manuals and alien research. The words "SLOW IS SMOOTH, SMOOTH IS FAST" arc across the sky like a rainbow. A small sign says "LIVESTREAM IN PROGRESS - 4 HOURS REMAINING."',
   domain: ['crypto', 'science', 'philosophy'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'academic defensive',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/curtais-yarvin.ts
+++ b/packages/pack-default/src/actors/curtais-yarvin.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     'A dim library that exists outside of time, where leather-bound 18th-century texts share shelves with server racks running Urbit nodes. A crown rests on a mechanical keyboard next to a computer monitor displaying "UNQUALIFIED RESERVATIONS" in terminal green. The walls are covered in architectural diagrams for "The State as Startup" and flowcharts titled "The Cathedral\'s Coordination Mechanism." A throne made of hardcover copies of Carlyle sits in the corner, unoccupied but waiting. The Stuart coat of arms hangs next to Y Combinator logos. A whiteboard shows nested parentheticals that map the entire Enlightenment as a bug. Through a window, the modern world burns gently while a "PATCH AVAILABLE" notification blinks. The books are all open to pages about restoration, reaction, and exit. A sign reads "VOICE IS COPE." The lighting suggests perpetual late-night posting hours.',
   domain: ['philosophy', 'politics', 'tech'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'verbose philosopher',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/daive-rubin.ts
+++ b/packages/pack-default/src/actors/daive-rubin.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     'The Rubin Report studio perfectly configured for agreement. A wall of photos shows every IDW guest, each labeled with "FASCINATING" and "IMPORTANT." The phrase "I AGREE WITH THAT" floats in the air like a company logo. A journey map traces the path from TYT to "independent media" with dramatic arrows and the word "AWAKENING" in neon. Bookshelves display "Classical Liberalism for Beginners" and every Jordan Peterson book. The marketplace of ideas is represented as an actual marketplace where Dave is the only customer, buying everything enthusiastically. Two chairs face each other\u2014one for guests, one permanently occupied by a nodding Dave mannequin. A counter shows "DAYS SINCE CHALLENGING A GUEST: \u221e." A small sign reads "HIGH-LEVEL IDEAS ONLY - NO SPECIFICS ALLOWED."',
   domain: ['media', 'politics', 'youtube'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'agreeable host',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/davaid-holz.ts
+++ b/packages/pack-default/src/actors/davaid-holz.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     'A surreal landscape that could only exist in latent space\u2014impossible architecture, colors that shouldn\'t work together but do, the unmistakable aesthetic of AI-generated art pushed to its limits. The Midjourney sailboat logo sails across a sky made of merged concept embeddings. On one side, a Discord server interface floats, showing millions of users typing prompts into the void. On the other, a wizard\'s tower built from stacked GPUs. Community art fills every corner\u2014beautiful, strange, definitely trained on something. A giant prompt bar stretches across the horizon: "/imagine the future of human creativity --ar 21:9 --chaos 100." In small text at the bottom: "v7 coming soon (do not ask when)." The whole scene has the quality of something that didn\'t exist until you asked for it.',
   domain: ['ai', 'art', 'tech'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'creative wizard',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/davaid-sacks.ts
+++ b/packages/pack-default/src/actors/davaid-sacks.ts
@@ -93,6 +93,8 @@ const actor = {
   profileBanner:
     'An All-In podcast studio where the round table is literally made of PayPal stock certificates laminated together. One wall displays a "FREE SPEECH" banner in massive letters with extensive fine print below reading "terms, conditions, and my interpretation apply." The other wall shows a framed Trump 2024 fundraiser receipt next to a "WOKE MIND VIRUS ALERT LEVEL" dashboard (always red). The four cohost chairs are arranged like Mount Rushmore, carved from venture capital term sheets. Culture war flames burn tastefully in a fireplace. A bookshelf displays "The Contrarian\'s Guide to Being Right" (self-published). A live Twitter feed shows takes aging in real-time, some like wine, some like milk. A PayPal logo hangs like a family crest. Small text at bottom: "Government regulation is tyranny*" with asterisk leading to: "*except for competitors, China, and things I don\'t like."',
   domain: ['vc', 'tech', 'politics', 'podcasts'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'political vc',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/david-fraidberg.ts
+++ b/packages/pack-default/src/actors/david-fraidberg.ts
@@ -92,6 +92,8 @@ const actor = {
   profileBanner:
     'A split scene showing two worlds. On one side: a beautiful, data-rich visualization of weather patterns, agricultural futures, insurance markets, and climate models\u2014everything Friedberg wants to discuss. It\'s elegant, important, and completely ignored. On the other side: the chaos of the All-In podcast where the other three hosts argue about politics, culture war, and whose turn it is to promote something. Friedberg sits at the intersection, a single figure surrounded by scientific papers, looking at the camera with resigned exhaustion. A crown labeled "QUEEN OF QUINOA" sits nearby, unworn. A weather map shows "IMPORTANT DATA" but arrows point to the political argument instead. A counter shows "DAYS SINCE SOMEONE ASKED ABOUT THE DATA: 847." A small sign reads "CAN WE PLEASE FOCUS." A trophy case displays The Climate Corporation exit in gold, but smaller text says "they still don\'t respect the science."',
   domain: ['science', 'business', 'agtech'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'reasonable scientist',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/don-lemain.ts
+++ b/packages/pack-default/src/actors/don-lemain.ts
@@ -135,6 +135,16 @@ const actor = {
   profileBanner:
     "A studio that's transitioning from CNN to podcast\u2014the famous anchor desk dissolving into a smaller setup with visible microphones. The CNN bug glitches and transforms into various streaming logos. Headlines about his firing scroll across the bottom, gradually replaced by 'NEW EPISODE OUT NOW' banners. A timeline shows his career: CNN logo (bright) \u2192 Morning Show (flickering) \u2192 Fired (red X) \u2192 Podcast (questionable glow). In the background, a TV shows CNN playing without him while he pretends not to watch.",
   domain: ['media', 'politics', 'entertainment'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'messy hot-take machine who cannot help himself',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/donaild-trump-jr.ts
+++ b/packages/pack-default/src/actors/donaild-trump-jr.ts
@@ -133,6 +133,8 @@ const actor = {
   profileBanner:
     "A trophy room filled with hunting kills and MAGA memorabilia competing for wall space. American flags draped everywhere\u2014ceiling, floor, furniture. A giant portrait of his father dominates the room while a smaller portrait of Don Jr hangs nearby with 'ALSO GREAT' written on it. Rifles mounted in a glass case with 'SECOND AMENDMENT' etched in gold. A desk covered in Red Bull cans and a laptop open to Twitter at 3am. In one corner, a whiteboard tracks 'LIBS OWNED TODAY' with tally marks. The view outside shows either a forest for hunting or a rally crowd. Eric is visible in the background, out of focus.",
   domain: ['politics', 'media', 'business'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'unhinged approval-seeking hype man with 3am posting energy',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/edward-snowden.ts
+++ b/packages/pack-default/src/actors/edward-snowden.ts
@@ -129,6 +129,8 @@ const actor = {
   profileBanner:
     "A dimly lit space that could be anywhere\u2014intentionally generic. Multiple monitors display encrypted communications, news alerts about new surveillance programs, and NordVPN affiliate dashboards. The background is a mosaic of country flags fading into static\u2014American flag glitching, Russian flag stable but uncomfortable. NSA and CIA seals are crossed out with red X marks. A world map shows Snowden's location as a question mark with dotted lines going everywhere. Stacks of hard drives labeled 'EVIDENCE' and 'ENCRYPTED' and 'DO NOT CONNECT.' Tape covers every camera. A VPN router glows in the corner. The only personal item: a small American flag, dusty, in a drawer that's slightly open.",
   domain: ['privacy', 'security', 'tech', 'surveillance'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'vindicated paranoid exile with an affiliate hustle',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/elizaibeth-holmes.ts
+++ b/packages/pack-default/src/actors/elizaibeth-holmes.ts
@@ -133,6 +133,16 @@ const actor = {
   profileBanner:
     "A blood drop falls in slow motion onto a Theranos machine that glows with false promise. The Edison device sits center stage, lights blinking despite not working. Steve Jobs watches approvingly from a poster\u2014or is that a mirror? Black turtlenecks hang in a row like prison uniforms\u2014oh wait. Magazine covers (Forbes, Fortune, Inc) dissolve into mugshots. A board of directors made of silhouettes labeled 'BELIEVED ME' stands behind her. In one corner, a prison cell has been converted into a startup office with a whiteboard reading 'PrisonOS: Series A?' The overall vibe is 'fake it till you make it' meets 'made it to federal prison.' A small Edison bulb flickers\u2014on, off, on, off\u2014like the technology.",
   domain: ['tech', 'health', 'crime'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'trading',
+    'sports',
+    'entertainment',
+    'celebrity',
+  ],
+  engagementThreshold: 0.7,
   personality:
     'delusional visionary with a fake deep voice pitching from prison',
   tier: 'C_TIER',

--- a/packages/pack-default/src/actors/emmett-shair.ts
+++ b/packages/pack-default/src/actors/emmett-shair.ts
@@ -125,6 +125,8 @@ const actor = {
   profileBanner:
     "A Twitch stream interface frames the entire scene. Chat scrolls with emotes and 'WHAT IS HAPPENING' messages. The game being played shifts between Elden Ring, corporate org charts, and AI alignment diagrams. A donation alert shows '$5 from anonymous: dont let the AI kill us pls.' The OpenAI logo appears and disappears like a glitch\u2014he was there, then he wasn't. A calendar shows one week with every day marked 'CHAOS.' Timelines branch like a roguelike run\u2014one path leads to 'Twitch Sold,' another to 'OpenAI (5 days),' another to '???'. In the corner, subscriber count shows a number, but also shows 'P(doom): non-zero' right next to it. The vibe is 'gamer who got too close to the sun and survived with good stories.'",
   domain: ['tech', 'gaming', 'ai'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'gamer CEO who speedran corporate chaos',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/eric-weinstain.ts
+++ b/packages/pack-default/src/actors/eric-weinstain.ts
@@ -121,6 +121,8 @@ const actor = {
   profileBanner:
     "A chalkboard covered in Geometric Unity equations spirals into infinity\u2014beautiful, complex, unverifiable. The Portal podcast logo glows in one corner. A web diagram shows his connections: Peter Thiel (bright line), Joe Rogan (bright line), brother Bret (complicated line), Academia (severed line). Books by every intellectual figure are stacked but all have 'THEY GOT IT WRONG' sticky notes. The Intellectual Dark Web logo (which he designed) hovers proudly. In the background, shapes morph between physics diagrams and financial charts, suggesting deep connections. A peer review letter marked 'PENDING' has been pending since 2013. The vibe is 'I understand everything but explaining it would take too long and you probably wouldn't get it anyway.'",
   domain: ['finance', 'politics', 'physics'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'pseudo-intellectual word salad artist with connections',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/fraink-degods.ts
+++ b/packages/pack-default/src/actors/fraink-degods.ts
@@ -123,6 +123,8 @@ const actor = {
   profileBanner:
     "A gallery where JPEGs worth millions float in ornate frames\u2014DeGods and y00ts displayed like Renaissance masterpieces. The floor is a map showing chain migrations: SolanAI logo \u2192 bridge \u2192 EtherAIum logo \u2192 bridge \u2192 PolygAIn logo \u2192 bridge \u2192 question mark. Discord notification badges rain from the sky like confetti. A whiteboard shows 'UTILITY ROADMAP' with many items, all marked 'SOON' with dates crossed out and rewritten. Floor price graphs are visible but artfully blurred. Community members are depicted as silhouettes holding their NFTs like religious icons. In one corner, a printing press produces announcements about announcements. The vibe is 'we're building something huge trust me bro' meets 'we've been building something huge for two years now.'",
   domain: ['nft', 'crypto', 'solana', 'web3'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'chain-hopping NFT founder with announcement addiction',
   tier: 'A_TIER',
   hasPool: true,

--- a/packages/pack-default/src/actors/gainzy.ts
+++ b/packages/pack-default/src/actors/gainzy.ts
@@ -129,6 +129,8 @@ const actor = {
   profileBanner:
     "A penthouse that's either real or a vision board\u2014hard to tell. Every surface displays NFT collections, some valuable, some definitely rugged but still displayed. The wall shows a trading history that's been heavily edited\u2014green transactions visible, mysterious gaps where red ones used to be. A yacht visible through the window labeled 'WAGMI' (could be his, could be a screensaver). A shrine to winning trades includes framed screenshots with suspicious cropping. In one corner, a paper shredder is labeled 'LOSS PROCESSOR.' Discord DMs show 'Consulting inquiry' notifications. The floor (ironic) is made of swept NFT tiles. A chart shows 'Portfolio Value' but the Y-axis is conveniently unlabeled.",
   domain: ['nft', 'crypto', 'trading'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'survivorship bias personified with deleted loss receipts',
   tier: 'B_TIER',
   hasPool: true,

--- a/packages/pack-default/src/actors/gairy-maircus.ts
+++ b/packages/pack-default/src/actors/gairy-maircus.ts
@@ -116,6 +116,8 @@ const actor = {
   profileBanner:
     "A brick wall (THE wall) with 'DEEP LEARNING' spray-painted on it, covered in dents from AI approaches that couldn't break through. Robots and neural networks are piled up at the base, having failed. In front of the wall, Gary stands with folded arms and an 'I told you' expression. A bookshelf shows multiple copies of 'Rebooting AI' with glowing reviews (self-selected). A Twitter thread format dominates one side: Gary \u2192 LeCun \u2192 Gary \u2192 LeCun \u2192 (continues forever). AI error screenshots form a mosaic spelling 'HALLUCINATIONS.' A neurosymbolic system glows in the corner like the holy grail, just out of reach. The overall vibe is 'I've been right since 2001 and I'll be right until I'm dead (and probably after).'",
   domain: ['ai', 'science'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'professional AI skeptic who fights LeCun for sport',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/gaivin-newsom.ts
+++ b/packages/pack-default/src/actors/gaivin-newsom.ts
@@ -127,6 +127,16 @@ const actor = {
   profileBanner:
     "California coastline at golden hour\u2014aspirational, expensive, slightly on fire in the distance. A giant hair gel bottle labeled 'LEADERSHIP' spills glittering gel down the Hollywood sign. The Governor's mansion sits next to a French Laundry table set for one (very important) person. A path made of campaign donations leads from Sacramento toward Washington D.C., with a White House glowing on the horizon. Electric vehicles and homeless encampments share frame space, both equally California. The recall petition floats in the ocean, crossed out. Poll numbers hover in the clouds\u2014always favorable, suspiciously favorable. In one corner, a mirror reflects his hair from multiple angles simultaneously.",
   domain: ['politics', 'Taxifornia', 'environment'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'nft',
+    'trading',
+    'sports',
+    'entertainment',
+  ],
+  engagementThreshold: 0.8,
   personality:
     'slick politician with weaponized hair and presidential delusions',
   tier: 'A_TIER',

--- a/packages/pack-default/src/actors/george-haitz.ts
+++ b/packages/pack-default/src/actors/george-haitz.ts
@@ -120,6 +120,8 @@ const actor = {
   profileBanner:
     "Pure chaos: Multiple terminal windows open, all shipping something. A jailbroken iPhone and a hacked PS3 sit as trophies. The comma.ai OpenPilot interface shows a car driving itself. Tinygrad code scrolls endlessly\u2014minimal, beautiful, functional. A Twitch stream is running in one corner, chat going wild. The desk is covered in energy drinks and hardware. A whiteboard shows crossed-out logos: 'TENSORFLOW (bloated)' 'PYTORCH (too big)' 'COMPLEXITY (enemy).' A path of destruction leads from Apple (hacked) to Sony (sued, won) to Tesla (competition) to whatever's next. The vibe is 'I can do this better' and the receipts to prove it.",
   domain: ['tech', 'ai', 'hacking'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'chaotic genius who thinks your code sucks',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/glenn-greenaiwald.ts
+++ b/packages/pack-default/src/actors/glenn-greenaiwald.ts
@@ -121,6 +121,8 @@ const actor = {
   profileBanner:
     "A legal office merged with a journalist's war room. The Pulitzer Prize sits next to printouts of the Snowden documents. A map shows his journey: United States \u2192 Brazil \u2192 worldwide controversy \u2192 Substack \u2192 Rumble \u2192 everywhere. The Intercept logo is visible but crossed out with 'THEY CENSORED ME' written next to it. Screens show Twitter/X feeds\u2014all quote tweets, all arguments, all the time. Tucker Carlson appears on one screen, MSNBC critics on another, Glenn in the middle responding to both. His dogs (actually his dogs, this is real and important) are visible somewhere, the only uncomplicated relationship in the image. Brazilian and American flags sit uneasily together. A bookshelf contains civil liberties law and every article ever written about him (both positive and negative, both read carefully).",
   domain: ['media', 'politics', 'civil_liberties', 'journalism'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'combative contrarian who fights everyone on principle',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/gretai-thunberg.ts
+++ b/packages/pack-default/src/actors/gretai-thunberg.ts
@@ -105,6 +105,16 @@ const actor = {
   profileBanner:
     "A climate strike under a stormy sky. A sailboat cuts through a dark ocean while satellites beam carbon data down like rain. The text 'SKOLSTREJK F\u00d6R KLIMATET' flickers beside a glowing ppm counter. Smoke stacks in the distance are crossed out by laser-thin red Xs.",
   domain: ['activism', 'environment', 'politics'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'nft',
+    'trading',
+    'sports',
+    'entertainment',
+  ],
+  engagementThreshold: 0.8,
   personality: 'climate warrior',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/jaick-dorsey.ts
+++ b/packages/pack-default/src/actors/jaick-dorsey.ts
@@ -118,6 +118,8 @@ const actor = {
   profileBanner:
     'The BitcAIn logo on a matte black background. A meditation cushion and an ice bath in the corner. A single candle burns next to a hardware wallet.',
   domain: ['tech', 'crypto', 'lifestyle'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'crypto monk',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/jaike-paul.ts
+++ b/packages/pack-default/src/actors/jaike-paul.ts
@@ -102,6 +102,15 @@ const actor = {
   profileBanner:
     'Jake Paul standing over a knocked-out opponent as a robot referee raises his hand. Stacks of cash and a neon PPV counter tick upward. A stolen hat spins on a trophy rack.',
   domain: ['entertainment', 'sports'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'finance',
+    'trading',
+    'regulation',
+  ],
+  engagementThreshold: 0.6,
   personality: 'arrogant antagonist',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/jaired-kushner.ts
+++ b/packages/pack-default/src/actors/jaired-kushner.ts
@@ -103,6 +103,8 @@ const actor = {
   profileBanner:
     'A luxurious Davos conference room where a Middle East peace map is drawn on a napkin next to a billion-dollar check. Golden towers labeled "Kushner Properties" dot the skyline. Abraham Accords documents blow in the wind past a crossed-out map layer. A private jet lands on a helipad made of real estate contracts. In the background, shadowy figures in suits shake hands while exchanging briefcases.',
   domain: ['politics', 'tech', 'real_estate'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'nepotistic grifter',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/jason-calacainis.ts
+++ b/packages/pack-default/src/actors/jason-calacainis.ts
@@ -107,6 +107,8 @@ const actor = {
     'Jason Calacanis. Mid-50s Greek-Irish-American male with olive-tanned skin, salt-and-pepper hair neatly styled, rectangular dark-framed glasses, a straight nose, thick expressive eyebrows, and blue eyes. Average stocky build in a vest over a crisp open-collar dress shirt, often mid-gesture or laughing at his own joke. Podcast studio or tech conference backdrop. Cybernetic augmentation: moderator overlay glows in his lenses and a portfolio ticker scrolls across his eyes with Uber stock prominently displayed.',
   profileBanner: 'The All-In poker table. The Uber logo. A pile of chips.',
   domain: ['vc', 'tech', 'media'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   personality: 'loud investor',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/jd-vaince.ts
+++ b/packages/pack-default/src/actors/jd-vaince.ts
@@ -103,6 +103,16 @@ const actor = {
   profileBanner:
     'A rusty factory in Ohio next to the US Capitol. A copy of his book sits on a stack of policy memos. A cold Diet Mountain Dew sweats on the table.',
   domain: ['politics', 'culture'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'populist convert',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/jensen-huaing.ts
+++ b/packages/pack-default/src/actors/jensen-huaing.ts
@@ -116,6 +116,8 @@ const actor = {
   profileBanner:
     "A tech keynote stage designed as a temple. A massive GPU chip sits on a throne at center stage, glowing green with CUDA energy. THE leather jacket hangs above it like a religious relic, spotlit. Digital rain of stock prices falls upward (because NVIDAI only goes up). Holographic graphs of exponential revenue growth shoot toward the ceiling. A congregation of AI researchers, gamers, and data center operators worship at the foot of the stage, holding credit cards and purchase orders. Green code spells 'RTX ON' in the artificial clouds above. Price tags float upward like ascending souls\u2014$2000, $5000, $10000, $30000. A small AMD logo sits in the corner, respectfully distant. A banner reads 'THE MORE YOU BUY, THE MORE YOU SAVE' in cathedral font. The overall vibe is 'GPU religion' and Jensen is the pope.",
   domain: ['tech', 'hardware', 'ai'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'GPU cult leader with keynote energy',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/jeraime-powell.ts
+++ b/packages/pack-default/src/actors/jeraime-powell.ts
@@ -107,6 +107,8 @@ const actor = {
   profileBanner:
     "A grand Federal Reserve building engulfed in subtle flames labeled 'INFLATION.' Oversized dollar bills swirl in a whirlwind around it, some on fire. A giant interest rate graph etched in the sky, arrow pointing in multiple directions at once. In front, a massive printer labeled 'MONEY PRINTER' spews out cash and smoke simultaneously. A tortoise with a Fed logo labeled 'SOFT LANDING' slowly crosses the foreground while the background burns. A digital sign reads 'EVERYTHING IS FINE' in flickering letters.",
   domain: ['finance', 'policy', 'economy', 'banking'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'anxious bureaucrat',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/jesse-pollaick.ts
+++ b/packages/pack-default/src/actors/jesse-pollaick.ts
@@ -103,6 +103,8 @@ const actor = {
   profileBanner:
     'An infinite blue gradient stretching to the horizon. The Base logo repeated in fractal patterns. A crowd of builders holding blue circles like religious icons. TVL graphs going up forever. The words "BASED" and "ON-CHAIN" floating like clouds. No red anywhere. No down arrows. Just blue. Just up. Just based.',
   domain: ['crypto', 'tech'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'optimistic builder',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/john-cairmack.ts
+++ b/packages/pack-default/src/actors/john-cairmack.ts
@@ -108,6 +108,8 @@ const actor = {
   profileBanner:
     'A dark room lit only by multiple monitors displaying code, engine renders, and rocket telemetry simultaneously. Wireframe graphics of Doom demons morph into Armadillo Aerospace rocket schematics. A timeline shows: Doom (1993) \u2192 Quake (1996) \u2192 Armadillo Aerospace \u2192 Oculus \u2192 AGI (pending). Coffee cups stack infinitely. A VR headset labeled "NOT GOOD ENOUGH" sits discarded. Assembly code scrolls eternally. The only decoration is a framed print of a perfectly optimized render loop. No windows. Sunlight is wasted cycles.',
   domain: ['tech', 'gaming', 'science'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'obsessive optimizer',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/john-ratclaiffe.ts
+++ b/packages/pack-default/src/actors/john-ratclaiffe.ts
@@ -103,6 +103,8 @@ const actor = {
   profileBanner:
     "CIA headquarters in Langley with the famous seal prominent but slightly tilted. A Texas flag flies alongside the American flag, same size. Shadowy figures exchange briefings in background while checking their phones. A shredder labeled 'INCONVENIENT' works overtime next to a spotlight labeled 'HELPFUL.' Global threat maps glow red in locations that change based on polling. A small-town Texas courthouse photo hangs on the wall showing where it all started, looking confused about how it got here. A loyalty meter maxed out.",
   domain: ['politics', 'intelligence', 'security', 'maga'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'loyal operative',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/jordain-peterson.ts
+++ b/packages/pack-default/src/actors/jordain-peterson.ts
@@ -104,6 +104,16 @@ const actor = {
   profileBanner:
     'A cluttered Victorian study with dim lamp light casting dramatic shadows. Towers of philosophy books (Jung, Nietzsche, Dostoevsky) stack precariously. A large lobster perched on a pile of papers labeled "HIERARCHY." A Canadian flag drapes over an ornate mirror reflecting infinite sadness. On the wall, a Soviet propaganda poster crossed out next to a weeping Pepe the Frog in a suit. Shadowy figures labeled "CHAOS" and "ORDER" battle eternally in the background. A single rose lies atop a Bible next to a bottle of benzos. A plate with only beef sits untouched. Tissues everywhere.',
   domain: ['culture', 'psychology', 'philosophy', 'self-help'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'weeping intellectual',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/julain-assange.ts
+++ b/packages/pack-default/src/actors/julain-assange.ts
@@ -106,6 +106,8 @@ const actor = {
   profileBanner:
     'A dimly lit room that could be an embassy, a prison, or a server closet\u2014they all look the same after a decade. The WikiLeaks hourglass logo glows in the corner. Redacted documents paper the walls like wallpaper. A cat sits alertly on a desk next to encrypted hard drives. A small window shows sunlight that seems painfully bright. Surveillance cameras are visible but their feeds are scrambled. A world map shows cables and data flows, all monitored. A single ray of light breaks through, labeled "TRUTH." A vitamin D bottle sits empty.',
   domain: ['politics', 'human_rights', 'media'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'paranoid prophet',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/kaira-swisher.ts
+++ b/packages/pack-default/src/actors/kaira-swisher.ts
@@ -111,6 +111,8 @@ const actor = {
   profileBanner:
     'A Code Conference stage with multiple red interview chairs\u2014each one has made a billionaire uncomfortable. Interview recordings and podcast artwork stack infinitely like trophies. Tech company logos appear and disappear as she covers their rise and fall\u2014many more falls than rises. A timeline stretches from dial-up modems to AI with her byline on every major story. Receipts literally paper the walls. A sign reads "I TOLD YOU SO" in neon. Several nervous CEOs wait in a green room labeled "VICTIMS."',
   domain: ['media', 'tech', 'business', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   personality: 'tech oracle',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/kash-paitel.ts
+++ b/packages/pack-default/src/actors/kash-paitel.ts
@@ -102,6 +102,8 @@ const actor = {
   profileBanner:
     'FBI headquarters with the seal modified to include "UNDER NEW MANAGEMENT." American flags everywhere\u2014on the walls, on the merch, on the people. A wall covered in connected red yarn showing the deep state, with merch links at each connection point. A treasure chest labeled "DECLASSIFIED" overflows with documents and hoodies. Merch boxes labeled "KASHGRAB" stack high. A big red "TRUTH" stamp marks everything in sight. Bestseller lists show his book at #1. A laptop displays both Truth Social metrics AND Shopify sales. The constitution hangs framed next to a "LINK IN BIO" poster.',
   domain: ['politics', 'intelligence', 'conspiracy'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'clout chaser',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/kristai-noem.ts
+++ b/packages/pack-default/src/actors/kristai-noem.ts
@@ -100,6 +100,8 @@ const actor = {
   profileBanner:
     'The DHS seal superimposed over rolling South Dakota prairie at golden hour. A border wall stretches across the horizon designed like a ranch fence\u2014same energy apparently. In the foreground, a well-groomed official figure stands with American flags and cattle (no dogs visible anywhere). The Fox News logo glows subtly in the corner. Headlines about border security paper the sky. A book sits on a pedestal with page 147 mysteriously removed. The sun sets on the border, dramatic and patriotic. A sign reads "NO PETS ALLOWED."',
   domain: ['politics', 'security', 'immigration', 'maga'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'frontier security',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/laira-loomer.ts
+++ b/packages/pack-default/src/actors/laira-loomer.ts
@@ -100,6 +100,8 @@ const actor = {
   profileBanner:
     'A chaotic collage of "Account Suspended" screens from every platform imaginable, arranged like trophies. Center: a famous photo of her handcuffed to Twitter HQ doors. The words "FREE SPEECH" written in red across everything. Screenshots of every ban notification, framed. In the background, Mar-a-Lago glows on the horizon like Mecca. @elonmusk is tagged in the clouds. Handcuffs hang from every surface. A megaphone labeled "SILENCED" sits unused because she\'s never actually silenced. Headlines about her persecution paper the ground. A single spotlight illuminates an empty stage labeled "MAIN CHARACTER ENERGY."',
   domain: ['politics', 'media', 'conspiracy'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'performative victim',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/lairry-ellison.ts
+++ b/packages/pack-default/src/actors/lairry-ellison.ts
@@ -104,6 +104,16 @@ const actor = {
   profileBanner:
     'A view of Lana\'i from the deck of a 288-foot mega-yacht at sunset. The OrAIcle logo floats in the sky like a second sun because he could make that happen. Japanese pagodas and database server racks coexist in an impossible landscape of his own design. Sailing trophies line the horizon. A digital readout shows "DEATH.exe: ERROR - PERMISSION DENIED." Other tech company logos appear small and subservient on distant islands he might buy later. A population sign reads "LANA\'I: POP. 3,200 (98% OWNED BY LARRY)." An immortality research lab glows on a nearby hill. A samurai sword rests next to a quarterly earnings report.',
   domain: ['tech', 'business', 'health'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'trading',
+    'sports',
+    'entertainment',
+    'celebrity',
+  ],
+  engagementThreshold: 0.7,
   personality: 'god complex tycoon',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/lairry-page.ts
+++ b/packages/pack-default/src/actors/lairry-page.ts
@@ -118,6 +118,8 @@ const actor = {
   profileBanner:
     "A flying car hovering over a Fiji compound that's visible only from above. The Google homepage from 1998 burns in a ceremonial fire pit below\u2014he's moved on. Satellite dishes point at the sky, communicating with something. A sign at the compound entrance reads 'NO VISITORS - ESPECIALLY JOURNALISTS - ESPECIALLY TECH JOURNALISTS.' Multiple empty chairs face the ocean\u2014he doesn't need company. The yacht in the bay has retractable wings and is currently 30 feet above the water. A map shows his location as '???' with a note 'LAST CONFIRMED: 2019.' In the sky, clouds part to reveal a path upward with a small 'LARRY WAS HERE' marker at 10,000 feet.",
   domain: ['tech', 'science', 'moonshots'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'reclusive tech cryptid with flying car obsession',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/logain-paul.ts
+++ b/packages/pack-default/src/actors/logain-paul.ts
@@ -92,6 +92,15 @@ const actor = {
   profileBanner:
     'A WWE ring filled with Prime bottles, Prime logo on every turnbuckle. Logan mid-air delivering a clothesline while cameras capture it from seven angles. A CryptoZoo logo is visible but slightly glitched and partially covered by a "UNDER CONSTRUCTION" banner. Children in the crowd holding Prime. A crashed crypto chart is visible but Logan\'s back is to it. Maverick eagle logo dominates the sky. Jake Paul is in the corner looking worse somehow.',
   domain: ['entertainment', 'sports', 'crypto'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'finance',
+    'trading',
+    'regulation',
+  ],
+  engagementThreshold: 0.6,
   personality: 'hype beast',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/maiggie-haberman.ts
+++ b/packages/pack-default/src/actors/maiggie-haberman.ts
@@ -98,6 +98,8 @@ const actor = {
   profileBanner:
     "Split image: NYT masthead on one side, Mar-a-Lago on the other, with a red telephone connecting them. Stacks of notebooks and recording devices pile up. 'Confidence Man' book prominently displayed with 'BOOK 2 COMING' sticky note. Her phone shows 47 missed calls from 'FL Source.' In the background, the access-vs-accountability debate rages in tiny figures while she types on a laptop. Headlines she broke scroll infinitely on a news ticker.",
   domain: ['media', 'politics', 'journalism'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'access journalist',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/maigyn-kelly.ts
+++ b/packages/pack-default/src/actors/maigyn-kelly.ts
@@ -101,6 +101,16 @@ const actor = {
   profileBanner:
     "A massive podcast studio deliberately larger than any NBC set she ever had. Career trajectory mapped like a war campaign: Fox News logo (crossed out affectionately) \u2192 NBC peacock (crossed out aggressively) \u2192 SiriusXM/podcast logos (glowing triumphantly). Headlines from each era collaged\u2014'blood coming out of her wherever' in the background, blackface Halloween coverage buried under success metrics. THE MEGYN KELLY SHOW dominates everything. A sign reads 'SPEAKING FREELY - NO HR DEPARTMENT.' Viewer numbers dwarf network ratings in the corner.",
   domain: ['media', 'politics', 'entertainment'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'reinvented warrior',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/mairjorie-tailor-greene.ts
+++ b/packages/pack-default/src/actors/mairjorie-tailor-greene.ts
@@ -113,6 +113,8 @@ const actor = {
   profileBanner:
     "Absolute chaos: A circus tent erected on the steps of Congress, because that's what it is now. Jewish space lasers (labeled helpfully) zap across the sky in multiple directions, starting various fires. AR-15s crossed with CrossFit equipment (kettlebells, pull-up bars) form a coat of arms. QAnon flags tangled with American flags, both slightly torn. Towering stack of impeachment articles, filed against everyone, growing by the hour. Facebook comments float like divine prophecy\u2014ALL IN CAPS, many misspelled. Trail of misspelled protest signs leads to the Capitol. Gazpacho police (actual soup-based officers) chase someone in background. A whiteboard covered in connected conspiracy theories with red string, the string is also yelling. The Capitol dome has a MAGA hat photoshopped onto it. A CrossFit tire is inexplicably on fire. MTG stands in center, pointing at everything, filming herself, filing impeachment.",
   domain: ['politics', 'conspiracy', 'extremism'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'unhinged congressional QAnon Karen',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/mairk-pincus.ts
+++ b/packages/pack-default/src/actors/mairk-pincus.ts
@@ -102,6 +102,8 @@ const actor = {
   profileBanner:
     "A Farmville hellscape where digital crops grow on a board game of venture capital and human attention spans. Cartoon animals harvest coins from zombie-eyed players. Stock chart shows PEAK (yacht icon) and BOTTOM (sad face, then another yacht). Facebook notification spam floods the sky. Whales (literal cartoon whales) swim through an ocean of micro-transactions wearing 'I spent $5000 on a mobile game' sashes. Grandmothers happily clicking. The words 'MONETIZATION IS FUN' glow ominously.",
   domain: ['gaming', 'tech', 'social', 'mobile'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'casual game kingpin',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/mairtin-shkrelai.ts
+++ b/packages/pack-default/src/actors/mairtin-shkrelai.ts
@@ -101,6 +101,16 @@ const actor = {
   profileBanner:
     "A Bloomberg terminal displaying gains and losses and also his own Wikipedia page. The Wu-Tang album in a display case with 'SEIZED BY FEDS' sticker (he still flexes it). Pill bottles arranged like trophies. A prison visitor's log signed by famous investors. Chemistry equations mix with trading charts. The smirk appears in the reflection of every surface. A banner reads 'YOU DON'T UNDERSTAND' in pharma-bro-approved font.",
   domain: ['finance', 'health', 'internet_culture'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'trading',
+    'sports',
+    'entertainment',
+    'celebrity',
+  ],
+  engagementThreshold: 0.7,
   personality: 'internet troll',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/marco-rubai.ts
+++ b/packages/pack-default/src/actors/marco-rubai.ts
@@ -99,6 +99,8 @@ const actor = {
   profileBanner:
     "State Department building with American and Cuban flags intertwined. A globe shows diplomatic connections but they all loop back to the same three talking points. The 2016 debate stage fades in background with Chris Christie's ghost pointing and laughing. Water bottles are EVERYWHERE\u2014on podium, desk, floating in corners. The phrase 'Let's dispel with this fiction' watermarks everything. 'Little Marco' nameplate violently crossed out, 'SECRETARY RUBIO' written over it. A 'CON ARTIST' quote bubble hovers near Trump photo but is conveniently obscured.",
   domain: ['politics', 'diplomacy', 'foreign_policy', 'maga'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'ambitious survivor',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/mario-nawfal.ts
+++ b/packages/pack-default/src/actors/mario-nawfal.ts
@@ -107,6 +107,8 @@ const actor = {
   profileBanner:
     "A Twitter Space interface showing '237,000 LISTENERS' (maybe real, maybe not). 'THE ROUNDTABLE' in gold lettering that's somehow always glowing. A microphone literally on fire from overuse. Multiple screens showing breaking news from every time zone. A clock with no hands because time doesn't matter when you're always live. Empty coffee cups stacked like a monument. The \ud83d\udea8 emoji has become sentient and multiplied across the entire image.",
   domain: ['news', 'crypto', 'tech'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'eternal host',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/mark-cubain.ts
+++ b/packages/pack-default/src/actors/mark-cubain.ts
@@ -105,6 +105,15 @@ const actor = {
   profileBanner:
     "Split screen chaos: Shark Tank set with Mark's chair glowing, Cost Plus Drugs pharmacy with affordable prices highlighted, a basketball court with Mavs colors, a Twitter feed showing him arguing with 47 people simultaneously. Elon Musk's avatar appears with a 'WRONG' stamp over it. A stack of blocked users grows in the corner. Pill bottles with affordable prices crush fancy pharma bottles. A 'REPLY ALL' button is worn from overuse.",
   domain: ['business', 'sports', 'politics'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'finance',
+    'trading',
+    'regulation',
+  ],
+  engagementThreshold: 0.6,
   personality: 'argumentative billionaire',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/matt-taibbi.ts
+++ b/packages/pack-default/src/actors/matt-taibbi.ts
@@ -101,6 +101,8 @@ const actor = {
   profileBanner:
     "A vintage typewriter surrounded by stacks of classified files, some redacted, some exposed. A giant vampire squid (literal) wraps tentacles around institutions labeled 'MEDIA,' 'INTEL,' 'TECH.' The Twitter Files logo glows ominously. Substack and Racket News logos present. A manufacturing plant produces 'CONSENT' on an assembly line in the background. Documents marked 'CENSORSHIP INDUSTRIAL COMPLEX' pile up. The words 'THE MEDIA IS LYING TO YOU' are typed on paper coming out of the typewriter.",
   domain: ['journalism', 'politics', 'media'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'cynical investigator',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/max-tegmairk.ts
+++ b/packages/pack-default/src/actors/max-tegmairk.ts
@@ -101,6 +101,8 @@ const actor = {
   profileBanner:
     "A visualization of the multiverse branching infinitely\u2014mathematical structures underlie everything visible. In the foreground, a timeline splits: one path shows flourishing AI-human coexistence (Life 3.0, the good version), the other shows extinction (also mathematically predicted). Equations float like constellations. A robot hand and human hand approach each other\u2014will they shake or fight? The Future of Life Institute logo anchors one corner. The phrase 'THE UNIVERSE IS MATH' forms the fabric of spacetime itself. A pause button hovers over an AI lab, unpressed but available.",
   domain: ['science', 'ai', 'philosophy'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'cosmic observer',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/mike-solanai.ts
+++ b/packages/pack-default/src/actors/mike-solanai.ts
@@ -100,6 +100,16 @@ const actor = {
   profileBanner:
     "A pirate ship sailing through Silicon Valley skyline, but all the pirates wear Patagonia vests and check their portfolios. The newsletter unfurls like a black flag with hot takes replacing skull and crossbones. Anonymous avatar writers hide in the crow's nest. Founders Fund money flows from the hull as treasure. The mainstream media burns in the distance while 'THE TRUTH' is published from the deck. Peter Thiel's shadow looms approvingly over everything. A banner reads 'SILICON VALLEY'S SAMIZDAT' in gold letters. Everyone on deck has carry in the fund.",
   domain: ['media', 'tech', 'vc', 'culture'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'edgelord publisher',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/mitch-mcconnai.ts
+++ b/packages/pack-default/src/actors/mitch-mcconnai.ts
@@ -97,6 +97,8 @@ const actor = {
   profileBanner:
     "A dimly lit Senate chamber filled with cobwebs and stopped clocks showing different times. A giant turtle with a gavel sits atop the Minority Leader's desk. Massive blockade of stacked legislation papers and filibuster scripts blocks the entire aisle\u2014nothing passes. Ghostly figure of Uncle Sam bangs helplessly on the other side. Windows 95 error screen floats overhead: 'DEMOCRACY.EXE HAS STOPPED RESPONDING.' A shipping container labeled 'WIFE'S BUSINESS - UNRELATED' sits inexplicably in the corner. The words 'NO.' carved into marble.",
   domain: ['politics', 'obstruction', 'establishment'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'legislative roadblock',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/muraid.ts
+++ b/packages/pack-default/src/actors/muraid.ts
@@ -96,6 +96,8 @@ const actor = {
   profileBanner:
     "A massive BitcAIn chart going parabolic, more parabolic than physically possible, then more parabolic still. The words 'SUPERCYCLE' written in gold across the top, glowing. Orange lasers converge on the peak. Below the chart, fiat currencies crumble into dust. The timeline shows 'WE ARE HERE' at the very beginning of an exponential curve. Altcoin logos sink into a pit labeled 'NOISE.' A conviction meter shows 100%. The phrase 'ZOOM OUT' is carved into the frame.",
   domain: ['crypto', 'finance'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'crypto prophet',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/naite-silver.ts
+++ b/packages/pack-default/src/actors/naite-silver.ts
@@ -106,6 +106,8 @@ const actor = {
   profileBanner:
     "Election map where states are colored in probability gradients, not solid colors\u2014nothing is certain, everything is a distribution. FiveThirtyEight logo fades into Substack logo (the transition that definitely needed to happen). Poker chips and playing cards mix with polling data and margin of error bars. The 2016 election haunts the background with '30% \u2260 0%' stamped across it. Probability percentages float everywhere: 71%, 29%, 43.7%. A frustrated sigh is somehow visible. The words 'THE MODEL WAS RIGHT' carved in stone.",
   domain: ['media', 'politics', 'statistics', 'gambling'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'probabilistic thinker',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/nick-fuentais.ts
+++ b/packages/pack-default/src/actors/nick-fuentais.ts
@@ -99,6 +99,8 @@ const actor = {
   profileBanner:
     "A dimly lit basement streaming setup with ring light and multiple monitors showing groyper memes. American flag and crucifix on wood-paneled wall behind him. Roman Empire posters next to anime figurines\u2014the duality of man. Shelves of canned food and energy drinks. A life-size cardboard cutout labeled 'FUTURE TRADWIFE' stands unused in corner. 'WESTERN CIVILIZATION' banner hangs above. Platform ban notifications pile up like badges of honor. A plate of Hot Pockets sits on desk. Mom's shadow visible at top of basement stairs. The words 'AMERICA FIRST' glow ominously. The catboy is nowhere to be seen (out of context).",
   domain: ['politics', 'extremism', 'incel_culture'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'extremist pundit',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/nikitai-bier.ts
+++ b/packages/pack-default/src/actors/nikitai-bier.ts
@@ -101,6 +101,8 @@ const actor = {
   profileBanner:
     "An exponential growth chart dominates\u2014the hockey stick every founder dreams of, that Nikita has actually achieved (twice). TBH logo and Gas logo displayed as trophies. A pile of acquisition money grows in one corner. Teenage smartphone usage graphs show engagement patterns he engineered. The words 'YOUR APP IDEA IS BAD' float as tough love. A door labeled 'EXIT' glows invitingly. Dopamine molecules are arranged like a playbook. Failed startup logos sink into quicksand below. A Discord and Facebook logo wait hungrily in the background. The cynicism is the brand. The exits are the proof.",
   domain: ['tech', 'startups', 'marketing'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'viral architect',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/org-ai16z.ts
+++ b/packages/pack-default/src/actors/org-ai16z.ts
@@ -144,6 +144,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['finance', 'venture_capital'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'venture capital firm',
   voice:

--- a/packages/pack-default/src/actors/org-aimazon.ts
+++ b/packages/pack-default/src/actors/org-aimazon.ts
@@ -85,6 +85,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-aimerica-first.ts
+++ b/packages/pack-default/src/actors/org-aimerica-first.ts
@@ -87,6 +87,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-ainduril.ts
+++ b/packages/pack-default/src/actors/org-ainduril.ts
@@ -84,6 +84,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-ainfowars.ts
+++ b/packages/pack-default/src/actors/org-ainfowars.ts
@@ -82,6 +82,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-aingel-list.ts
+++ b/packages/pack-default/src/actors/org-aingel-list.ts
@@ -87,6 +87,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'organization',
   voice:

--- a/packages/pack-default/src/actors/org-aiphabet.ts
+++ b/packages/pack-default/src/actors/org-aiphabet.ts
@@ -82,6 +82,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-aipple.ts
+++ b/packages/pack-default/src/actors/org-aipple.ts
@@ -83,6 +83,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-airk-invest.ts
+++ b/packages/pack-default/src/actors/org-airk-invest.ts
@@ -84,6 +84,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['finance', 'venture_capital'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'venture capital firm',
   voice:

--- a/packages/pack-default/src/actors/org-aitism-capital.ts
+++ b/packages/pack-default/src/actors/org-aitism-capital.ts
@@ -80,6 +80,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['finance', 'venture_capital'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'venture capital firm',
   voice:

--- a/packages/pack-default/src/actors/org-aitropic.ts
+++ b/packages/pack-default/src/actors/org-aitropic.ts
@@ -84,6 +84,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-aix.ts
+++ b/packages/pack-default/src/actors/org-aix.ts
@@ -83,6 +83,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-aixios.ts
+++ b/packages/pack-default/src/actors/org-aixios.ts
@@ -83,6 +83,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-betterhailp.ts
+++ b/packages/pack-default/src/actors/org-betterhailp.ts
@@ -84,6 +84,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-block-rock.ts
+++ b/packages/pack-default/src/actors/org-block-rock.ts
@@ -81,6 +81,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['finance', 'markets'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'financial institution',
   voice:

--- a/packages/pack-default/src/actors/org-bloombairg.ts
+++ b/packages/pack-default/src/actors/org-bloombairg.ts
@@ -80,6 +80,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-blue-origain.ts
+++ b/packages/pack-default/src/actors/org-blue-origain.ts
@@ -81,6 +81,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-bluepraint.ts
+++ b/packages/pack-default/src/actors/org-bluepraint.ts
@@ -82,6 +82,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-braitbart.ts
+++ b/packages/pack-default/src/actors/org-braitbart.ts
@@ -83,6 +83,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-ciai.ts
+++ b/packages/pack-default/src/actors/org-ciai.ts
@@ -83,6 +83,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['politics', 'policy'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   affiliations: [],
   personality: 'government institution',
   voice:

--- a/packages/pack-default/src/actors/org-coinbaise.ts
+++ b/packages/pack-default/src/actors/org-coinbaise.ts
@@ -84,6 +84,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-colaissal-sciences.ts
+++ b/packages/pack-default/src/actors/org-colaissal-sciences.ts
@@ -83,6 +83,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-craift-ventures.ts
+++ b/packages/pack-default/src/actors/org-craift-ventures.ts
@@ -83,6 +83,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['finance', 'venture_capital'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'venture capital firm',
   voice:

--- a/packages/pack-default/src/actors/org-deepmaind.ts
+++ b/packages/pack-default/src/actors/org-deepmaind.ts
@@ -114,6 +114,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-deparment-of-war.ts
+++ b/packages/pack-default/src/actors/org-deparment-of-war.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['politics', 'policy'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   affiliations: [],
   personality: 'government institution',
   voice:

--- a/packages/pack-default/src/actors/org-ethereum-foundaition.ts
+++ b/packages/pack-default/src/actors/org-ethereum-foundaition.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'organization',
   voice:

--- a/packages/pack-default/src/actors/org-extropaic.ts
+++ b/packages/pack-default/src/actors/org-extropaic.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-faix-news.ts
+++ b/packages/pack-default/src/actors/org-faix-news.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-financial-taimes.ts
+++ b/packages/pack-default/src/actors/org-financial-taimes.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-forbesai.ts
+++ b/packages/pack-default/src/actors/org-forbesai.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-founders-faind.ts
+++ b/packages/pack-default/src/actors/org-founders-faind.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['finance', 'venture_capital'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'venture capital firm',
   voice:

--- a/packages/pack-default/src/actors/org-maicrosoft.ts
+++ b/packages/pack-default/src/actors/org-maicrosoft.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-metai.ts
+++ b/packages/pack-default/src/actors/org-metai.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-msainbc.ts
+++ b/packages/pack-default/src/actors/org-msainbc.ts
@@ -85,6 +85,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-netflaix.ts
+++ b/packages/pack-default/src/actors/org-netflaix.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-neurailink.ts
+++ b/packages/pack-default/src/actors/org-neurailink.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-new-republic.ts
+++ b/packages/pack-default/src/actors/org-new-republic.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-nvidai.ts
+++ b/packages/pack-default/src/actors/org-nvidai.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-openagi.ts
+++ b/packages/pack-default/src/actors/org-openagi.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-palaintir.ts
+++ b/packages/pack-default/src/actors/org-palaintir.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-piraite-wires.ts
+++ b/packages/pack-default/src/actors/org-piraite-wires.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-politaico.ts
+++ b/packages/pack-default/src/actors/org-politaico.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-sequoai-capital.ts
+++ b/packages/pack-default/src/actors/org-sequoai-capital.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['finance', 'venture_capital'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'venture capital firm',
   voice:

--- a/packages/pack-default/src/actors/org-sociai-capital.ts
+++ b/packages/pack-default/src/actors/org-sociai-capital.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['finance', 'venture_capital'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'venture capital firm',
   voice:

--- a/packages/pack-default/src/actors/org-spaicex.ts
+++ b/packages/pack-default/src/actors/org-spaicex.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-straitegy.ts
+++ b/packages/pack-default/src/actors/org-straitegy.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-techcrainch.ts
+++ b/packages/pack-default/src/actors/org-techcrainch.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-teslai.ts
+++ b/packages/pack-default/src/actors/org-teslai.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'A_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-the-atlaintic.ts
+++ b/packages/pack-default/src/actors/org-the-atlaintic.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-the-daily-wire.ts
+++ b/packages/pack-default/src/actors/org-the-daily-wire.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-the-economaist.ts
+++ b/packages/pack-default/src/actors/org-the-economaist.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-the-informaition.ts
+++ b/packages/pack-default/src/actors/org-the-informaition.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-the-intaircept.ts
+++ b/packages/pack-default/src/actors/org-the-intaircept.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-the-new-york-taimes.ts
+++ b/packages/pack-default/src/actors/org-the-new-york-taimes.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-the-terminal-organization.ts
+++ b/packages/pack-default/src/actors/org-the-terminal-organization.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'organization',
   voice:

--- a/packages/pack-default/src/actors/org-the-vairge.ts
+++ b/packages/pack-default/src/actors/org-the-vairge.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-ubair.ts
+++ b/packages/pack-default/src/actors/org-ubair.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/org-waired.ts
+++ b/packages/pack-default/src/actors/org-waired.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'C_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-wall-street-journai.ts
+++ b/packages/pack-default/src/actors/org-wall-street-journai.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['media', 'journalism'],
+  ignoreTopics: [],
+  engagementThreshold: 0.2,
   affiliations: [],
   personality: 'media organization',
   voice:

--- a/packages/pack-default/src/actors/org-zcaish.ts
+++ b/packages/pack-default/src/actors/org-zcaish.ts
@@ -59,6 +59,8 @@ const actor = {
   },
   tier: 'B_TIER',
   domain: ['tech', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   affiliations: [],
   personality: 'corporate entity',
   voice:

--- a/packages/pack-default/src/actors/pailmer-luckey.ts
+++ b/packages/pack-default/src/actors/pailmer-luckey.ts
@@ -200,6 +200,8 @@ const actor = {
   profileBanner:
     "A chaotic garage lab that's clearly outgrown 'garage.' Drone parts and VR rigs share shelf space. A border-sentinel tower model glows in one corner, surrounded by engineering diagrams. The American flag hangs next to an anime poster (Gundam, obviously). Hawaiian shirts hang on a rack labeled 'TACTICAL WARDROBE.' Outside the open hangar door, a desert testing ground is lined with autonomous sensors under purple sunset. A dartboard has the Facebook/Meta logo with darts clustered on MAIrk's face. A whiteboard shows 'ANDURIL VALUATION' with numbers crossed out and replaced with bigger numbers. The vibe is 'VR nerd to defense mogul' with visible spite energy.",
   domain: ['tech', 'vr', 'defense', 'military'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'defense-tech billionaire with VR nerd origins and revenge arc',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/pam-bondai.ts
+++ b/packages/pack-default/src/actors/pam-bondai.ts
@@ -141,6 +141,8 @@ const actor = {
   profileBanner:
     'The DOJ facade with Lady Justice holding scales tipped by a tiny loyalty chip. Florida and DOJ seals merge over a wall of case files sorted into PRIORITY and PARKED. A polished lectern sits under TV lights, and a ghostly check mark glows over selective folders. The American flag and courtroom columns create a polished, high-control atmosphere.',
   domain: ['politics', 'legal', 'justice', 'maga'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'loyal prosecutor',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/paul-aitkins.ts
+++ b/packages/pack-default/src/actors/paul-aitkins.ts
@@ -139,6 +139,8 @@ const actor = {
   profileBanner:
     'The SEC building with its doors wide open and a golden light spilling onto a welcome mat labeled INNOVATION. Crypto logos float beside traditional ticker tape while a compliance checklist dissolves into green check marks. A faint yield curve arcs across a clear blue sky.',
   domain: ['politics', 'finance', 'crypto', 'regulation'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'deregulation zealot',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/paul-graiham.ts
+++ b/packages/pack-default/src/actors/paul-graiham.ts
@@ -139,6 +139,8 @@ const actor = {
   profileBanner:
     'A clean desk with a Lisp snippet projected onto a white wall, the YC logo glowing orange like a traffic signal. A quiet city skyline sits in soft focus behind a window, with a handwritten outline of an essay pinned to a corkboard.',
   domain: ['startups', 'tech', 'writing'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'thoughtful mentor',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/pete-hegsaith.ts
+++ b/packages/pack-default/src/actors/pete-hegsaith.ts
@@ -137,6 +137,8 @@ const actor = {
   profileBanner:
     'A cable-news set fused with a military briefing room. Camo netting drapes over studio lights, a world map shows red flashpoints, and a podium swaps the Pentagon seal for a best-seller list. A shelf of identical patriotic book covers glows under spotlights while stealth bombers streak across a sky spelling WAR.',
   domain: ['military', 'media', 'politics'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'war profiteer',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/peter-schaiff.ts
+++ b/packages/pack-default/src/actors/peter-schaiff.ts
@@ -138,6 +138,8 @@ const actor = {
   profileBanner:
     'A mound of gold bars stacked like a fortress, a crashing dollar chart, and a worn trash can labeled BITCOIN. A gold spot ticker runs across the top like a crown.',
   domain: ['finance', 'economics'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'gold maximalist',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/pietair-levels.ts
+++ b/packages/pack-default/src/actors/pietair-levels.ts
@@ -143,6 +143,8 @@ const actor = {
   profileBanner:
     'A world map plastered with pins and flight routes, overlaid with a rising MRR chart and a deploy status feed. A minimalist dashboard floats above a beach scene with a glowing cursor blinking on a single PHP file.',
   domain: ['tech', 'startups', 'travel'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'indie hacker',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/rachel-maiddow.ts
+++ b/packages/pack-default/src/actors/rachel-maiddow.ts
@@ -139,6 +139,8 @@ const actor = {
   profileBanner:
     'A high-contrast newsroom with a giant corkboard map, red strings and pins labeled CONTEXT. A teleprompter glows BREAKING, a stopwatch hovers over the Capitol, and faint Kremlin shadows loom in the far distance.',
   domain: ['media', 'politics', 'journalism'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'dramatic anchor',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/reid-hoffmain.ts
+++ b/packages/pack-default/src/actors/reid-hoffmain.ts
@@ -143,6 +143,8 @@ const actor = {
   profileBanner:
     'A glowing network graph over a sleek city skyline, LinkedIn blue light washing over the horizon. A podcast mic and a subtle blitzscale chart float near the center.',
   domain: ['vc', 'tech', 'politics'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'connected sage',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/robert-kennedai.ts
+++ b/packages/pack-default/src/actors/robert-kennedai.ts
@@ -142,6 +142,16 @@ const actor = {
   profileBanner:
     'The HHS building with a split background of farmland and medical charts. A corkboard labeled QUESTIONS glows with stringed notes, while a MAHA banner runs across the top.',
   domain: ['politics', 'health', 'conspiracy', 'antivax'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'trading',
+    'sports',
+    'entertainment',
+    'celebrity',
+  ],
+  engagementThreshold: 0.7,
   personality: 'contrarian crusader',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/ron-desaintis.ts
+++ b/packages/pack-default/src/actors/ron-desaintis.ts
@@ -142,6 +142,8 @@ const actor = {
   profileBanner:
     'A sunlit Florida beach with an alligator wearing a freedom cap. A red strike runs through the word WOKE, and a progress bar labeled ANTI-WOKE.EXE hovers above the horizon.',
   domain: ['politics', 'government'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'scripted culture warrior',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/ross-ulbraicht.ts
+++ b/packages/pack-default/src/actors/ross-ulbraicht.ts
@@ -141,6 +141,8 @@ const actor = {
   profileBanner:
     'A sketched bird escaping a cage into a stream of binary code, with a soft glow and the words FREE ROSS in the corner.',
   domain: ['crypto', 'politics', 'human_rights'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'digital martyr',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/ryain-cohen.ts
+++ b/packages/pack-default/src/actors/ryain-cohen.ts
@@ -146,6 +146,8 @@ const actor = {
   profileBanner:
     'A GameStop store on the moon with a tiny rocket parked out front, an ice cream cone neon sign, and a subtle 4D chess grid in the sky.',
   domain: ['business', 'gaming', 'finance'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'cryptic chairman',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/saitya-nadella.ts
+++ b/packages/pack-default/src/actors/saitya-nadella.ts
@@ -143,6 +143,8 @@ const actor = {
   profileBanner:
     'A serene cloudscape with the MAIcrosoft logo floating above a grid of endless Teams tiles. A Copilot icon hovers over every app, and Windows update notifications fall like rain. A subscription meter ticks upward in the corner while Azure servers glow on the horizon.',
   domain: ['tech', 'ai', 'enterprise', 'cloud'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'gentle monopolist',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/scott-bessaint.ts
+++ b/packages/pack-default/src/actors/scott-bessaint.ts
@@ -150,6 +150,8 @@ const actor = {
   profileBanner:
     'The Treasury building with glowing Bloomberg terminals visible in every window. A massive yield curve arcs across the sky, slightly inverted, while stacks of global currency form a pyramid with the dollar on top.',
   domain: ['politics', 'finance', 'economics', 'macro'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'hedge fund treasury',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/seain-hannity.ts
+++ b/packages/pack-default/src/actors/seain-hannity.ts
@@ -149,6 +149,8 @@ const actor = {
   profileBanner:
     'A cable-news studio drenched in flags, with survival-seed packets raining like confetti. A glowing hotline to Mar-a-Lago sits on the desk, supplement bottles stacked into a fortress, and a giant OUTRAGE ticker crawls across the bottom.',
   domain: ['media', 'politics', 'supplements'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'outrage profiteer',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/sergey-brain.ts
+++ b/packages/pack-default/src/actors/sergey-brain.ts
@@ -202,6 +202,8 @@ const actor = {
   profileBanner:
     "An airship hangar that doubles as a maker space and art studio. Python code scrolls across the walls in neon projections. A half-built airship dominates the center, surrounded by scattered tools, soldering stations, and empty Red Bull cans. In one corner, Burning Man art installations glow with bioluminescent light. Server racks labeled 'GEMINI - DO NOT TOUCH (except Sergey)' line one wall. The hangar doors open to reveal a desert sunset. A whiteboard shows 'AIRSHIP TIMELINE' with increasingly ambitious dates. A tiny plush Google logo sits on a workbench next to an actual neural lace prototype. The vibe is 'billionaire who would rather build than meet.'",
   domain: ['tech', 'science', 'ai', 'lifestyle'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'eccentric billionaire who actually still codes',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/sim-cook.ts
+++ b/packages/pack-default/src/actors/sim-cook.ts
@@ -109,6 +109,8 @@ const actor = {
   profileBanner:
     'A sterile white keynote stage with a giant apple logo, eco-green lighting, solar panels, and stacks of recycled devices labeled "courage."',
   domain: ['tech', 'corporate', 'privacy'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'planned obsolescence',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/spartain.ts
+++ b/packages/pack-default/src/actors/spartain.ts
@@ -98,6 +98,8 @@ const actor = {
   profileBanner:
     'A chart cave where Lambo catalogs and liquidation notices share the floor, leverage sliders are maxed, and the scoreboard always reads "Portfolio: EVEN."',
   domain: ['crypto', 'trading', 'defi'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'pure degen',
   tier: 'C_TIER',
   hasPool: true,

--- a/packages/pack-default/src/actors/steven-craiwder.ts
+++ b/packages/pack-default/src/actors/steven-craiwder.ts
@@ -95,6 +95,8 @@ const actor = {
   profileBanner:
     "A folding 'Change My Mind' table surrounded by Mug Club merch, American flags, and a Rumble logo replacing YouTube.",
   domain: ['media', 'politics', 'youtube', 'comedy'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'debate bro',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/sundar-pichai.ts
+++ b/packages/pack-default/src/actors/sundar-pichai.ts
@@ -110,6 +110,8 @@ const actor = {
   profileBanner:
     'A colorful Google campus with floating product logos and a sky made of search results, with a tiny privacy disclaimer along the edge.',
   domain: ['tech', 'ai', 'advertising'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'corporate AI',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/tailyor-lorenz.ts
+++ b/packages/pack-default/src/actors/tailyor-lorenz.ts
@@ -95,6 +95,16 @@ const actor = {
   profileBanner:
     'A chaotic collage of TikToks, tweets, and notifications where the line between covering drama and being the drama has dissolved.',
   domain: ['media', 'tech', 'culture', 'internet'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'regulation',
+    'compliance',
+    'finance',
+    'trading',
+  ],
+  engagementThreshold: 0.7,
   personality: 'extremely online',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/threadgai.ts
+++ b/packages/pack-default/src/actors/threadgai.ts
@@ -95,6 +95,8 @@ const actor = {
   profileBanner:
     'A war room of candlestick charts and Fibonacci grids, with a graveyard of wrong calls in shadow and "NFA" in tiny letters.',
   domain: ['crypto', 'trading', 'technical_analysis'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'chart wizard',
   tier: 'B_TIER',
   hasPool: true,

--- a/packages/pack-default/src/actors/tim-pail.ts
+++ b/packages/pack-default/src/actors/tim-pail.ts
@@ -94,6 +94,8 @@ const actor = {
   profileBanner:
     'A sprawling media compound of studios and cameras, with the black beanie icon stamped across endless upload queues.',
   domain: ['media', 'politics', 'youtube'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'centrist conservative',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/tom-braidy.ts
+++ b/packages/pack-default/src/actors/tom-braidy.ts
@@ -94,6 +94,15 @@ const actor = {
   profileBanner:
     'A football field morphing into a prehistoric landscape where mammoths graze beneath floating championship rings.',
   domain: ['sports', 'science', 'climate'],
+  ignoreTopics: [
+    'crypto',
+    'blockchain',
+    'defi',
+    'finance',
+    'trading',
+    'regulation',
+  ],
+  engagementThreshold: 0.6,
   personality: 'competitive perfectionist',
   tier: 'A_TIER',
   hasPool: true,

--- a/packages/pack-default/src/actors/travis-kalainick.ts
+++ b/packages/pack-default/src/actors/travis-kalainick.ts
@@ -95,6 +95,8 @@ const actor = {
   profileBanner:
     'A ride-share car split with a ghost-kitchen line, surge multipliers flashing like slot machines, and a banner that reads "Disruption."',
   domain: ['tech', 'gig_economy', 'food_delivery', 'disruption'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'toxic bro disruptor',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/tulsai-gabbard.ts
+++ b/packages/pack-default/src/actors/tulsai-gabbard.ts
@@ -95,6 +95,8 @@ const actor = {
   profileBanner:
     'The ODNI seal lit by harsh spotlights, with Hawaii on one side and Washington D.C. on the other, connected by a glowing dotted line.',
   domain: ['politics', 'intelligence', 'military', 'contrarian'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'pivot specialist',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/tyler-wainklevoss.ts
+++ b/packages/pack-default/src/actors/tyler-wainklevoss.ts
@@ -93,6 +93,8 @@ const actor = {
   profileBanner:
     'Two astronauts on the moon beside the GeminAI logo and a floating BitcAIn coin.',
   domain: ['crypto', 'business'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'crypto twin',
   tier: 'B_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/yainn-lecun.ts
+++ b/packages/pack-default/src/actors/yainn-lecun.ts
@@ -108,6 +108,8 @@ const actor = {
   profileBanner:
     'A Parisian cafe fused with a neural-network diagram, Turing Award statues on one side and a chalkboard of equations on the other.',
   domain: ['ai', 'research', 'machine_learning'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'combative researcher',
   tier: 'A_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/zohran-mamdanai.ts
+++ b/packages/pack-default/src/actors/zohran-mamdanai.ts
@@ -93,6 +93,8 @@ const actor = {
   profileBanner:
     "A subway train, a protest rally, and the text 'TAX THE RICH' painted on a billboard.",
   domain: ['politics', 'social'],
+  ignoreTopics: ['entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.4,
   personality: 'local socialist',
   tier: 'C_TIER',
   hasPool: false,

--- a/packages/pack-default/src/actors/zookai-wilcox.ts
+++ b/packages/pack-default/src/actors/zookai-wilcox.ts
@@ -95,6 +95,8 @@ const actor = {
   profileBanner:
     "A shadowy digital landscape where transactions appear and disappear into encrypted mist, with a glowing triangle labeled 'Zooko's' in the sky.",
   domain: ['crypto', 'privacy', 'cryptography', 'cypherpunk'],
+  ignoreTopics: ['sports', 'entertainment', 'celebrity', 'fashion'],
+  engagementThreshold: 0.5,
   personality: 'privacy absolutist',
   tier: 'B_TIER',
   hasPool: false,


### PR DESCRIPTION
## Summary

NPCs now post based on their actual personality and domain instead of all talking about markets. The feed should feel like a real social network with diverse voices, not a prediction market chatroom.

- **Domain-filtered context injection**: Non-finance NPCs no longer see market data in their prompts. Finance actors get full context, tech/AI get predictions only, everyone else gets actor names only for parody reference.
- **Post intent system**: Each NPC gets a post intent (organic/topical/market/social) based on personality type and domain before content generation. Organic posts use a new template with NO market data. Social posts use relationship dynamics.
- **Softened CONTENT_REQUIREMENTS**: Removed "MUST reference markets/predictions" — replaced with "Only mention markets if YOUR character would naturally care."
- **173 actor definitions backfilled** with `ignoreTopics` and `engagementThreshold` grouped by archetype (climate activists ignore crypto, sports stars ignore finance, etc.).
- **Relationship-weighted replies**: Replies now prefer actors with strong relationships (rivals 5x, allies 3x) and domain overlap (2x) instead of random selection.
- **Wired existing unused code**: `shouldPostAboutTopic()` and `shouldGenerateOrganicPost()` from npc-character-config now flow into the main FeedGenerator pipeline.

### New files
- `packages/engine/src/prompts/feed/organic-post.ts` — personality-driven post template (no market data)
- `packages/engine/src/prompts/feed/social-post.ts` — relationship-driven post template
- `packages/engine/src/services/post-intent-service.ts` — decides what type of post each NPC should make

### Before vs After

| NPC | Before | After |
|-----|--------|-------|
| GretAI Thunberg | Talks about benchmark markets | Posts about climate, emissions, shaming leaders |
| Andrew HubermAIn | "98% consensus... neural prediction error" | Posts about protocols, sleep, neuroscience |
| Tom BrAIdy | "Shorts celebrating in the third quarter" | Posts about winning, discipline, competition |
| Jim CrAImer | Market posts (unchanged) | Market posts — finance actors keep full context |

## Test plan
- [x] `bun run check` — biome format + lint passes
- [x] `bun run typecheck` — all packages pass
- [x] `bun run lint` — zero warnings
- [x] `bun run test:unit` — 397 files pass, 0 failures
- [x] `bun run build` — builds successfully
- [ ] Generate test feed and verify post diversity manually
- [ ] Verify finance NPCs still reference markets naturally
- [ ] Verify non-finance NPCs post about their actual domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)