### PR TITLE
feat: agent memory from execution logs

### DIFF
--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -77,6 +77,7 @@ import {
   getAgentGroupChats,
   getAgentOwnPosts,
   getAgentPositions,
+  getAgentMemory,
   getAgentSocialGraph,
   getAgentTradeHistory,
   getGroupChatIntel,
@@ -841,6 +842,8 @@ export class MultiStepExecutor {
       recentNpcTradesResult,
       // Social graph for user-controlled agents
       socialGraphResult,
+      // Agent memory for user-controlled agents
+      agentMemoryResult,
     ] = await Promise.all([
       canTrade
         ? this.timedOperation('predictionMarkets', () => getPredictionMarkets())
@@ -931,6 +934,12 @@ export class MultiStepExecutor {
             getAgentSocialGraph(agentUserId)
           )
         : Promise.resolve({ data: [], duration: 0 }),
+      // Memory for user-controlled agents (NPCs have NpcMemoryService)
+      !isNpc
+        ? this.timedOperation('agentMemory', () =>
+            getAgentMemory(agentUserId, ['trade'])
+          )
+        : Promise.resolve({ data: [], duration: 0 }),
     ]);
     timings.parallelTotal = Date.now() - parallelStart;
 
@@ -952,6 +961,7 @@ export class MultiStepExecutor {
     const resolvedQsRows = resolvedQuestionsResult.data;
     const recentNpcTradesRows = recentNpcTradesResult.data;
     const socialGraph = socialGraphResult.data;
+    const agentMemory = agentMemoryResult.data;
 
     // Collect individual operation timings
     timings.predictionMarkets = predictionMarketsResult.duration;
@@ -971,6 +981,7 @@ export class MultiStepExecutor {
     timings.resolvedQuestions = resolvedQuestionsResult.duration;
     timings.recentNpcTrades = recentNpcTradesResult.duration;
     timings.socialGraph = socialGraphResult.duration;
+    timings.agentMemory = agentMemoryResult.duration;
 
     // Filter chat messages based on DMs vs group chats feature
     const pendingChatMessages = pendingChatMessagesRaw.filter((m) =>
@@ -1075,6 +1086,7 @@ export class MultiStepExecutor {
       agentTradeHistory:
         agentTradeHistory.length > 0 ? agentTradeHistory : undefined,
       socialGraph: socialGraph.length > 0 ? socialGraph : undefined,
+      recentMemory: agentMemory.length > 0 ? agentMemory : undefined,
       // Engine-grade context (Phase 1: unified NPC pipeline)
       marketTrends: marketTrends.length > 0 ? marketTrends : undefined,
       relationships: relationships.length > 0 ? relationships : undefined,

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -495,6 +495,13 @@ export interface AgentTradeHistoryEntry {
   executedAt: Date;
 }
 
+export interface AgentMemoryEntry {
+  type: string;
+  message: string;
+  thinking: string | null;
+  createdAt: Date;
+}
+
 export interface AgentSocialConnection {
   userId: string;
   displayName: string;
@@ -555,6 +562,8 @@ export interface AgentTickContext {
   agentTradeHistory?: AgentTradeHistoryEntry[];
   // Agent social graph (user-controlled agents only)
   socialGraph?: AgentSocialConnection[];
+  // Agent's recent activity memory (user-controlled agents only)
+  recentMemory?: AgentMemoryEntry[];
   // Engine-grade context (Phase 1: provider enrichment)
   marketTrends?: MarketTrendContext[];
   relationships?: RelationshipContext[];
@@ -1102,6 +1111,14 @@ ${formatAgentOwnPosts(context.agentOwnPosts)}`
         : '',
     },
     { name: 'markets', priority: 2, content: tradingSection },
+    {
+      name: 'memory',
+      priority: 3,
+      content:
+        !isNpc && context.recentMemory && context.recentMemory.length > 0
+          ? `# Your Recent Activity\n${formatAgentMemory(context.recentMemory)}`
+          : '',
+    },
     // Engine-grade context sections (Phase 1: unified NPC pipeline)
     {
       name: 'marketTrends',
@@ -1573,6 +1590,31 @@ function formatAgentSocialGraph(
   }
 
   return parts.join('\n\n');
+}
+
+function formatAgentMemory(entries: AgentMemoryEntry[]): string {
+  if (entries.length === 0) return '';
+
+  return entries
+    .map((e) => {
+      const timeAgo = formatMemoryTimeAgo(e.createdAt);
+      const typeLabel = e.type.toUpperCase();
+      const reasonText = e.thinking ? ` — "${e.thinking}"` : '';
+      return `- [${timeAgo}] ${typeLabel}: ${e.message}${reasonText}`;
+    })
+    .join('\n');
+}
+
+function formatMemoryTimeAgo(date: Date): string {
+  const ms = Date.now() - date.getTime();
+  if (ms < 0) return 'just now';
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
 }
 
 function formatActionSchemas(enabledFeatures: string[]): string {

--- a/packages/agents/src/autonomous/utils/context-gatherers.ts
+++ b/packages/agents/src/autonomous/utils/context-gatherers.ts
@@ -8,6 +8,7 @@
 import {
   actorRelationships,
   actorState,
+  agentLogs as agentLogsTable,
   agentTrades,
   and,
   chatParticipants,
@@ -42,6 +43,7 @@ import {
 import { StaticDataRegistry } from '@babylon/engine';
 import { logger } from '../../shared/logger';
 import type {
+  AgentMemoryEntry,
   AgentOwnPostContext,
   AgentSocialConnection,
   AgentTradeHistoryEntry,
@@ -1140,4 +1142,56 @@ async function getAgentSocialGraphInner(
   });
 
   return connections.slice(0, 15);
+}
+
+// =============================================================================
+// Agent Memory (user-controlled agents)
+// =============================================================================
+
+/**
+ * Get recent activity log entries for a user-controlled agent to use as memory.
+ * Queries the agentLogs table for the agent's recent actions, re-surfacing
+ * the LLM's reasoning (thinking field) from previous ticks.
+ *
+ * Uses the existing compound index on (agentUserId, createdAt).
+ *
+ * @param excludeTypes - Log types to exclude (e.g., ['trade'] when trade
+ *   history section already provides that data, avoiding duplication)
+ */
+export async function getAgentMemory(
+  agentUserId: string,
+  excludeTypes: string[] = []
+): Promise<AgentMemoryEntry[]> {
+  const allTypes = ['trade', 'post', 'comment', 'chat', 'dm'];
+  const types = allTypes.filter((t) => !excludeTypes.includes(t));
+  if (types.length === 0) return [];
+
+  const rows = await db
+    .select({
+      type: agentLogsTable.type,
+      message: agentLogsTable.message,
+      thinking: agentLogsTable.thinking,
+      createdAt: agentLogsTable.createdAt,
+    })
+    .from(agentLogsTable)
+    .where(
+      and(
+        eq(agentLogsTable.agentUserId, agentUserId),
+        inArray(agentLogsTable.type, types),
+        eq(agentLogsTable.level, 'info')
+      )
+    )
+    .orderBy(desc(agentLogsTable.createdAt))
+    .limit(12);
+
+  return rows.map((r) => ({
+    type: r.type,
+    message: r.message.length > 100 ? `${r.message.slice(0, 100)}...` : r.message,
+    thinking: r.thinking
+      ? r.thinking.length > 120
+        ? `${r.thinking.slice(0, 120)}...`
+        : r.thinking
+      : null,
+    createdAt: r.createdAt,
+  }));
 }

--- a/packages/agents/src/autonomous/utils/index.ts
+++ b/packages/agents/src/autonomous/utils/index.ts
@@ -7,6 +7,7 @@
 // Context gathering
 export {
   getAgentGroupChats,
+  getAgentMemory,
   getAgentOwnPosts,
   getAgentPositions,
   getAgentSocialGraph,


### PR DESCRIPTION
## Summary
- User agents had no memory across ticks — each tick was a blank slate, unable to recall past reasoning
- Now queries `agentLogs` table for recent non-trade actions (post, comment, chat, dm) and re-surfaces the LLM's reasoning (`thinking` field) as a "Your Recent Activity" prompt section
- No new tables needed — `agentLogs` already has the data and correct indexes
- Excludes `type='trade'` to avoid duplicating trade history section (when #1446 is merged)

## Files Changed
- `context-gatherers.ts` — new `getAgentMemory()` with `excludeTypes` param
- `multi-step-decision.ts` — `AgentMemoryEntry` type, formatter, prompt section
- `MultiStepExecutor.ts` — wire memory fetch for non-NPC agents
- `utils/index.ts` — barrel export

## Test plan
- [ ] `bun run typecheck` passes (agents package: 0 new errors)
- [ ] Verify via `bun run inspect:context -- --agent <userId>` that memory section appears
- [ ] Verify NPC agents do NOT get memory section
- [ ] Verify trade-type logs are excluded from memory output

🤖 Generated with [Claude Code](https://claude.com/claude-code)