### PR TITLE
feat(markets): screener T/Q notionals, numeric guards, org avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Markets trending screener — display formatting & org avatars**
+  - **Why (OI / 24h vol column width)**: Compact formatters stopped at **billions** (`B`). When open interest or volume exceeded ~1e12, the UI still divided by 1e9 and printed a huge mantissa (e.g. `ƀ81309980567587.61B`), blowing table layout. **T** (trillion) and **Q** (quadrillion) tiers in `formatVolume`, `formatCompactCurrency`, `formatCompactNumber`, and the terminal’s local `formatCompactNumber` keep strings short and comparable across rows.
+  - **Why (guards on Price / 24h % / Fund.)**: Raw `.toFixed()` on non-finite or extreme API values produced `NaN%`, `Infinity%`, or multi-hundred-character strings. `formatPrice`, `formatChange24h`, and `formatFundingApr` in `apps/web/src/app/markets/_lib/formatters.ts` use `Number.isFinite` and display clamps so bad data never widens columns; sorting still uses raw numbers in `sortPerpsForScreener`.
+  - **Why (org image in Asset column)**: Initials-only tiles looked like missing logos; static org art already lives at `/images/organizations/{organizationId}.jpg`. `TrendingScreenerTable` uses `Avatar` with `type="business"` and `organizationId` so real logos show when files exist; `Avatar` falls back to initials when the image fails or the id is numeric-only (no static file convention).
+  - **Why (`formatBalance` guard)**: Same class of bug as price — `toLocaleString` on `NaN` is user-visible garbage; non-finite balances now show `ƀ—`.
+  - **Docs**: `docs/markets/trending-screener.md` — section **Display & formatting**; tests in `packages/testing/unit/markets/market-cards.test.ts` and `packages/testing/unit/shared/format.test.ts`.
+
 ### Added
 
 - **Markets API caching and real-time updates (Terminal performance)**

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -265,10 +265,19 @@ function formatYesPct(raw: number): string {
   return `${rounded.toFixed(clamped >= 10 ? 0 : 1)}%`;
 }
 
+/** Sidebar “Vol …” labels; tiers must stay aligned with `packages/shared` `formatCompactNumber` (T/Q). */
 function formatCompactNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return Math.round(n).toLocaleString();
