### PR TITLE
fix: align autonomous prediction pricing semantics

### DIFF
--- a/packages/agents/src/autonomous/AutonomousA2AService.ts
+++ b/packages/agents/src/autonomous/AutonomousA2AService.ts
@@ -17,6 +17,7 @@ import {
 } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { trackAgentTradeExecuted } from './track-agent-trade';
+import { getPredictionMarketPrices } from './utils/prediction-pricing';
 
 /**
  * Type guard to check if runtime has A2A client
@@ -197,9 +198,10 @@ ${
   predictions.length > 0
     ? predictions
         .map((m: PredictionMarket, i: number) => {
-          const totalShares = m.yesShares + m.noShares;
-          const yesPrice = totalShares > 0 ? m.yesShares / totalShares : 0.5;
-          const noPrice = 1 - yesPrice;
+          const { yesPrice, noPrice } = getPredictionMarketPrices(
+            m.yesShares,
+            m.noShares
+          );
           return `${i + 1}. "${m.question}"
    - Market ID: ${m.id}
    - YES: ${(yesPrice * 100).toFixed(1)}% (${m.yesShares} shares)

--- a/packages/agents/src/autonomous/AutonomousCoordinator.ts
+++ b/packages/agents/src/autonomous/AutonomousCoordinator.ts
@@ -32,6 +32,7 @@ import {
 } from '../plugins/plugin-trajectory-logger/src/action-interceptor';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
+import { getPredictionMarketPrices } from './utils/prediction-pricing';
 
 // Import services
 import { autonomousPlanningCoordinator } from './AutonomousPlanningCoordinator';
@@ -783,12 +784,15 @@ export class AutonomousCoordinator {
     const marketsForTopics = activeMarkets.map((m) => {
       const yesShares = Number(m.yesShares || 1);
       const noShares = Number(m.noShares || 1);
-      const total = yesShares + noShares;
+      const { yesPrice, noPrice } = getPredictionMarketPrices(
+        yesShares,
+        noShares
+      );
       return {
         id: m.id,
         question: m.question,
-        yesPrice: yesShares / total,
-        noPrice: noShares / total,
+        yesPrice,
+        noPrice,
       };
     });
 

--- a/packages/agents/src/autonomous/AutonomousPlanningCoordinator.ts
+++ b/packages/agents/src/autonomous/AutonomousPlanningCoordinator.ts
@@ -27,6 +27,7 @@ import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';
+import { getPredictionMarketPrices } from './utils/prediction-pricing';
 import type {
   AgentConstraints,
   AgentDirective,
@@ -970,8 +971,7 @@ async function detectTradingOpportunities(
 
     if (totalShares === 0) continue;
 
-    // Calculate implied probability
-    const yesPrice = yesShares / totalShares;
+    const { yesPrice } = getPredictionMarketPrices(yesShares, noShares);
 
     // Look for mispriced markets (one side < 0.3 or > 0.7)
     if (yesPrice < 0.3 || yesPrice > 0.7) {

--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -28,6 +28,7 @@ import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { executeDirectTrade } from './DirectExecutors';
+import { getPredictionMarketPrices } from './utils/prediction-pricing';
 import { trackAgentTradeExecuted } from './track-agent-trade';
 import { resolvePerpTicker } from './utils/resolvePerpTicker';
 
@@ -139,9 +140,8 @@ export class AutonomousTradingService {
       .map((m) => {
         const yesShares = Number(m.yesShares || 1);
         const noShares = Number(m.noShares || 1);
-        const total = yesShares + noShares;
-        const yesPrice = ((yesShares / total) * 100).toFixed(1);
-        return `- [${m.id}] "${m.question}" (YES: ${yesPrice}%)`;
+        const { yesPrice } = getPredictionMarketPrices(yesShares, noShares);
+        return `- [${m.id}] "${m.question}" (YES: ${(yesPrice * 100).toFixed(1)}%)`;
       })
       .join('\n');
 

--- a/packages/agents/src/autonomous/utils/context-gatherers.ts
+++ b/packages/agents/src/autonomous/utils/context-gatherers.ts
@@ -52,6 +52,7 @@ import type {
   RelationshipContext,
   WorldEventContext,
 } from '../templates/multi-step-decision';
+import { getPredictionMarketPrices } from './prediction-pricing';
 import { formatTimeHeld, getTimeAgo } from './time-helpers';
 
 // =============================================================================
@@ -74,14 +75,17 @@ export async function getPredictionMarkets(): Promise<
   return activeMarkets.map((m) => {
     const yesShares = Number(m.yesShares || 1);
     const noShares = Number(m.noShares || 1);
-    const total = yesShares + noShares;
+    const { yesPrice, noPrice } = getPredictionMarketPrices(
+      yesShares,
+      noShares
+    );
 
     return {
       id: m.id,
       question: m.question,
-      yesPrice: yesShares / total,
-      noPrice: noShares / total,
-      volume: total,
+      yesPrice,
+      noPrice,
+      volume: yesShares + noShares,
       endDate: m.endDate?.toISOString().split('T')[0] ?? 'Unknown',
     };
   });
@@ -164,11 +168,14 @@ export async function getAgentPositions(agentUserId: string): Promise<{
     for (const m of marketsData) {
       const yesShares = Number(m.yesShares || 1);
       const noShares = Number(m.noShares || 1);
-      const total = yesShares + noShares;
+      const { yesPrice, noPrice } = getPredictionMarketPrices(
+        yesShares,
+        noShares
+      );
       marketData.set(m.id, {
         question: m.question,
-        yesPrice: yesShares / total,
-        noPrice: noShares / total,
+        yesPrice,
+        noPrice,
       });
     }
   }

--- a/packages/agents/src/autonomous/utils/prediction-pricing.test.ts
+++ b/packages/agents/src/autonomous/utils/prediction-pricing.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test';
+import { getPredictionMarketPrices } from './prediction-pricing';
+
+describe('prediction-pricing utils', () => {
+  it('uses canonical YES/NO semantics for skewed markets', () => {
+    const { yesPrice, noPrice } = getPredictionMarketPrices(8000, 2000);
+    expect(yesPrice).toBe(0.2);
+    expect(noPrice).toBe(0.8);
+  });
+
+  it('falls back to 50/50 when the market has no shares', () => {
+    const { yesPrice, noPrice } = getPredictionMarketPrices(0, 0);
+    expect(yesPrice).toBe(0.5);
+    expect(noPrice).toBe(0.5);
+  });
+});

--- a/packages/agents/src/autonomous/utils/prediction-pricing.ts
+++ b/packages/agents/src/autonomous/utils/prediction-pricing.ts
@@ -1,0 +1,11 @@
+import { PredictionPricing } from '@babylon/core/markets/prediction/client';
+
+export function getPredictionMarketPrices(
+  yesShares: number,
+  noShares: number
+): { yesPrice: number; noPrice: number } {
+  return {
+    yesPrice: PredictionPricing.getCurrentPrice(yesShares, noShares, 'yes'),
+    noPrice: PredictionPricing.getCurrentPrice(yesShares, noShares, 'no'),
+  };
+}


### PR DESCRIPTION
## Summary
- align autonomous/agent-side prediction pricing with canonical CPMM YES/NO semantics
- remove duplicated manual probability calculations across autonomous services
- add a small shared helper and targeted tests so future prediction-context work does not drift again

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Follows the merged prediction profile/context work on `staging`
- Fixes remaining semantic drift in `packages/agents/src/autonomous/*` where YES price was still computed with non-canonical share math

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Other areas

## Non-goals / follow-ups
- No public UI changes
- No prediction market creation or auto-AMM changes
- No wider agent-context redesign beyond pricing-semantic alignment

## Changes
- add `packages/agents/src/autonomous/utils/prediction-pricing.ts` as a canonical helper over `PredictionPricing.getCurrentPrice(...)`
- update autonomous prediction market formatting / gathering / opportunity detection paths to use the shared helper
- remove incorrect `yesShares / total` style calculations in autonomous services
- add targeted utility tests covering skewed and empty-market cases

## Review guide
**Start here**
- `packages/agents/src/autonomous/utils/prediction-pricing.ts`
- `packages/agents/src/autonomous/utils/context-gatherers.ts`
- `packages/agents/src/autonomous/AutonomousTradingService.ts`
- `packages/agents/src/autonomous/AutonomousA2AService.ts`
- `packages/agents/src/autonomous/AutonomousPlanningCoordinator.ts`
- `packages/agents/src/autonomous/AutonomousCoordinator.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This PR is intentionally narrow: the goal is not new behavior, but one consistent prediction pricing story across autonomous services.
- All affected paths now route through a single helper backed by the canonical pricing utility.

## Test plan
**Commands run**
- [ ] `bun run check`
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test`

**Focused verification / manual verification**
1. `bunx biome check --write` on touched files.
2. `bun test packages/agents/src/autonomous/utils/prediction-pricing.test.ts`.
3. `bun test packages/agents/src/__tests__/rl.test.ts` was attempted but fails in this isolated worktree because of unrelated environment/module resolution (`next/server` via `packages/api/src/cron-auth.ts`).
4. Verified via grep that the affected autonomous paths no longer compute prediction YES price with `yesShares / total`.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates
- [ ] Requires DB migration
- [ ] Changes cron schedule or endpoints
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes
- [x] None
- [ ] Yes

## Security / privacy
- [x] No security impact
- [ ] Needs extra review

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Agents/autonomous internal consistency fix only. No end-user UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path
- [x] Handlers remain thin and portable
- [x] Domain logic stays in packages
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] **Screenshots/recordings section filled**
