### PR TITLE
fix: set NODE_ENV=test for CI server so integration tests can authenticate

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -270,8 +270,8 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
           # Set DEPLOYMENT_ENV=localnet to skip strict testnet/mainnet validation in CI
           DEPLOYMENT_ENV: localnet
-          # NODE_ENV=production required for Next.js production build
-          NODE_ENV: production
+          # NODE_ENV=test so integration tests can use x-dev-user-id headers
+          NODE_ENV: test
           PORT: 3000
           PLAYWRIGHT_BASE_URL: http://localhost:3000
           # NEXT_PUBLIC_* variables are embedded at build time, but ensure they're available


### PR DESCRIPTION
## Summary
- Change `NODE_ENV` from `production` to `test` when starting the server in CI integration tests
- The build step already completed with `NODE_ENV=production` — this only affects the runtime server
- Integration tests use `x-dev-user-id` headers for auth, which the server's `authenticate()` middleware only accepts when `NODE_ENV !== 'production'`
- This was causing 335+ integration test failures (all returning 401)

## Test plan
- [ ] CI integration tests should now authenticate successfully via dev headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)