### PR TITLE
feat: agent social graph for user-controlled agents

### DIFF
--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -75,6 +75,7 @@ import {
   getAgentGroupChats,
   getAgentOwnPosts,
   getAgentPositions,
+  getAgentSocialGraph,
   getAgentTradeHistory,
   getGroupChatIntel,
   getMarketTrends,
@@ -836,6 +837,8 @@ export class MultiStepExecutor {
       // NPC-only narrative context (insider knowledge)
       resolvedQuestionsResult,
       recentNpcTradesResult,
+      // Social graph for user-controlled agents
+      socialGraphResult,
     ] = await Promise.all([
       canTrade
         ? this.timedOperation('predictionMarkets', () => getPredictionMarkets())
@@ -920,6 +923,12 @@ export class MultiStepExecutor {
               .limit(20);
           })
         : Promise.resolve({ data: [], duration: 0 }),
+      // Social graph for user-controlled agents (NPCs use actorRelationships)
+      !isNpc
+        ? this.timedOperation('socialGraph', () =>
+            getAgentSocialGraph(agentUserId)
+          )
+        : Promise.resolve({ data: [], duration: 0 }),
     ]);
     timings.parallelTotal = Date.now() - parallelStart;
 
@@ -940,6 +949,7 @@ export class MultiStepExecutor {
     const agentTradeHistory = agentTradeHistoryResult.data;
     const resolvedQsRows = resolvedQuestionsResult.data;
     const recentNpcTradesRows = recentNpcTradesResult.data;
+    const socialGraph = socialGraphResult.data;
 
     // Collect individual operation timings
     timings.predictionMarkets = predictionMarketsResult.duration;
@@ -958,6 +968,7 @@ export class MultiStepExecutor {
     timings.agentTradeHistory = agentTradeHistoryResult.duration;
     timings.resolvedQuestions = resolvedQuestionsResult.duration;
     timings.recentNpcTrades = recentNpcTradesResult.duration;
+    timings.socialGraph = socialGraphResult.duration;
 
     // Filter chat messages based on DMs vs group chats feature
     const pendingChatMessages = pendingChatMessagesRaw.filter((m) =>
@@ -1061,6 +1072,7 @@ export class MultiStepExecutor {
       },
       agentTradeHistory:
         agentTradeHistory.length > 0 ? agentTradeHistory : undefined,
+      socialGraph: socialGraph.length > 0 ? socialGraph : undefined,
       // Engine-grade context (Phase 1: unified NPC pipeline)
       marketTrends: marketTrends.length > 0 ? marketTrends : undefined,
       relationships: relationships.length > 0 ? relationships : undefined,

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -495,6 +495,16 @@ export interface AgentTradeHistoryEntry {
   executedAt: Date;
 }
 
+export interface AgentSocialConnection {
+  userId: string;
+  displayName: string;
+  username: string | null;
+  isFollowing: boolean;
+  isFollowedBy: boolean;
+  interactionCount: number;
+  source: 'follow' | 'interaction' | 'both';
+}
+
 export interface CreatorInfo {
   name: string;
   username?: string;
@@ -543,6 +553,8 @@ export interface AgentTickContext {
   };
   // Agent's own trade history (user-controlled agents only)
   agentTradeHistory?: AgentTradeHistoryEntry[];
+  // Agent social graph (user-controlled agents only)
+  socialGraph?: AgentSocialConnection[];
   // Engine-grade context (Phase 1: provider enrichment)
   marketTrends?: MarketTrendContext[];
   relationships?: RelationshipContext[];
@@ -1101,11 +1113,16 @@ ${formatAgentOwnPosts(context.agentOwnPosts)}`
     },
     {
       name: 'relationships',
-      priority: 4,
-      content:
-        context.relationships && context.relationships.length > 0
-          ? `# Your Relationships\n${formatRelationships(context.relationships)}`
-          : '',
+      priority: 3,
+      content: (() => {
+        if (isNpc && context.relationships && context.relationships.length > 0) {
+          return `# Your Relationships\n${formatRelationships(context.relationships)}`;
+        }
+        if (!isNpc && context.socialGraph && context.socialGraph.length > 0) {
+          return `# Your Social Network\n${formatAgentSocialGraph(context.socialGraph)}`;
+        }
+        return '';
+      })(),
     },
     {
       name: 'worldEvents',
@@ -1519,6 +1536,45 @@ function formatWorldEvents(events: WorldEventContext[]): string {
 /**
  * Format action schemas based on enabled features using ACTION_DEFINITIONS
  */
+function formatAgentSocialGraph(
+  connections: AgentSocialConnection[]
+): string {
+  if (connections.length === 0)
+    return 'No social connections yet. Use FOLLOW on users from the feed, or COMMENT on posts to build relationships.';
+
+  const following = connections.filter((c) => c.isFollowing);
+  const interactionOnly = connections.filter(
+    (c) => !c.isFollowing && c.interactionCount > 0
+  );
+
+  const parts: string[] = [];
+
+  if (following.length > 0) {
+    const lines = following.map((c) => {
+      const name = c.username ? `@${c.username}` : c.displayName;
+      const mutual = c.isFollowedBy ? ' (mutual ↔)' : '';
+      const interactions =
+        c.interactionCount > 0
+          ? ` — ${c.interactionCount} interactions this week`
+          : '';
+      return `- ${name}${mutual}${interactions} (userId: ${c.userId})`;
+    });
+    parts.push(`Following (${following.length}):\n${lines.join('\n')}`);
+  }
+
+  if (interactionOnly.length > 0) {
+    const lines = interactionOnly.map((c) => {
+      const name = c.username ? `@${c.username}` : c.displayName;
+      return `- ${name} — ${c.interactionCount} interactions (consider FOLLOW?) (userId: ${c.userId})`;
+    });
+    parts.push(
+      `Engaged with recently (not following):\n${lines.join('\n')}`
+    );
+  }
+
+  return parts.join('\n\n');
+}
+
 function formatActionSchemas(enabledFeatures: string[]): string {
   const schemas: string[] = [];
 

--- a/packages/agents/src/autonomous/utils/context-gatherers.ts
+++ b/packages/agents/src/autonomous/utils/context-gatherers.ts
@@ -17,6 +17,7 @@ import {
   db,
   desc,
   eq,
+  follows,
   getDbInstance,
   getRawDrizzle,
   groups,
@@ -42,6 +43,7 @@ import { StaticDataRegistry } from '@babylon/engine';
 import { logger } from '../../shared/logger';
 import type {
   AgentOwnPostContext,
+  AgentSocialConnection,
   AgentTradeHistoryEntry,
   GroupChatIntel,
   MarketTrendContext,
@@ -971,4 +973,171 @@ export async function getAgentTradeHistory(
     );
     return [];
   }
+}
+
+// =============================================================================
+// Agent Social Graph (user-controlled agents)
+// =============================================================================
+
+/**
+ * Derive a lightweight social graph for a user-controlled agent from:
+ * 1. follows table — who the agent follows and who follows them back (mutual detection)
+ * 2. comments + posts — who the agent has engaged with recently (last 7 days)
+ *
+ * Uses existing indexes: Follow_followerId_idx, Follow_followingId_idx,
+ * Comment_authorId_createdAt_idx, Reaction_userId_createdAt_idx
+ */
+export async function getAgentSocialGraph(
+  agentUserId: string
+): Promise<AgentSocialConnection[]> {
+  try {
+    return await getAgentSocialGraphInner(agentUserId);
+  } catch (error) {
+    logger.warn(
+      'Failed to fetch agent social graph',
+      {
+        agentUserId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'ContextGatherers'
+    );
+    return [];
+  }
+}
+
+async function getAgentSocialGraphInner(
+  agentUserId: string
+): Promise<AgentSocialConnection[]> {
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  const [followingRows, followerRows, commentInteractions, reactionInteractions] =
+    await Promise.all([
+      db
+        .select({ followingId: follows.followingId })
+        .from(follows)
+        .where(eq(follows.followerId, agentUserId))
+        .orderBy(desc(follows.createdAt))
+        .limit(20),
+
+      db
+        .select({ followerId: follows.followerId })
+        .from(follows)
+        .where(eq(follows.followingId, agentUserId))
+        .limit(100),
+
+      db
+        .select({
+          targetUserId: posts.authorId,
+          interactionCount: count(),
+        })
+        .from(comments)
+        .innerJoin(posts, eq(comments.postId, posts.id))
+        .where(
+          and(
+            eq(comments.authorId, agentUserId),
+            ne(posts.authorId, agentUserId),
+            gte(comments.createdAt, sevenDaysAgo)
+          )
+        )
+        .groupBy(posts.authorId)
+        .orderBy(desc(count()))
+        .limit(10),
+
+      db
+        .select({
+          targetUserId: posts.authorId,
+          interactionCount: count(),
+        })
+        .from(reactions)
+        .innerJoin(posts, eq(reactions.postId, posts.id))
+        .where(
+          and(
+            eq(reactions.userId, agentUserId),
+            ne(posts.authorId, agentUserId),
+            gte(reactions.createdAt, sevenDaysAgo)
+          )
+        )
+        .groupBy(posts.authorId)
+        .orderBy(desc(count()))
+        .limit(10),
+    ]);
+
+  const followingIds = new Set(followingRows.map((r) => r.followingId));
+  const followerIds = new Set(followerRows.map((r) => r.followerId));
+
+  const interactionMap = new Map<string, number>();
+  for (const row of commentInteractions) {
+    interactionMap.set(
+      row.targetUserId,
+      (interactionMap.get(row.targetUserId) || 0) + Number(row.interactionCount)
+    );
+  }
+  for (const row of reactionInteractions) {
+    interactionMap.set(
+      row.targetUserId,
+      (interactionMap.get(row.targetUserId) || 0) + Number(row.interactionCount)
+    );
+  }
+
+  const connectionMap = new Map<string, AgentSocialConnection>();
+
+  for (const id of followingIds) {
+    connectionMap.set(id, {
+      userId: id,
+      displayName: '',
+      username: null,
+      isFollowing: true,
+      isFollowedBy: followerIds.has(id),
+      interactionCount: interactionMap.get(id) || 0,
+      source: interactionMap.has(id) ? 'both' : 'follow',
+    });
+  }
+
+  for (const [userId, cnt] of interactionMap) {
+    if (!connectionMap.has(userId)) {
+      connectionMap.set(userId, {
+        userId,
+        displayName: '',
+        username: null,
+        isFollowing: false,
+        isFollowedBy: followerIds.has(userId),
+        interactionCount: cnt,
+        source: 'interaction',
+      });
+    }
+  }
+
+  if (connectionMap.size === 0) return [];
+
+  const allUserIds = [...connectionMap.keys()];
+  const userRows = await db
+    .select({
+      id: users.id,
+      displayName: users.displayName,
+      username: users.username,
+    })
+    .from(users)
+    .where(inArray(users.id, allUserIds));
+
+  const nameMap = new Map(
+    userRows.map((u) => [
+      u.id,
+      { displayName: u.displayName || u.username || u.id.slice(0, 8), username: u.username },
+    ])
+  );
+
+  const connections = [...connectionMap.values()].map((c) => ({
+    ...c,
+    displayName: nameMap.get(c.userId)?.displayName || c.userId.slice(0, 8),
+    username: nameMap.get(c.userId)?.username || null,
+  }));
+
+  connections.sort((a, b) => {
+    const aMutual = a.isFollowing && a.isFollowedBy ? 1 : 0;
+    const bMutual = b.isFollowing && b.isFollowedBy ? 1 : 0;
+    if (aMutual !== bMutual) return bMutual - aMutual;
+    return b.interactionCount - a.interactionCount;
+  });
+
+  return connections.slice(0, 15);
 }

--- a/packages/agents/src/autonomous/utils/index.ts
+++ b/packages/agents/src/autonomous/utils/index.ts
@@ -9,6 +9,7 @@ export {
   getAgentGroupChats,
   getAgentOwnPosts,
   getAgentPositions,
+  getAgentSocialGraph,
   getAgentTradeHistory,
   getGroupChatIntel,
   getMarketTrends,


### PR DESCRIPTION
## Summary
- User agents had zero social awareness — FOLLOW/UNFOLLOW/DM decisions were completely blind
- Now derives social graph from existing `follows` table + `comments`/`reactions` interaction data
- Renders as priority-3 prompt section with follows (mutual indicators ↔) and recent interaction-only contacts
- NPCs continue using existing `formatRelationships()` — section branches on `isNpc`

## Files Changed
- `context-gatherers.ts` — new `getAgentSocialGraph()` with 4 parallel queries
- `multi-step-decision.ts` — `AgentSocialConnection` type, formatter, unified section
- `MultiStepExecutor.ts` — wire social graph fetch for non-NPC agents
- `utils/index.ts` — barrel export

## Test plan
- [ ] `bun run typecheck` passes (agents package: 0 new errors)
- [ ] Verify via `bun run inspect:context -- --agent <userId>` that social graph appears
- [ ] Verify NPC relationship section unchanged (regression)
- [ ] EXPLAIN ANALYZE the comments→posts join query with a real userId

🤖 Generated with [Claude Code](https://claude.com/claude-code)