### PR TITLE
fix: declare undeclared env vars to pass env audit CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -635,10 +635,10 @@ LEADERBOARD_CACHE_MS=120000
 GAME_TICK_BUDGET_MS=180000
 
 # Event diversity: hours between same actor appearing in world events (default: 4)
-# EVENT_ACTOR_COOLDOWN_HOURS=4
+EVENT_ACTOR_COOLDOWN_HOURS=4
 
 # Parody headlines: max mentions of a single entity per batch (default: 3)
-# PARODY_MAX_ENTITY_MENTIONS=3
+PARODY_MAX_ENTITY_MENTIONS=3
 
 # ============================================
 # Optional: Debug and Monitoring
@@ -952,6 +952,7 @@ PREDICTION_MARKET_INITIAL_LIQUIDITY=
 PRIVY_APP_ID=
 PYTHON_BIN=
 REALTIME_SIGNING_SECRET=
+RECORD_AGENT_TRAJECTORIES=false
 REDIS_URL=
 RESOLUTION_POSTPONE_HOURS=
 RL_MODEL_VERSION=


### PR DESCRIPTION
## Summary
- Uncomment `EVENT_ACTOR_COOLDOWN_HOURS` and `PARODY_MAX_ENTITY_MENTIONS` in `.env.example` (commented-out vars are treated as undeclared by the audit)
- Add missing `RECORD_AGENT_TRAJECTORIES=false` declaration

Fixes the failing `Env Audit` CI check on staging.

## Test plan
- [x] `bun run env:audit:check` passes locally (`usedButUndeclaredRuntime: 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)