+  if (!Number.isFinite(n)) {
+    return '0';
+  }
+  const sign = n < 0 ? '-' : '';
+  const abs = Math.abs(n);
+  if (abs >= 1e15) return `${sign}${(abs / 1e15).toFixed(1)}Q`;
+  if (abs >= 1e12) return `${sign}${(abs / 1e12).toFixed(1)}T`;
+  if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(1)}B`;
+  if (abs >= 1_000_000) return `${sign}${(abs / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${sign}${(abs / 1_000).toFixed(1)}K`;
+  return `${sign}${Math.round(abs).toLocaleString()}`;
 }
 
 function formatDate(dateStr: string | undefined | null): string {

--- a/apps/web/src/app/markets/_lib/README.md
+++ b/apps/web/src/app/markets/_lib/README.md
@@ -1,0 +1,18 @@
+# Markets `_lib` — shared helpers for the markets routes
+
+## `formatters.ts`
+
+**Purpose:** Format Babylon points, volumes, and percentages for **dense tables** (trending screener, prediction volume column, etc.).
+
+**WHY not only `@babylon/shared`:**
+
+- Screener-specific rules: **ƀ** prefix, **T/Q** volume tiers (so OI and 24h vol never print 15-digit `…B` strings), and **em dash** for non-finite API values.
+- Shared `formatCompactCurrency` / `formatCompactNumber` serve **engine and prompts** with slightly different defaults (e.g. decimal places). Keeping web table rules here avoids coupling every UI tweak to NPC context.
+
+**Documentation:** [`docs/markets/trending-screener.md`](../../../../../../docs/markets/trending-screener.md) → **Display & formatting**.
+
+**Tests:** [`packages/testing/unit/markets/market-cards.test.ts`](../../../../../../packages/testing/unit/markets/market-cards.test.ts).
+
+## Other exports
+
+- **`getDaysLeft`**, **`calculateSharePercentages`** — prediction UI helpers; documented inline in `formatters.ts`.

--- a/apps/web/src/app/markets/_lib/formatters.ts
+++ b/apps/web/src/app/markets/_lib/formatters.ts
@@ -1,27 +1,78 @@
 /**
- * Utility functions for formatting values in the Markets page.
+ * Markets UI formatting helpers (`/markets`, `/markets/trending`, prediction tables).
+ *
+ * **WHY this file (not only `@babylon/shared`):** Screener tables need Babylon-specific
+ * rules: ƀ prefix, column-width safety (compact T/Q tiers), and “missing value” glyphs
+ * for bad API data. Shared `formatCompactCurrency` serves engine/prompts; these helpers
+ * target **dense tables** where `NaN%` or a 20-digit `…B` string breaks layout.
+ *
+ * **Docs:** `docs/markets/trending-screener.md` → “Display & formatting”.
  */
 
 import { PredictionPricing } from '@babylon/core/markets/prediction/client';
 import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
 
+/** U+2014 — single missing-value glyph; avoids “NaN” / empty string ambiguity in tables. */
+const EM_DASH = '\u2014';
+
 /**
- * Formats a price value as Babylon points currency.
+ * Perp / table price in Babylon points.
  *
- * @param price - The price to format
- * @returns Formatted price string (e.g., "ƀ123.45")
+ * **WHY `Number.isFinite`:** A poisoned `currentPrice` would render `ƀNaN` and stretch
+ * or confuse readers; em dash matches other guarded columns.
  */
 export function formatPrice(price: number): string {
+  if (!Number.isFinite(price)) {
+    return `${BABYLON_POINTS_SYMBOL}${EM_DASH}`;
+  }
   return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
 }
 
 /**
- * Formats a Babylon points balance with 2 decimals and separators.
+ * 24h change for sortable screener columns.
  *
- * @param balance - The balance to format
- * @returns Formatted balance string (e.g., "ƀ12,345.00")
+ * **WHY clamp ±9999.99%:** Extreme outliers should not produce 10+ character mantissas.
+ * **WHY leading `+`:** Matches trader screener convention; negatives keep a single `-` from `toFixed`.
+ * **WHY not alter sort:** Callers sort on raw `changePercent24h`; this is display-only.
+ */
+export function formatChange24h(pct: number): string {
+  if (!Number.isFinite(pct)) {
+    return EM_DASH;
+  }
+  const clamped = Math.max(-9999.99, Math.min(9999.99, pct));
+  const sign = clamped >= 0 ? '+' : '';
+  return `${sign}${clamped.toFixed(2)}%`;
+}
+
+/**
+ * Funding APR from annual **decimal** rate (`0.01` → `+1.00%`), per `PerpMarketService` storage.
+ *
+ * **WHY clamp ±999.99%:** Engine caps near ~50% APR; corrupt JSON should never widen the Fund. column.
+ * **WHY `decimals` option:** Screener uses 2; detail panels may pass 4 without duplicating math.
+ */
+export function formatFundingApr(
+  rate: number,
+  options: { decimals?: number } = {}
+): string {
+  const decimals = options.decimals ?? 2;
+  if (!Number.isFinite(rate)) {
+    return EM_DASH;
+  }
+  const pct = rate * 100;
+  const clamped = Math.max(-999.99, Math.min(999.99, pct));
+  const sign = clamped >= 0 ? '+' : '';
+  return `${sign}${clamped.toFixed(decimals)}%`;
+}
+
+/**
+ * Balance with locale grouping (user-facing readability).
+ *
+ * **WHY finite guard:** `toLocaleString` on `NaN` yields a literal “NaN” in many locales.
  */
 export function formatBalance(balance: number): string {
+  if (!Number.isFinite(balance)) {
+    return `${BABYLON_POINTS_SYMBOL}${EM_DASH}`;
+  }
   return `${BABYLON_POINTS_SYMBOL}${balance.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
@@ -29,20 +80,34 @@ export function formatBalance(balance: number): string {
 }
 
 /**
- * Formats a volume value with appropriate suffix (K, M, B).
- * Values under ƀ1,000 are displayed without suffix.
+ * Open interest, 24h volume, or prediction share totals — compact ƀ + suffix.
  *
- * @param volume - The volume to format
- * @returns Formatted volume string (e.g., "ƀ1.23M", "ƀ500.00")
+ * **WHY T and Q tiers:** Stopping at `B` left values like 1e16 as `ƀ10000000.00B` (useless width).
+ * **WHY 2 decimals:** Aligns OI and Vol columns visually; shared `formatCompactNumber` uses 1 dp for different UX.
+ * **WHY non-finite → ƀ—:** Same “missing metric” pattern as price.
  */
 export function formatVolume(volume: number): string {
-  if (volume >= 1e9)
-    return `${BABYLON_POINTS_SYMBOL}${(volume / 1e9).toFixed(2)}B`;
-  if (volume >= 1e6)
-    return `${BABYLON_POINTS_SYMBOL}${(volume / 1e6).toFixed(2)}M`;
-  if (volume >= 1e3)
-    return `${BABYLON_POINTS_SYMBOL}${(volume / 1e3).toFixed(2)}K`;
-  return `${BABYLON_POINTS_SYMBOL}${volume.toFixed(2)}`;
+  if (!Number.isFinite(volume)) {
+    return `${BABYLON_POINTS_SYMBOL}${EM_DASH}`;
+  }
+  const abs = Math.abs(volume);
+  const sign = volume < 0 ? '-' : '';
+  if (abs >= 1e15) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1e15).toFixed(2)}Q`;
+  }
+  if (abs >= 1e12) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1e12).toFixed(2)}T`;
+  }
+  if (abs >= 1e9) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1e9).toFixed(2)}B`;
+  }
+  if (abs >= 1e6) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1e6).toFixed(2)}M`;
+  }
+  if (abs >= 1e3) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1e3).toFixed(2)}K`;
+  }
+  return `${sign}${BABYLON_POINTS_SYMBOL}${abs.toFixed(2)}`;
 }
 
 /**

--- a/apps/web/src/app/markets/_lib/formatters.ts
+++ b/apps/web/src/app/markets/_lib/formatters.ts
@@ -25,7 +25,8 @@ export function formatPrice(price: number): string {
   if (!Number.isFinite(price)) {
     return `${BABYLON_POINTS_SYMBOL}${EM_DASH}`;
   }
-  return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
+  const sign = price < 0 ? '-' : '';
+  return `${sign}${BABYLON_POINTS_SYMBOL}${Math.abs(price).toFixed(2)}`;
 }
 
 /**
@@ -73,7 +74,8 @@ export function formatBalance(balance: number): string {
   if (!Number.isFinite(balance)) {
     return `${BABYLON_POINTS_SYMBOL}${EM_DASH}`;
   }
-  return `${BABYLON_POINTS_SYMBOL}${balance.toLocaleString(undefined, {
+  const sign = balance < 0 ? '-' : '';
+  return `${sign}${BABYLON_POINTS_SYMBOL}${Math.abs(balance).toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })}`;

--- a/apps/web/src/app/markets/trending/README.md
+++ b/apps/web/src/app/markets/trending/README.md
@@ -29,6 +29,9 @@ Next.js App Router keeps route-specific UI next to `page.tsx`. The screener is *
 | Perp polling (30 s) | `page.tsx` → `usePerpMarketsPolling(30_000)` — WHY: ensures refresh even when SSE reconnects are slow |
 | SSE prediction patching (real-time) | `useMarketsPageData` → `useSSEChannel('markets', ...)` — patches trades, resolutions, cancellations in-place |
 | Redis cache-aside on APIs | [`docs/markets/markets-api-caching.md`](../../../../../../docs/markets/markets-api-caching.md) |
+| OI / vol / price / 24h % / funding display | `../_lib/formatters.ts` — WHY: T/Q compact tiers + finite guards keep columns scannable (`docs/markets/trending-screener.md` → Display & formatting) |
+| Org logo tile (perp Asset column) | `_components/TrendingScreenerTable.tsx` → `Avatar type="business"` — WHY: `public/images/organizations/{id}.jpg`; initials when missing |
+| Terminal sidebar “Vol …” | `../_components/terminal/MarketsTradingTerminal.tsx` → `formatCompactNumber` — WHY: same tier rules as `@babylon/shared`; local to avoid import churn |
 
 ## Touch points when changing behavior
 
@@ -36,3 +39,4 @@ Next.js App Router keeps route-specific UI next to `page.tsx`. The screener is *
 2. **Search** — do not bypass `deferredSearchQuery` for one tab without updating both.
 3. **New columns** — only add fields that exist on `PerpMarket` / prediction types, or document API work in `docs/markets/trending-screener.md`.
 4. **New localStorage keys** — document in `docs/markets/trending-screener.md` and validate reads in `page.tsx` (never trust raw `JSON.parse`).
+5. **New numeric columns** — use `../_lib/formatters.ts` or extend it; document **WHY** (layout, precision) in `docs/markets/trending-screener.md` and add tests in `packages/testing/unit/markets/market-cards.test.ts` when behavior is user-visible.

--- a/apps/web/src/app/markets/trending/_components/PredictionsScreenerTable.tsx
+++ b/apps/web/src/app/markets/trending/_components/PredictionsScreenerTable.tsx
@@ -147,7 +147,7 @@ function SortableHeader({
         <button
           type="button"
           className={cn(
-            'inline-flex w-full items-center gap-1 cursor-pointer select-none',
+            'inline-flex w-full cursor-pointer select-none items-center gap-1',
             alignment
           )}
           onClick={() => onSort(col.key!)}

--- a/apps/web/src/app/markets/trending/_components/TrendingScreenerTable.tsx
+++ b/apps/web/src/app/markets/trending/_components/TrendingScreenerTable.tsx
@@ -286,7 +286,6 @@ export const TrendingScreenerTable = memo(function TrendingScreenerTable({
                             type="business"
                             id={m.organizationId}
                             name={m.name}
-                            alt=""
                             size="sm"
                             className="h-full w-full rounded-md"
                           />

--- a/apps/web/src/app/markets/trending/_components/TrendingScreenerTable.tsx
+++ b/apps/web/src/app/markets/trending/_components/TrendingScreenerTable.tsx
@@ -1,11 +1,28 @@
 'use client';
 
+/**
+ * Perpetual markets table for `/markets/trending`.
+ *
+ * **WHY formatting imports:** OI, 24h vol, price, 24h %, and funding use `@/app/markets/_lib/formatters`
+ * so non-finite data and oversized notionals never blow column width (see `docs/markets/trending-screener.md`).
+ *
+ * **WHY `Avatar` for Asset:** Org logos live at `/images/organizations/{organizationId}.jpg`; initials-only
+ * tiles looked like missing branding. `type="business"` + `rounded-md` matches a square screener tile;
+ * numeric-only org ids skip static filenames by design inside `Avatar`.
+ */
+
 import { cn } from '@babylon/shared';
 import { ArrowDown, ArrowUp, ArrowUpDown, HelpCircle } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { memo, useCallback, useState } from 'react';
-import { formatPrice, formatVolume } from '@/app/markets/_lib/formatters';
+import {
+  formatChange24h,
+  formatFundingApr,
+  formatPrice,
+  formatVolume,
+} from '@/app/markets/_lib/formatters';
+import { Avatar } from '@/components/shared/Avatar';
 import { Tooltip } from '@/components/ui/tooltip';
 import type { PerpMarket } from '@/types/markets';
 import {
@@ -61,18 +78,6 @@ const COLUMNS: ColumnDef[] = [
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function initials(name: string, ticker: string): string {
-  const t = ticker.slice(0, 2).toUpperCase();
-  if (t.length >= 2) return t;
-  const w = name.trim().split(/\s+/)[0];
-  return w ? w.slice(0, 2).toUpperCase() : '??';
-}
-
-function formatFundingApr(rate: number): string {
-  const pct = rate * 100;
-  return `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`;
-}
 
 function tradeHref(m: PerpMarket): string {
   const q = new URLSearchParams({
@@ -154,7 +159,7 @@ function SortableHeader({
         <button
           type="button"
           className={cn(
-            'inline-flex w-full items-center gap-1 cursor-pointer select-none',
+            'inline-flex w-full cursor-pointer select-none items-center gap-1',
             alignment
           )}
           // Note: Non-null assertion reflects confidence `col.key` is truthy after the prior check.
@@ -250,7 +255,8 @@ export const TrendingScreenerTable = memo(function TrendingScreenerTable({
               </tr>
             ) : (
               rows.map((m) => {
-                const up = m.changePercent24h >= 0;
+                const finiteChange = Number.isFinite(m.changePercent24h);
+                const up = finiteChange && m.changePercent24h >= 0;
                 const href = tradeHref(m);
                 const isNavigating = navigatingTicker === m.ticker;
                 return (
@@ -268,16 +274,22 @@ export const TrendingScreenerTable = memo(function TrendingScreenerTable({
                         onClick={(e) => e.stopPropagation()}
                         className="flex items-center gap-2"
                       >
+                        {/* Avatar defaults to rounded-full; !rounded-md matches the screener tile (square with radius). */}
                         <div
                           className={cn(
-                            'flex h-9 w-9 shrink-0 items-center justify-center rounded-md font-bold text-[10px]',
-                            isNavigating
-                              ? 'animate-pulse bg-primary/20 text-primary'
-                              : 'bg-muted text-muted-foreground'
+                            'h-9 w-9 shrink-0 overflow-hidden rounded-md',
+                            isNavigating &&
+                              'animate-pulse ring-2 ring-primary/30'
                           )}
-                          aria-hidden
                         >
-                          {initials(m.name, m.ticker)}
+                          <Avatar
+                            type="business"
+                            id={m.organizationId}
+                            name={m.name}
+                            alt=""
+                            size="sm"
+                            className="h-full w-full rounded-md"
+                          />
                         </div>
                         <div className="min-w-0">
                           <div className="truncate font-semibold text-foreground">
@@ -302,11 +314,12 @@ export const TrendingScreenerTable = memo(function TrendingScreenerTable({
                     <td
                       className={cn(
                         'whitespace-nowrap px-3 py-2 text-right font-mono font-semibold text-xs',
-                        up ? 'text-green-600' : 'text-red-600'
+                        !finiteChange && 'text-muted-foreground',
+                        finiteChange && up && 'text-green-600',
+                        finiteChange && !up && 'text-red-600'
                       )}
                     >
-                      {up ? '+' : ''}
-                      {m.changePercent24h.toFixed(2)}%
+                      {formatChange24h(m.changePercent24h)}
                     </td>
                     <td className="whitespace-nowrap px-3 py-2 text-right font-mono text-muted-foreground text-xs">
                       {formatVolume(m.openInterest)}

--- a/docs/markets/README.md
+++ b/docs/markets/README.md
@@ -4,8 +4,13 @@ Design notes, rationale (**WHY**), and pointers for the markets product surface 
 
 | Doc | Purpose |
 |-----|---------|
-| [trending-screener.md](./trending-screener.md) | `/markets/trending` browse-first screener: flows, deep links, code map, roadmap, rate limits |
+| [trending-screener.md](./trending-screener.md) | `/markets/trending` browse-first screener: flows, deep links, **display formatting (compact tiers, guards, org avatars)**, code map, roadmap, rate limits |
 | [markets-api-caching.md](./markets-api-caching.md) | Redis cache-aside for markets list APIs, SSE patching, invalidation topology, pagination, known caveats |
 | Root [CHANGELOG.md](../../CHANGELOG.md) | What shipped, with **WHY** bullets where it helps reviewers |
 
 **Why a `docs/markets/` folder:** Keeps product/architecture notes next to the domain without scattering READMEs across every route. App Router code stays in `apps/web`; long-form rationale lives here so agents and humans find one index.
+
+**See also (code-adjacent READMEs):**
+
+- [`apps/web/src/app/markets/_lib/README.md`](../../apps/web/src/app/markets/_lib/README.md) — why `formatters.ts` lives next to routes vs only `@babylon/shared`.
+- [`apps/web/src/app/markets/trending/README.md`](../../apps/web/src/app/markets/trending/README.md) — quick dev map for the screener route.

--- a/docs/markets/trending-screener.md
+++ b/docs/markets/trending-screener.md
@@ -123,11 +123,11 @@ Dense tables break when **strings get wide** (wrong suffix tier) or **values are
 
 ### Organization image in the Asset column
 
-- **Path**: `/images/organizations/{organizationId}.jpg` under `apps/web/public/images/organizations/`.
+- **Path**: For non-numeric org ids, `Avatar` builds the static filename from `sanitizeId(organizationId)`, so place the file at `/images/organizations/{sanitizeId(organizationId)}.jpg` under `apps/web/public/images/organizations/` (not necessarily the raw id string).
 - **Component**: `Avatar` with `type="business"`, `id={organizationId}`, `name={name}` for alt/fallback initial.
-- **Why `Avatar`**: Centralizes static path, sanitize rules, and img `onError` → initials fallback.
+- **Why `Avatar`**: Centralizes static path construction, sanitize rules, and image fallback behavior: primary org image → `/assets/user-profiles/profile-*.jpg` fallback on load failure → initials fallback.
 - **Why `rounded-md` on the tile**: Screener uses **square tiles** with radius; default `Avatar` is `rounded-full` — merged `className` + wrapper `overflow-hidden` keeps the tile shape.
-- **Numeric-only org ids**: `Avatar` skips static filename lookup for all-digit ids (snowflake-style); fallback initials still work until API supplies `imageUrl`.
+- **Numeric-only org ids**: `Avatar` skips the static `/images/organizations/...` filename lookup entirely for all-digit ids (snowflake-style); fallback initials still work until API supplies `imageUrl`.
 
 ---
 

--- a/docs/markets/trending-screener.md
+++ b/docs/markets/trending-screener.md
@@ -65,7 +65,10 @@ Must stay aligned with `parseSelected()` in `MarketsTradingTerminal`:
 | `apps/web/src/app/markets/trending/_components/PerpSparklineCell.tsx` | Lazy sparkline from `usePerpHistory`. |
 | `apps/web/src/app/markets/trending/_lib/sortPerpsForScreener.ts` | Pure perp sort + cap; trending weights mirror dashboard logic. |
 | `apps/web/src/app/markets/_hooks/useMarketsPageData.ts` | Perp store, debounced filter, **one** predictions fetch, 429 retry, Strict Mode–safe mount effect. |
+| `apps/web/src/app/markets/_lib/formatters.ts` | Screener/table formatting: `formatVolume` (T/Q), `formatPrice`, `formatChange24h`, `formatFundingApr`, `formatBalance`, prediction helpers. |
 | `packages/testing/unit/markets/sort-perps-screener.test.ts` | Unit tests for perp sort. |
+| `packages/testing/unit/markets/market-cards.test.ts` | Unit tests for markets `_lib/formatters` (guards, T/Q, funding, change %). |
+| `packages/shared/src/utils/format.ts` | `formatCompactCurrency` / `formatCompactNumber` with T/Q for shared consumers. |
 
 ---
 
@@ -80,6 +83,54 @@ Reference UIs show mcap, pool liquidity, txn splits, etc. We intentionally **do 
 
 ---
 
+## Display & formatting
+
+Dense tables break when **strings get wide** (wrong suffix tier) or **values are non-finite** (NaN/Infinity from API glitches). This section documents what we format, where, and **why**.
+
+### Compact notional: K / M / B / T / Q
+
+| Suffix | Magnitude (divide by) | Why it exists |
+|--------|------------------------|---------------|
+| K | 1e3 | Human-readable thousands without full digit strings. |
+| M | 1e6 | Same for millions. |
+| B | 1e9 | Same for billions — was the **top** tier before huge OI/volume blew columns. |
+| T | 1e12 | Values above 1e12 were still shown as `X.XXB` with `X` enormous (e.g. 14 digits). **T** caps mantissa length. |
+| Q | 1e15 | Same for quadrillion-scale notionals; keeps worst-case cell width bounded. |
+
+**Where implemented**
+
+- **Screener & prediction volume cells** — `apps/web/src/app/markets/_lib/formatters.ts` → `formatVolume` (ƀ prefix, 2 decimals per tier).
+- **Shared package** — `packages/shared/src/utils/format.ts` → `formatCompactCurrency`, `formatCompactNumber` (engine, prompts, other UI).
+- **Trading terminal market list** — `MarketsTradingTerminal.tsx` local `formatCompactNumber` for sidebar “Vol …” text (**why duplicate**: avoids importing shared into a file that already has many concerns; tiers kept in sync intentionally).
+
+**Why not `Intl` compact notation everywhere**: We need a **stable ƀ + K/M/B/T/Q** vocabulary across NPC prompts, CLI-ish strings, and UI; custom tiers match product copy and tests.
+
+**Floating-point caveat**: JavaScript `number` loses integer precision above `Number.MAX_SAFE_INTEGER`. Formatting is for **display**; sort and business logic should not rely on string round-trips for huge IDs.
+
+### Finite guards and clamps (Price, 24h %, Fund., volume)
+
+| Helper | Column / use | Non-finite | Clamp | Why |
+|--------|----------------|------------|-------|-----|
+| `formatPrice` | Perp price | `ƀ—` | — | Avoids `ƀNaN` / `ƀInfinity`. |
+| `formatVolume` | OI, 24h vol, prediction volume | `ƀ—` | — | Same; negative signed rarely but supported for symmetry. |
+| `formatChange24h` | 24h % | `—` | ±9999.99% | Prevents absurd `%` strings; color uses `Number.isFinite` so NaN is muted, not red/green. |
+| `formatFundingApr` | Fund. | `—` | ±999.99% displayed | Engine caps near ~50% APR; clamp is **UI safety** for corrupt payloads, not economics. |
+| `formatBalance` | (markets balances) | `ƀ—` | — | `toLocaleString(NaN)` is ugly; consistent with price. |
+
+**Why em dash (U+2014)**: Single glyph, accessible “missing value” pattern; matches other panels (e.g. agents perp funding).
+
+**Why sort unchanged**: `sortPerpsForScreener` compares **raw numbers**. Display formatting must not change ranking.
+
+### Organization image in the Asset column
+
+- **Path**: `/images/organizations/{organizationId}.jpg` under `apps/web/public/images/organizations/`.
+- **Component**: `Avatar` with `type="business"`, `id={organizationId}`, `name={name}` for alt/fallback initial.
+- **Why `Avatar`**: Centralizes static path, sanitize rules, and img `onError` → initials fallback.
+- **Why `rounded-md` on the tile**: Screener uses **square tiles** with radius; default `Avatar` is `rounded-full` — merged `className` + wrapper `overflow-hidden` keeps the tile shape.
+- **Numeric-only org ids**: `Avatar` skips static filename lookup for all-digit ids (snowflake-style); fallback initials still work until API supplies `imageUrl`.
+
+---
+
 ## Navigation
 
 - **Terminal** `href`: `/markets/trending`.
@@ -89,7 +140,7 @@ Reference UIs show mcap, pool liquidity, txn splits, etc. We intentionally **do 
 
 ## Testing
 
-- **Unit**: `sortPerpsForScreener` modes.
+- **Unit**: `sortPerpsForScreener` modes; `market-cards.test.ts` for `apps/web/.../markets/_lib/formatters.ts`; `packages/testing/unit/shared/format.test.ts` for shared compact T/Q tiers.
 - **E2E**: Synpress `ROUTES.MARKETS_TRENDING`, `data-testid="markets-trending-screener"` / `markets-trending-predictions`.
 
 ---
@@ -105,7 +156,7 @@ Prioritized by impact and dependency on backend work.
 5. **Intraday list stats** — **Why**: If product needs list columns to match short time windows, the API must expose windowed aggregates (avoid client-side lies).
 6. **Virtualized rows** — **Why**: When market count grows past ~100, DOM + observers cost rises; virtualization keeps scroll smooth.
 7. **Column visibility (“eye” tool)** — **Why**: Power users on small laptops can hide OI or funding; low priority vs correctness.
-8. **Org avatars** — **Why**: Replace initials when a stable image URL exists on org/perp metadata (no fabricated token art).
+8. ~~**Org avatars**~~ — **Shipped.** Static files at `public/images/organizations/{id}.jpg` + `Avatar type="business"` in `TrendingScreenerTable`. **Why**: Initials-only tiles read as broken logos; org art is curated, not synthetic token imagery.
 9. **Prediction sort tests** — **Why**: Pure sort comparators for predictions could mirror `sort-perps-screener.test.ts` for regression safety.
 
 Items we are **not** planning without domain support: DEX-style “paid listing”, tax %, buy/sell txn ratios, chain social links.
@@ -120,6 +171,7 @@ See the root [`CHANGELOG.md`](../../CHANGELOG.md) **[Unreleased]** / dated secti
 
 ## Related
 
+- Formatters entry: `apps/web/src/app/markets/_lib/README.md` (why web-specific formatting vs `@babylon/shared`)
 - Dev entry: `apps/web/src/app/markets/trending/README.md`
 - Full trading UI: `apps/web/src/app/markets/page.tsx` → `MarketsTradingTerminal`
 - Public read rate limits: `packages/api/src/rate-limiting/README.md`

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -192,10 +192,12 @@ export function formatRelativeTime(date: Date | string): string {
 }
 
 /**
- * Format number with K/M suffixes
+ * Format number with K/M/B/T/Q suffixes
  *
- * @description Formats large numbers with K (thousands) or M (millions) suffixes.
- * Rounds to one decimal place for readability.
+ * @description Compacts magnitudes for logs, tables, and NPC-facing strings. **T** and **Q**
+ * tiers exist because stopping at **B** still allowed enormous mantissas when values exceeded 1e12
+ * (same class of bug as wide OI/volume cells in the web screener). Non-finite input returns `"0"`
+ * so callers never print `NaN`. Negative values use a leading `-` on the compact magnitude.
  *
  * @param {number} num - Number to format
  * @returns {string} Formatted number string (e.g., "1.5K", "2.3M")
@@ -204,13 +206,34 @@ export function formatRelativeTime(date: Date | string): string {
  * ```typescript
  * formatCompactNumber(1500) // Returns "1.5K"
  * formatCompactNumber(2300000) // Returns "2.3M"
+ * formatCompactNumber(1e9) // Returns "1.0B"
+ * formatCompactNumber(2e12) // Returns "2.0T"
+ * formatCompactNumber(3e15) // Returns "3.0Q"
  * formatCompactNumber(500) // Returns "500"
  * ```
  */
 export function formatCompactNumber(num: number): string {
-  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-  if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
-  return num.toString();
+  if (!Number.isFinite(num)) {
+    return '0';
+  }
+  const sign = num < 0 ? '-' : '';
+  const abs = Math.abs(num);
+  if (abs >= 1_000_000_000_000_000) {
+    return `${sign}${(abs / 1_000_000_000_000_000).toFixed(1)}Q`;
+  }
+  if (abs >= 1_000_000_000_000) {
+    return `${sign}${(abs / 1_000_000_000_000).toFixed(1)}T`;
+  }
+  if (abs >= 1_000_000_000) {
+    return `${sign}${(abs / 1_000_000_000).toFixed(1)}B`;
+  }
+  if (abs >= 1_000_000) {
+    return `${sign}${(abs / 1_000_000).toFixed(1)}M`;
+  }
+  if (abs >= 1000) {
+    return `${sign}${(abs / 1000).toFixed(1)}K`;
+  }
+  return `${sign}${abs.toString()}`;
 }
 
 /**
@@ -268,10 +291,11 @@ export function formatCurrency(
 }
 
 /**
- * Format number as compact currency with K/M/B suffixes
+ * Format number as compact currency with K/M/B/T/Q suffixes
  *
- * @description Formats a number as Babylon points currency with K/M/B suffixes
- * for large values. Uses the ƀ symbol. Handles non-finite values gracefully.
+ * @description Babylon points (ƀ) with compact suffixes for prompts and UI. **T** and **Q** mirror
+ * `formatCompactNumber`: without them, trillion-scale values still render as `ƀ…B` with huge
+ * integer parts. Non-finite values return `ƀ0` with the requested decimal count (existing contract).
  *
  * @param {number} value - Amount to format
  * @param {number} decimals - Number of decimal places (default: 2)
@@ -282,6 +306,8 @@ export function formatCurrency(
  * formatCompactCurrency(1500) // Returns "ƀ1.50K"
  * formatCompactCurrency(2300000) // Returns "ƀ2.30M"
  * formatCompactCurrency(1500000000) // Returns "ƀ1.50B"
+ * formatCompactCurrency(2e12) // Returns "ƀ2.00T"
+ * formatCompactCurrency(3e15) // Returns "ƀ3.00Q"
  * formatCompactCurrency(500) // Returns "ƀ500.00"
  * formatCompactCurrency(-1500) // Returns "-ƀ1.50K"
  * formatCompactCurrency(NaN) // Returns "ƀ0.00"
@@ -298,6 +324,12 @@ export function formatCompactCurrency(value: number, decimals = 2): string {
   const abs = Math.abs(value);
   const sign = isNegative ? '-' : '';
 
+  if (abs >= 1_000_000_000_000_000) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1_000_000_000_000_000).toFixed(decimals)}Q`;
+  }
+  if (abs >= 1_000_000_000_000) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1_000_000_000_000).toFixed(decimals)}T`;
+  }
   if (abs >= 1_000_000_000) {
     return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1_000_000_000).toFixed(decimals)}B`;
   }

--- a/packages/testing/unit/markets/market-cards.test.ts
+++ b/packages/testing/unit/markets/market-cards.test.ts
@@ -3,10 +3,15 @@ import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
 
 import {
   calculateSharePercentages,
+  formatBalance,
+  formatChange24h,
+  formatFundingApr,
   formatPrice,
   formatVolume,
   getDaysLeft,
 } from '../../../../apps/web/src/app/markets/_lib/formatters';
+
+const EM_DASH = '\u2014';
 
 describe('formatPrice', () => {
   it('formats with ƀ symbol and 2 decimals', () => {
@@ -20,6 +25,13 @@ describe('formatPrice', () => {
     expect(formatPrice(0.001)).toBe(`${BABYLON_POINTS_SYMBOL}0.00`);
     expect(formatPrice(0.01)).toBe(`${BABYLON_POINTS_SYMBOL}0.01`);
     expect(formatPrice(999999)).toBe(`${BABYLON_POINTS_SYMBOL}999999.00`);
+  });
+
+  it('returns em dash for non-finite values', () => {
+    expect(formatPrice(Number.NaN)).toBe(`${BABYLON_POINTS_SYMBOL}${EM_DASH}`);
+    expect(formatPrice(Number.POSITIVE_INFINITY)).toBe(
+      `${BABYLON_POINTS_SYMBOL}${EM_DASH}`
+    );
   });
 });
 
@@ -35,6 +47,73 @@ describe('formatVolume', () => {
     expect(formatVolume(1500)).toBe(`${BABYLON_POINTS_SYMBOL}1.50K`);
     expect(formatVolume(1000000)).toBe(`${BABYLON_POINTS_SYMBOL}1.00M`);
     expect(formatVolume(1000000000)).toBe(`${BABYLON_POINTS_SYMBOL}1.00B`);
+  });
+
+  it('adds T and Q suffix for very large values', () => {
+    expect(formatVolume(2e12)).toBe(`${BABYLON_POINTS_SYMBOL}2.00T`);
+    expect(formatVolume(3e15)).toBe(`${BABYLON_POINTS_SYMBOL}3.00Q`);
+  });
+
+  it('returns em dash for non-finite values', () => {
+    expect(formatVolume(Number.NaN)).toBe(`${BABYLON_POINTS_SYMBOL}${EM_DASH}`);
+  });
+
+  it('prefixes minus for negative values', () => {
+    expect(formatVolume(-1500)).toBe(`-${BABYLON_POINTS_SYMBOL}1.50K`);
+  });
+});
+
+describe('formatBalance', () => {
+  it('uses locale separators and two decimals', () => {
+    expect(formatBalance(1234.5)).toMatch(
+      new RegExp(`^${BABYLON_POINTS_SYMBOL}1,?234\\.50$`)
+    );
+  });
+
+  it('returns em dash for non-finite values', () => {
+    expect(formatBalance(Number.NaN)).toBe(
+      `${BABYLON_POINTS_SYMBOL}${EM_DASH}`
+    );
+  });
+});
+
+describe('formatChange24h', () => {
+  it('adds plus for non-negative finite values', () => {
+    expect(formatChange24h(1.234)).toBe('+1.23%');
+    expect(formatChange24h(0)).toBe('+0.00%');
+  });
+
+  it('formats negative without duplicate minus', () => {
+    expect(formatChange24h(-5.5)).toBe('-5.50%');
+  });
+
+  it('returns em dash for non-finite', () => {
+    expect(formatChange24h(Number.NaN)).toBe(EM_DASH);
+  });
+
+  it('clamps extreme magnitudes', () => {
+    expect(formatChange24h(50000)).toBe('+9999.99%');
+    expect(formatChange24h(-50000)).toBe('-9999.99%');
+  });
+});
+
+describe('formatFundingApr', () => {
+  it('converts annual decimal to percent with sign', () => {
+    expect(formatFundingApr(0.01)).toBe('+1.00%');
+    expect(formatFundingApr(-0.02)).toBe('-2.00%');
+  });
+
+  it('respects decimals option', () => {
+    expect(formatFundingApr(0.01, { decimals: 4 })).toBe('+1.0000%');
+  });
+
+  it('returns em dash for non-finite', () => {
+    expect(formatFundingApr(Number.NaN)).toBe(EM_DASH);
+  });
+
+  it('clamps display magnitude', () => {
+    expect(formatFundingApr(10)).toBe('+999.99%');
+    expect(formatFundingApr(-10)).toBe('-999.99%');
   });
 });
 

--- a/packages/testing/unit/markets/market-cards.test.ts
+++ b/packages/testing/unit/markets/market-cards.test.ts
@@ -18,7 +18,7 @@ describe('formatPrice', () => {
     expect(formatPrice(123.456)).toBe(`${BABYLON_POINTS_SYMBOL}123.46`);
     expect(formatPrice(100)).toBe(`${BABYLON_POINTS_SYMBOL}100.00`);
     expect(formatPrice(0)).toBe(`${BABYLON_POINTS_SYMBOL}0.00`);
-    expect(formatPrice(-100)).toBe(`${BABYLON_POINTS_SYMBOL}-100.00`);
+    expect(formatPrice(-100)).toBe(`-${BABYLON_POINTS_SYMBOL}100.00`);
   });
 
   it('handles edge values', () => {
@@ -65,9 +65,15 @@ describe('formatVolume', () => {
 
 describe('formatBalance', () => {
   it('uses locale separators and two decimals', () => {
-    expect(formatBalance(1234.5)).toMatch(
-      new RegExp(`^${BABYLON_POINTS_SYMBOL}1,?234\\.50$`)
-    );
+    const expected = `${BABYLON_POINTS_SYMBOL}${(1234.5).toLocaleString(
+      undefined,
+      {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }
+    )}`;
+
+    expect(formatBalance(1234.5)).toBe(expected);
   });
 
   it('returns em dash for non-finite values', () => {

--- a/packages/testing/unit/shared/format.test.ts
+++ b/packages/testing/unit/shared/format.test.ts
@@ -115,6 +115,18 @@ describe('Format Utilities', () => {
       expect(formatCompactNumber(1000000)).toBe('1.0M');
       expect(formatCompactNumber(2500000)).toBe('2.5M');
     });
+
+    it('should format billions, trillions, and quadrillions', () => {
+      expect(formatCompactNumber(1e9)).toBe('1.0B');
+      expect(formatCompactNumber(2e12)).toBe('2.0T');
+      expect(formatCompactNumber(3e15)).toBe('3.0Q');
+      expect(formatCompactNumber(1e20)).toBe('100000.0Q');
+    });
+
+    it('should return 0 for non-finite values', () => {
+      expect(formatCompactNumber(Number.NaN)).toBe('0');
+      expect(formatCompactNumber(Number.POSITIVE_INFINITY)).toBe('0');
+    });
   });
 
   describe('formatCurrency', () => {
@@ -190,6 +202,13 @@ describe('Format Utilities', () => {
     it('should format billions with B suffix', () => {
       expect(formatCompactCurrency(1000000000)).toBe('ƀ1.00B');
       expect(formatCompactCurrency(1500000000)).toBe('ƀ1.50B');
+    });
+
+    it('should format trillions and quadrillions with T and Q suffixes', () => {
+      expect(formatCompactCurrency(2e12)).toBe('ƀ2.00T');
+      expect(formatCompactCurrency(3.5e15)).toBe('ƀ3.50Q');
+      // Use a power-of-10 magnitude so float precision matches the suffix tier.
+      expect(formatCompactCurrency(1e20)).toBe('ƀ100000.00Q');
     });
 
     it('should handle negative values correctly', () => {


### PR DESCRIPTION
just finishing up this work now I that I can see with production data

- Add T/Q compact tiers to formatCompactCurrency, formatCompactNumber, formatVolume, terminal Vol helper
- Harden formatPrice, formatChange24h, formatFundingApr, formatBalance for non-finite and display clamps
- TrendingScreenerTable: Avatar business tile for organizationId; import shared formatters
- Tests: shared format T/Q; market-cards tests for web formatters
- Docs: CHANGELOG, trending-screener display section, _lib README, index links

Made-with: Cursor
