### PR TITLE
feat: add market realism report

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "seed:nft-snapshot:csv": "bun run scripts/seed-nft-snapshot-csv.ts",
     "users:export:newsletter": "bun run scripts/export-newsletter-users-csv.ts",
     "report:markets": "bun run scripts/market-diversity-report.ts",
+    "report:realism": "bun run scripts/market-realism-report.ts",
     "report:training-quality": "bun run scripts/training-data-quality.ts",
     "report:training-viz": "bun run scripts/training-data-viz.ts",
     "inspect:context": "bun run scripts/context-inspector.ts",

--- a/packages/engine/src/services/market-realism-metrics.test.ts
+++ b/packages/engine/src/services/market-realism-metrics.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  computePerpRealismMetrics,
+  computePredictionRealismMetrics,
+  summarizeSeries,
+} from './market-realism-metrics';
+
+describe('market-realism-metrics', () => {
+  it('summarizes numeric series deterministically', () => {
+    expect(summarizeSeries([1, 2, 3, 4, 5])).toEqual({
+      count: 5,
+      min: 1,
+      max: 5,
+      mean: 3,
+      median: 3,
+      p90: 5,
+    });
+  });
+
+  it('flags narrow prediction price dispersion', () => {
+    const metrics = computePredictionRealismMetrics({
+      markets: [
+        {
+          id: 'm1',
+          question: 'Will OpenAGI publish a roadmap?',
+          yesShares: 5200,
+          noShares: 4800,
+          liquidity: 18_000,
+          endDate: new Date('2026-04-05T00:00:00.000Z'),
+        },
+        {
+          id: 'm2',
+          question: 'Will AINBC post an earnings recap?',
+          yesShares: 5100,
+          noShares: 4900,
+          liquidity: 19_000,
+          endDate: new Date('2026-04-06T00:00:00.000Z'),
+        },
+      ],
+      priceHistory: [],
+      now: new Date('2026-04-02T00:00:00.000Z'),
+    });
+
+    expect(metrics.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('reports perp quote coverage and impact by size', () => {
+    const metrics = computePerpRealismMetrics({
+      markets: [
+        {
+          ticker: 'OPENAGI',
+          organizationId: 'openagi',
+          currentPrice: 100,
+          change24h: 1,
+          changePercent24h: 1,
+          high24h: 102,
+          low24h: 98,
+          volume24h: 50_000,
+          openInterest: 20_000,
+          fundingRate: {
+            ticker: 'OPENAGI',
+            rate: 0.01,
+            nextFundingTime: new Date().toISOString(),
+            predictedRate: 0.01,
+          },
+          maxLeverage: 100,
+          minOrderSize: 10,
+          bidPrice: 99.5,
+          askPrice: 100.5,
+          spreadBps: 100,
+          bidDepth: 1000,
+          askDepth: 1000,
+          liquidityRegime: 'balanced',
+          quoteUpdatedAt: new Date('2026-04-02T00:00:00.000Z'),
+          markPrice: 100,
+          indexPrice: 100,
+        },
+      ],
+      now: new Date('2026-04-02T00:10:00.000Z'),
+      sampleOrderSizes: [1000],
+    });
+
+    expect(metrics.quoteCoverageRate).toBe(1);
+    expect(metrics.depthRatioByOrderSize['1000']?.mean).toBeGreaterThan(0);
+  });
+});

--- a/packages/engine/src/services/market-realism-metrics.test.ts
+++ b/packages/engine/src/services/market-realism-metrics.test.ts
@@ -44,6 +44,46 @@ describe('market-realism-metrics', () => {
     expect(metrics.warnings.length).toBeGreaterThan(0);
   });
 
+  it('ignores prediction history for markets outside the active market set', () => {
+    const metrics = computePredictionRealismMetrics({
+      markets: [
+        {
+          id: 'active-market',
+          question: 'Will OpenAGI publish a roadmap?',
+          yesShares: 5200,
+          noShares: 4800,
+          liquidity: 18_000,
+          endDate: new Date('2026-04-05T00:00:00.000Z'),
+        },
+      ],
+      priceHistory: [
+        {
+          marketId: 'active-market',
+          yesPrice: 0.4,
+          createdAt: new Date('2026-04-01T00:00:00.000Z'),
+        },
+        {
+          marketId: 'active-market',
+          yesPrice: 0.6,
+          createdAt: new Date('2026-04-02T00:00:00.000Z'),
+        },
+        {
+          marketId: 'resolved-market',
+          yesPrice: 0.01,
+          createdAt: new Date('2026-04-01T00:00:00.000Z'),
+        },
+        {
+          marketId: 'resolved-market',
+          yesPrice: 0.99,
+          createdAt: new Date('2026-04-02T00:00:00.000Z'),
+        },
+      ],
+      now: new Date('2026-04-02T00:00:00.000Z'),
+    });
+
+    expect(metrics.priceChange24h?.max).toBeCloseTo(0.2, 10);
+  });
+
   it('reports perp quote coverage and impact by size', () => {
     const metrics = computePerpRealismMetrics({
       markets: [

--- a/packages/engine/src/services/market-realism-metrics.ts
+++ b/packages/engine/src/services/market-realism-metrics.ts
@@ -148,19 +148,17 @@ export function computePredictionRealismMetrics(params: {
     (price) => price <= 0.2 || price >= 0.8
   ).length;
 
+  const activeMarketIds = new Set(params.markets.map((market) => market.id));
   const historyByMarket = new Map<string, PredictionHistoryPoint[]>();
   for (const point of params.priceHistory) {
+    if (!activeMarketIds.has(point.marketId)) continue;
     const existing = historyByMarket.get(point.marketId) ?? [];
     existing.push(point);
     historyByMarket.set(point.marketId, existing);
   }
 
-  const priceChange24h = Array.from(historyByMarket.values())
-    .map((points) => sorted(points.map((point) => point.createdAt.getTime())))
-    .length;
-
   const marketPriceChange24h = Array.from(historyByMarket.entries())
-    .map(([marketId, points]) => {
+    .map(([, points]) => {
       const ordered = [...points].sort(
         (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
       );

--- a/packages/engine/src/services/market-realism-metrics.ts
+++ b/packages/engine/src/services/market-realism-metrics.ts
@@ -1,0 +1,293 @@
+import { PredictionPricing } from '@babylon/core/markets/prediction/client';
+import {
+  buildPredictionMarketProfile,
+  getPredictionMarketLiquidityTier,
+} from './prediction-market-profiles';
+
+export interface SummaryStats {
+  count: number;
+  min: number;
+  max: number;
+  mean: number;
+  median: number;
+  p90: number;
+}
+
+export interface PredictionMarketDiagnosticInput {
+  id: string;
+  question: string;
+  yesShares: number;
+  noShares: number;
+  liquidity: number;
+  endDate: Date;
+}
+
+export interface PredictionHistoryPoint {
+  marketId: string;
+  yesPrice: number;
+  createdAt: Date;
+}
+
+export interface PredictionRealismMetrics {
+  activeMarkets: number;
+  yesPriceDispersion: SummaryStats | null;
+  distanceFromMid: SummaryStats | null;
+  priceChange24h: SummaryStats | null;
+  nearMidCount: number;
+  extremeCount: number;
+  horizonBuckets: Record<'short' | 'medium' | 'long', number>;
+  urgencyLevels: Record<'imminent' | 'near-term' | 'dated', number>;
+  eventSensitivity: Record<'low' | 'medium' | 'high', number>;
+  liquidityTiers: Record<'thin' | 'balanced' | 'deep', number>;
+  warnings: string[];
+}
+
+export interface PerpRealismMetrics {
+  activeMarkets: number;
+  quoteCoverageRate: number;
+  spreadBps: SummaryStats | null;
+  bidDepth: SummaryStats | null;
+  askDepth: SummaryStats | null;
+  depthRatioByOrderSize: Record<string, SummaryStats | null>;
+  liquidityRegimes: Record<'thin' | 'balanced' | 'deep', number>;
+  staleQuotesCount: number;
+  warnings: string[];
+}
+
+export interface PerpRealismDiagnosticInput {
+  ticker: string;
+  openInterest: number;
+  volume24h: number;
+  bidPrice?: number;
+  askPrice?: number;
+  spreadBps?: number;
+  bidDepth?: number;
+  askDepth?: number;
+  liquidityRegime?: 'thin' | 'balanced' | 'deep';
+  quoteUpdatedAt?: Date;
+}
+
+function sorted(values: number[]): number[] {
+  return [...values].sort((a, b) => a - b);
+}
+
+function percentile(values: number[], q: number): number {
+  const ordered = sorted(values);
+  if (ordered.length === 0) return 0;
+  const index = Math.min(
+    ordered.length - 1,
+    Math.max(0, Math.ceil(q * ordered.length) - 1)
+  );
+  return ordered[index] ?? 0;
+}
+
+export function summarizeSeries(values: number[]): SummaryStats | null {
+  if (values.length === 0) return null;
+  const ordered = sorted(values);
+  const count = ordered.length;
+  const sum = ordered.reduce((acc, value) => acc + value, 0);
+  const median =
+    count % 2 === 0
+      ? ((ordered[count / 2 - 1] ?? 0) + (ordered[count / 2] ?? 0)) / 2
+      : (ordered[Math.floor(count / 2)] ?? 0);
+
+  return {
+    count,
+    min: ordered[0] ?? 0,
+    max: ordered[count - 1] ?? 0,
+    mean: sum / count,
+    median,
+    p90: percentile(ordered, 0.9),
+  };
+}
+
+function zeroCounts<T extends string>(keys: readonly T[]): Record<T, number> {
+  return Object.fromEntries(keys.map((key) => [key, 0])) as Record<T, number>;
+}
+
+export function computePredictionRealismMetrics(params: {
+  markets: PredictionMarketDiagnosticInput[];
+  priceHistory: PredictionHistoryPoint[];
+  now?: Date;
+}): PredictionRealismMetrics {
+  const now = params.now ?? new Date();
+  const horizonBuckets = zeroCounts(['short', 'medium', 'long'] as const);
+  const urgencyLevels = zeroCounts(
+    ['imminent', 'near-term', 'dated'] as const
+  );
+  const eventSensitivity = zeroCounts(['low', 'medium', 'high'] as const);
+  const liquidityTiers = zeroCounts(['thin', 'balanced', 'deep'] as const);
+
+  const yesPrices: number[] = [];
+  const distanceFromMid: number[] = [];
+
+  for (const market of params.markets) {
+    const yesPrice = PredictionPricing.getCurrentPrice(
+      market.yesShares,
+      market.noShares,
+      'yes'
+    );
+    const profile = buildPredictionMarketProfile({
+      marketId: market.id,
+      question: market.question,
+      endDate: market.endDate,
+      now,
+    });
+
+    horizonBuckets[profile.horizonBucket]++;
+    urgencyLevels[profile.urgencyLevel]++;
+    eventSensitivity[profile.eventSensitivity]++;
+    liquidityTiers[getPredictionMarketLiquidityTier(market.liquidity)]++;
+    yesPrices.push(yesPrice);
+    distanceFromMid.push(Math.abs(yesPrice - 0.5));
+  }
+
+  const nearMidCount = yesPrices.filter((price) => Math.abs(price - 0.5) <= 0.05)
+    .length;
+  const extremeCount = yesPrices.filter(
+    (price) => price <= 0.2 || price >= 0.8
+  ).length;
+
+  const historyByMarket = new Map<string, PredictionHistoryPoint[]>();
+  for (const point of params.priceHistory) {
+    const existing = historyByMarket.get(point.marketId) ?? [];
+    existing.push(point);
+    historyByMarket.set(point.marketId, existing);
+  }
+
+  const priceChange24h = Array.from(historyByMarket.values())
+    .map((points) => sorted(points.map((point) => point.createdAt.getTime())))
+    .length;
+
+  const marketPriceChange24h = Array.from(historyByMarket.entries())
+    .map(([marketId, points]) => {
+      const ordered = [...points].sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+      );
+      const first = ordered[0];
+      const last = ordered[ordered.length - 1];
+      if (!first || !last || first.createdAt.getTime() === last.createdAt.getTime()) {
+        return null;
+      }
+      return Math.abs(last.yesPrice - first.yesPrice);
+    })
+    .filter((value): value is number => value !== null);
+
+  const warnings: string[] = [];
+  const yesPriceSummary = summarizeSeries(yesPrices);
+  const distanceSummary = summarizeSeries(distanceFromMid);
+  const priceChangeSummary = summarizeSeries(marketPriceChange24h);
+
+  if (yesPriceSummary && yesPriceSummary.max - yesPriceSummary.min < 0.15) {
+    warnings.push(
+      'Prediction price dispersion is narrow; markets may still feel too similar.'
+    );
+  }
+
+  if (
+    params.markets.length > 0 &&
+    nearMidCount / params.markets.length > 0.7
+  ) {
+    warnings.push(
+      'Most prediction markets are clustered near 50/50; consider stronger profile/event differentiation.'
+    );
+  }
+
+  if (Object.values(eventSensitivity).every((count) => count === 0)) {
+    warnings.push('Prediction event sensitivity buckets are unexpectedly empty.');
+  }
+
+  return {
+    activeMarkets: params.markets.length,
+    yesPriceDispersion: yesPriceSummary,
+    distanceFromMid: distanceSummary,
+    priceChange24h: priceChangeSummary,
+    nearMidCount,
+    extremeCount,
+    horizonBuckets,
+    urgencyLevels,
+    eventSensitivity,
+    liquidityTiers,
+    warnings,
+  };
+}
+
+export function computePerpRealismMetrics(params: {
+  markets: PerpRealismDiagnosticInput[];
+  now?: Date;
+  sampleOrderSizes?: number[];
+}): PerpRealismMetrics {
+  const now = params.now ?? new Date();
+  const sampleOrderSizes = params.sampleOrderSizes ?? [1000, 5000];
+  const liquidityRegimes = zeroCounts(['thin', 'balanced', 'deep'] as const);
+
+  const coveredMarkets = params.markets.filter(
+    (market) =>
+      market.bidPrice !== undefined &&
+      market.askPrice !== undefined &&
+      market.spreadBps !== undefined &&
+      market.bidDepth !== undefined &&
+      market.askDepth !== undefined
+  );
+
+  const spreads = coveredMarkets
+    .map((market) => market.spreadBps)
+    .filter((value): value is number => typeof value === 'number');
+  const bidDepths = coveredMarkets
+    .map((market) => market.bidDepth)
+    .filter((value): value is number => typeof value === 'number');
+  const askDepths = coveredMarkets
+    .map((market) => market.askDepth)
+    .filter((value): value is number => typeof value === 'number');
+
+  let staleQuotesCount = 0;
+  for (const market of params.markets) {
+    const regime = market.liquidityRegime ?? 'thin';
+    liquidityRegimes[regime]++;
+    if (
+      market.quoteUpdatedAt &&
+      now.getTime() - market.quoteUpdatedAt.getTime() > 30 * 60 * 1000
+    ) {
+      staleQuotesCount++;
+    }
+  }
+
+  const depthRatioByOrderSize = Object.fromEntries(
+    sampleOrderSizes.map((size) => [
+      String(size),
+      summarizeSeries(
+        coveredMarkets.map((market) => size / Math.max(market.askDepth ?? 1, 1))
+      ),
+    ])
+  ) as Record<string, SummaryStats | null>;
+
+  const warnings: string[] = [];
+  const spreadSummary = summarizeSeries(spreads);
+
+  if (params.markets.length > 0 && coveredMarkets.length !== params.markets.length) {
+    warnings.push('Some perp markets are missing quote-state fields.');
+  }
+
+  if (spreadSummary && spreadSummary.max - spreadSummary.min < 10) {
+    warnings.push(
+      'Perp spread dispersion is narrow; market personalities may still be too uniform.'
+    );
+  }
+
+  if (staleQuotesCount > 0) {
+    warnings.push(`${staleQuotesCount} perp markets have stale quote timestamps.`);
+  }
+
+  return {
+    activeMarkets: params.markets.length,
+    quoteCoverageRate:
+      params.markets.length > 0 ? coveredMarkets.length / params.markets.length : 0,
+    spreadBps: spreadSummary,
+    bidDepth: summarizeSeries(bidDepths),
+    askDepth: summarizeSeries(askDepths),
+    depthRatioByOrderSize,
+    liquidityRegimes,
+    staleQuotesCount,
+    warnings,
+  };
+}

--- a/scripts/market-realism-report.ts
+++ b/scripts/market-realism-report.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env bun
+
+import { parseArgs } from 'node:util';
+import { db } from '@babylon/db';
+import {
+  initializeDatabaseMode,
+} from '@babylon/engine';
+import {
+  markets,
+  perpMarketSnapshots,
+  predictionPriceHistories,
+} from '@babylon/db/schema';
+import { desc, gte } from 'drizzle-orm';
+import {
+  computePerpRealismMetrics,
+  computePredictionRealismMetrics,
+  type SummaryStats,
+} from '../packages/engine/src/services/market-realism-metrics';
+
+const { values: args } = parseArgs({
+  options: {
+    json: { type: 'boolean', default: false },
+    hours: { type: 'string', default: '24' },
+  },
+  strict: true,
+});
+
+const hours = Number.parseInt(args.hours ?? '24', 10);
+if (!Number.isFinite(hours) || hours <= 0) {
+  throw new Error('--hours must be a positive integer');
+}
+
+function formatStat(stat: SummaryStats | null, digits = 2): string {
+  if (!stat) return 'n/a';
+  return `min ${stat.min.toFixed(digits)} | p50 ${stat.median.toFixed(
+    digits
+  )} | mean ${stat.mean.toFixed(digits)} | p90 ${stat.p90.toFixed(
+    digits
+  )} | max ${stat.max.toFixed(digits)}`;
+}
+
+function formatBuckets(record: Record<string, number>): string {
+  return Object.entries(record)
+    .map(([key, value]) => `${key}:${value}`)
+    .join(' | ');
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error(
+      'DATABASE_URL is required to run market realism diagnostics.'
+    );
+  }
+
+  initializeDatabaseMode();
+  const now = new Date();
+  const since = new Date(now.getTime() - hours * 60 * 60 * 1000);
+
+  const predictionMarkets = await db
+    .select({
+      id: markets.id,
+      question: markets.question,
+      yesShares: markets.yesShares,
+      noShares: markets.noShares,
+      liquidity: markets.liquidity,
+      endDate: markets.endDate,
+    })
+    .from(markets)
+    .where(gte(markets.endDate, now))
+    .orderBy(desc(markets.createdAt));
+
+  const predictionHistory = await db
+    .select({
+      marketId: predictionPriceHistories.marketId,
+      yesPrice: predictionPriceHistories.yesPrice,
+      createdAt: predictionPriceHistories.createdAt,
+    })
+    .from(predictionPriceHistories)
+    .where(gte(predictionPriceHistories.createdAt, since))
+    .orderBy(desc(predictionPriceHistories.createdAt));
+
+  const perpRows = await db
+    .select({
+      ticker: perpMarketSnapshots.ticker,
+      openInterest: perpMarketSnapshots.openInterest,
+      volume24h: perpMarketSnapshots.volume24h,
+      bidPrice: perpMarketSnapshots.bidPrice,
+      askPrice: perpMarketSnapshots.askPrice,
+      spreadBps: perpMarketSnapshots.spreadBps,
+      bidDepth: perpMarketSnapshots.bidDepth,
+      askDepth: perpMarketSnapshots.askDepth,
+      liquidityRegime: perpMarketSnapshots.liquidityRegime,
+      quoteUpdatedAt: perpMarketSnapshots.quoteUpdatedAt,
+    })
+    .from(perpMarketSnapshots)
+    .orderBy(desc(perpMarketSnapshots.openInterest));
+
+  const predictionMetrics = computePredictionRealismMetrics({
+    markets: predictionMarkets.map((market) => ({
+      id: market.id,
+      question: market.question,
+      yesShares: Number(market.yesShares),
+      noShares: Number(market.noShares),
+      liquidity: Number(market.liquidity),
+      endDate: market.endDate,
+    })),
+    priceHistory: predictionHistory.map((point) => ({
+      marketId: point.marketId,
+      yesPrice: point.yesPrice,
+      createdAt: point.createdAt,
+    })),
+    now,
+  });
+
+  const perpMetrics = computePerpRealismMetrics({
+    markets: perpRows.map((row) => ({
+      ticker: row.ticker,
+      openInterest: Number(row.openInterest),
+      volume24h: Number(row.volume24h),
+      bidPrice: row.bidPrice ? Number(row.bidPrice) : undefined,
+      askPrice: row.askPrice ? Number(row.askPrice) : undefined,
+      spreadBps: row.spreadBps ? Number(row.spreadBps) : undefined,
+      bidDepth: row.bidDepth ? Number(row.bidDepth) : undefined,
+      askDepth: row.askDepth ? Number(row.askDepth) : undefined,
+      liquidityRegime:
+        (row.liquidityRegime as 'thin' | 'balanced' | 'deep' | null) ??
+        undefined,
+      quoteUpdatedAt: row.quoteUpdatedAt ?? undefined,
+    })),
+    now,
+  });
+
+  const report = {
+    generatedAt: now.toISOString(),
+    windowHours: hours,
+    predictions: predictionMetrics,
+    perps: perpMetrics,
+  };
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  console.log('Market Realism Report');
+  console.log(`Generated: ${now.toISOString()}`);
+  console.log(`Window: ${hours}h`);
+  console.log('');
+
+  console.log('Predictions');
+  console.log(`- Active markets: ${predictionMetrics.activeMarkets}`);
+  console.log(
+    `- YES price dispersion: ${formatStat(predictionMetrics.yesPriceDispersion, 3)}`
+  );
+  console.log(
+    `- Distance from 50/50: ${formatStat(predictionMetrics.distanceFromMid, 3)}`
+  );
+  console.log(
+    `- 24h price change: ${formatStat(predictionMetrics.priceChange24h, 3)}`
+  );
+  console.log(
+    `- Near 50/50: ${predictionMetrics.nearMidCount} | Extreme: ${predictionMetrics.extremeCount}`
+  );
+  console.log(`- Horizons: ${formatBuckets(predictionMetrics.horizonBuckets)}`);
+  console.log(`- Urgency: ${formatBuckets(predictionMetrics.urgencyLevels)}`);
+  console.log(
+    `- Event sensitivity: ${formatBuckets(predictionMetrics.eventSensitivity)}`
+  );
+  console.log(
+    `- Liquidity tiers: ${formatBuckets(predictionMetrics.liquidityTiers)}`
+  );
+  if (predictionMetrics.warnings.length > 0) {
+    console.log('- Warnings:');
+    for (const warning of predictionMetrics.warnings) {
+      console.log(`  - ${warning}`);
+    }
+  }
+  console.log('');
+
+  console.log('Perps');
+  console.log(`- Active markets: ${perpMetrics.activeMarkets}`);
+  console.log(
+    `- Quote coverage: ${(perpMetrics.quoteCoverageRate * 100).toFixed(1)}%`
+  );
+  console.log(`- Spread bps: ${formatStat(perpMetrics.spreadBps, 1)}`);
+  console.log(`- Bid depth: ${formatStat(perpMetrics.bidDepth, 0)}`);
+  console.log(`- Ask depth: ${formatStat(perpMetrics.askDepth, 0)}`);
+  console.log(`- Liquidity regimes: ${formatBuckets(perpMetrics.liquidityRegimes)}`);
+  console.log(`- Stale quotes: ${perpMetrics.staleQuotesCount}`);
+  for (const [size, stats] of Object.entries(perpMetrics.depthRatioByOrderSize)) {
+    console.log(`- Size/depth ratio @ ${size}: ${formatStat(stats, 2)}`);
+  }
+  if (perpMetrics.warnings.length > 0) {
+    console.log('- Warnings:');
+    for (const warning of perpMetrics.warnings) {
+      console.log(`  - ${warning}`);
+    }
+  }
+}
+
+void main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Market realism report failed: ${message}`);
+  process.exitCode = 1;
+});

--- a/scripts/market-realism-report.ts
+++ b/scripts/market-realism-report.ts
@@ -10,7 +10,7 @@ import {
   perpMarketSnapshots,
   predictionPriceHistories,
 } from '@babylon/db/schema';
-import { desc, gte } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray } from 'drizzle-orm';
 import {
   computePerpRealismMetrics,
   computePredictionRealismMetrics,
@@ -66,18 +66,28 @@ async function main() {
       endDate: markets.endDate,
     })
     .from(markets)
-    .where(gte(markets.endDate, now))
+    .where(and(eq(markets.resolved, false), gte(markets.endDate, now)))
     .orderBy(desc(markets.createdAt));
 
-  const predictionHistory = await db
-    .select({
-      marketId: predictionPriceHistories.marketId,
-      yesPrice: predictionPriceHistories.yesPrice,
-      createdAt: predictionPriceHistories.createdAt,
-    })
-    .from(predictionPriceHistories)
-    .where(gte(predictionPriceHistories.createdAt, since))
-    .orderBy(desc(predictionPriceHistories.createdAt));
+  const activePredictionMarketIds = predictionMarkets.map((market) => market.id);
+
+  const predictionHistory =
+    activePredictionMarketIds.length > 0
+      ? await db
+          .select({
+            marketId: predictionPriceHistories.marketId,
+            yesPrice: predictionPriceHistories.yesPrice,
+            createdAt: predictionPriceHistories.createdAt,
+          })
+          .from(predictionPriceHistories)
+          .where(
+            and(
+              gte(predictionPriceHistories.createdAt, since),
+              inArray(predictionPriceHistories.marketId, activePredictionMarketIds)
+            )
+          )
+          .orderBy(desc(predictionPriceHistories.createdAt))
+      : [];
 
   const perpRows = await db
     .select({


### PR DESCRIPTION
## Summary
- add a first calibration/diagnostics report for market realism across prediction markets and perps
- compute reusable market-realism metrics in pure helpers so diagnostics stay testable and easy to extend
- expose the report as `bun run report:realism` for ongoing tuning and regression checks

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- This is the first concrete slice of Track C (calibration / validation) after the market realism structure work on perps and prediction markets
- Goal: move from “we changed the system” to “we can observe and tune the system”

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Web UI (`apps/web`)
- [ ] Other areas

## Non-goals / follow-ups
- No admin UI yet
- No automatic tuning yet
- No persistent metrics store yet
- This PR focuses on diagnostics/reporting only

## Changes
- add `market-realism-metrics.ts` with pure helpers for prediction/perp realism summaries
- add unit coverage for the new metrics helpers
- add `scripts/market-realism-report.ts` CLI report to inspect current market realism from canonical market data
- add `bun run report:realism`

## Review guide
**Start here**
- `packages/engine/src/services/market-realism-metrics.ts`
- `scripts/market-realism-report.ts`
- `packages/engine/src/services/market-realism-metrics.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The report is intentionally read-only.
- It focuses on immediately actionable metrics: price dispersion, distance from 50/50, quote coverage, spread/depth dispersion, stale quotes, and simple warnings.
- I intentionally kept the perp side to canonical quote/depth metrics instead of introducing a second synthetic impact model just for diagnostics.

## Test plan
**Commands run**
- [ ] `bun run check`
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test`

**Focused verification / manual verification**
1. `bunx biome check --write package.json packages/engine/src/services/market-realism-metrics.ts packages/engine/src/services/market-realism-metrics.test.ts scripts/market-realism-report.ts`
2. `bun test packages/engine/src/services/market-realism-metrics.test.ts`
3. Attempted `bun run report:realism -- --json` from the isolated worktree, but this worktree does not have the full workspace dependency environment available; the script itself is read-only and should be exercised from a normal repo checkout with env/deps in place.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates
- [ ] Requires DB migration
- [ ] Changes cron schedule or endpoints
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes
- [x] None
- [ ] Yes

## Security / privacy
- [x] No security impact
- [ ] Needs extra review

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Developer diagnostics/reporting only. No end-user UI change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path
- [x] Handlers remain thin and portable
- [x] Domain logic stays in packages
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] **Screenshots/recordings section filled**
