### PR TITLE
feat: add embed mode for Milady iframe integration

### DIFF
--- a/apps/web/src/components/auth/FeedAuthBanner.tsx
+++ b/apps/web/src/components/auth/FeedAuthBanner.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@babylon/shared';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
+import { useEmbedMode } from '@/contexts/EmbedContext';
 import { useAuth } from '@/hooks/useAuth';
 
 function hasDesktopRightRail(pathname: string | null): boolean {
@@ -43,7 +44,8 @@ function FeedAuthBannerContent() {
   // Hide when WAITLIST_MODE is enabled on home page (unless ?dev=true)
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
-  const shouldHide = isWaitlistMode && isHomePage && !isDevMode;
+  const { isEmbedded } = useEmbedMode();
+  const shouldHide = isEmbedded || (isWaitlistMode && isHomePage && !isDevMode);
   const rightRailDesktop = hasDesktopRightRail(pathname);
 
   // If should be hidden, don't render anything

--- a/apps/web/src/components/providers/Providers.tsx
+++ b/apps/web/src/components/providers/Providers.tsx
@@ -21,6 +21,7 @@ import { SessionHeartbeatProvider } from '@/hooks/useSessionHeartbeat';
 import { getBrowserDevAuthSession } from '@/lib/auth/dev-auth';
 import { hydrateChatCacheFromIndexedDB } from '@/lib/chat/hydrateChatCache';
 import { useAuthStore } from '@/stores/authStore';
+import { EmbedModeProvider } from '@/contexts/EmbedContext';
 import { DiscordActivityProvider } from './DiscordActivityProvider';
 import { FarcasterMiniAppProvider } from './FarcasterMiniAppProvider';
 import { GameGuideProvider } from './GameGuideProvider';
@@ -320,6 +321,7 @@ export function Providers({
                     <QueryClientProvider client={queryClient}>
                       <GamePlaybackManager />
                       <ChatCacheHydrator />
+                      <EmbedModeProvider>
                       <FarcasterMiniAppProvider>
                         <TelegramMiniAppProvider>
                           <DiscordActivityProvider>
@@ -348,6 +350,7 @@ export function Providers({
                           </DiscordActivityProvider>
                         </TelegramMiniAppProvider>
                       </FarcasterMiniAppProvider>
+                      </EmbedModeProvider>
                     </QueryClientProvider>
                   </FontSizeProvider>
                 </TooltipProvider>
@@ -427,6 +430,7 @@ export function Providers({
                     <GamePlaybackManager />
                     <ChatCacheHydrator />
                     <ThemedPrivyProvider>
+                      <EmbedModeProvider>
                       <FarcasterMiniAppProvider>
                         <TelegramMiniAppProvider>
                           <DiscordActivityProvider>
@@ -461,6 +465,7 @@ export function Providers({
                           </DiscordActivityProvider>
                         </TelegramMiniAppProvider>
                       </FarcasterMiniAppProvider>
+                      </EmbedModeProvider>
                     </ThemedPrivyProvider>
                   </QueryClientProvider>
                 </FontSizeProvider>

--- a/apps/web/src/components/shared/BottomNav.tsx
+++ b/apps/web/src/components/shared/BottomNav.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { HouseIcon } from '@/components/shared/icons/HouseIcon';
+import { useEmbedMode } from '@/contexts/EmbedContext';
 import { usePostHog } from '@/hooks/usePostHog';
 import { useUnreadMessages } from '@/hooks/useUnreadMessages';
 
@@ -23,10 +24,11 @@ function BottomNavContent() {
   const { trackNavigation } = usePostHog();
   const { totalUnread: unreadMessages } = useUnreadMessages();
 
-  // Hide bottom nav when WAITLIST_MODE is enabled on home page
+  // Hide bottom nav when embedded or WAITLIST_MODE on home page
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
-  const shouldHide = isWaitlistMode && isHomePage;
+  const { isEmbedded } = useEmbedMode();
+  const shouldHide = isEmbedded || (isWaitlistMode && isHomePage);
 
   // Hide when virtual keyboard is open (interactiveWidget: 'resizes-content'
   // shrinks the layout viewport, pushing the fixed nav up with the keyboard).

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -27,6 +27,7 @@ import {
   fetchMobileHeaderPointsSnapshot,
   isAbortError,
 } from '@/components/shared/mobileHeaderPoints';
+import { useEmbedMode } from '@/contexts/EmbedContext';
 import { useAuth } from '@/hooks/useAuth';
 import { useUnreadMessages } from '@/hooks/useUnreadMessages';
 import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
@@ -57,10 +58,11 @@ function MobileHeaderContent() {
   const { totalUnread: unreadMessages } = useUnreadMessages();
   const { unreadCount: unreadNotifications } = useUnreadNotifications();
 
-  // Hide mobile header when WAITLIST_MODE is enabled on home page
+  // Hide mobile header when embedded or WAITLIST_MODE on home page
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
-  const shouldHide = isWaitlistMode && isHomePage;
+  const { isEmbedded } = useEmbedMode();
+  const shouldHide = isEmbedded || (isWaitlistMode && isHomePage);
 
   // All hooks must be called before any conditional returns
   useEffect(() => {

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -30,6 +30,7 @@ import { Avatar } from '@/components/shared/Avatar';
 import { BabylonIcon } from '@/components/shared/icons/BabylonIcon';
 import { BabylonFullLogo } from '@/components/shared/icons/BabylonLogo';
 import { HouseIcon } from '@/components/shared/icons/HouseIcon';
+import { useEmbedMode } from '@/contexts/EmbedContext';
 import { useAuth } from '@/hooks/useAuth';
 import { usePostHog } from '@/hooks/usePostHog';
 import { useUnreadMessages } from '@/hooks/useUnreadMessages';
@@ -104,10 +105,11 @@ function SidebarContent() {
     };
   }, [fetchPortfolio, refresh]);
 
-  // Hide sidebar when WAITLIST_MODE is enabled on home page
+  // Hide sidebar when WAITLIST_MODE is enabled on home page, or in embed mode
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
-  const shouldHideSidebar = isWaitlistMode && isHomePage;
+  const { isEmbedded } = useEmbedMode();
+  const shouldHideSidebar = isEmbedded || (isWaitlistMode && isHomePage);
 
   // Check if user is admin from the user object
   const isAdmin = user?.isAdmin ?? false;

--- a/apps/web/src/contexts/EmbedContext.tsx
+++ b/apps/web/src/contexts/EmbedContext.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface EmbedContextValue {
+  /** True when the app is loaded inside an iframe with ?embedded=true. */
+  isEmbedded: boolean;
+  /** The parent origin that sent auth credentials, if any. */
+  parentOrigin: string | null;
+  /** Agent session token received via postMessage from the embedding host. */
+  agentSessionToken: string | null;
+  /** Agent ID received via postMessage. */
+  agentId: string | null;
+}
+
+const EmbedContext = createContext<EmbedContextValue>({
+  isEmbedded: false,
+  parentOrigin: null,
+  agentSessionToken: null,
+  agentId: null,
+});
+
+export function useEmbedMode(): EmbedContextValue {
+  return useContext(EmbedContext);
+}
+
+/**
+ * Detects embed mode from URL params and listens for BABYLON_AUTH
+ * postMessage from the embedding host (Milady desktop/web).
+ *
+ * Flow:
+ * 1. Detect ?embedded=true in URL → set isEmbedded
+ * 2. Send { type: "BABYLON_READY" } to parent window
+ * 3. Listen for { type: "BABYLON_AUTH", authToken, agentId } response
+ * 4. Store credentials in context for use by API layer
+ */
+export function EmbedModeProvider({ children }: { children: ReactNode }) {
+  const [isEmbedded, setIsEmbedded] = useState(false);
+  const [parentOrigin, setParentOrigin] = useState<string | null>(null);
+  const [agentSessionToken, setAgentSessionToken] = useState<string | null>(
+    null,
+  );
+  const [agentId, setAgentId] = useState<string | null>(null);
+
+  // Detect embed mode from URL params
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const params = new URLSearchParams(window.location.search);
+    const embedded =
+      params.get("embedded") === "true" || window.self !== window.top;
+
+    if (!embedded) return;
+
+    setIsEmbedded(true);
+
+    // Notify parent that we're ready for auth
+    if (window.parent && window.parent !== window) {
+      try {
+        window.parent.postMessage({ type: "BABYLON_READY" }, "*");
+      } catch {
+        // Cross-origin restriction — parent will still post to us
+      }
+    }
+  }, []);
+
+  // Listen for BABYLON_AUTH from parent
+  useEffect(() => {
+    if (!isEmbedded) return;
+
+    function handleMessage(event: MessageEvent) {
+      const data = event.data;
+      if (!data || typeof data !== "object") return;
+      if (data.type !== "BABYLON_AUTH") return;
+
+      const token =
+        typeof data.authToken === "string" ? data.authToken.trim() : null;
+      const id =
+        typeof data.agentId === "string" ? data.agentId.trim() : null;
+
+      if (token) {
+        setAgentSessionToken(token);
+        // Make token available globally for API calls
+        (window as unknown as Record<string, unknown>).__babylonEmbedToken =
+          token;
+      }
+      if (id) {
+        setAgentId(id);
+        (window as unknown as Record<string, unknown>).__babylonEmbedAgentId =
+          id;
+      }
+      setParentOrigin(event.origin);
+    }
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [isEmbedded]);
+
+  return (
+    <EmbedContext.Provider
+      value={{ isEmbedded, parentOrigin, agentSessionToken, agentId }}
+    >
+      {children}
+    </EmbedContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `EmbedContext` that detects `?embedded=true` URL param or iframe embedding
- Hide app chrome (sidebar, mobile header, bottom nav, auth banner) when embedded
- Handle `BABYLON_READY` / `BABYLON_AUTH` postMessage flow for agent credential pass-through from the Milady desktop/web app

## Changes

- **New:** `apps/web/src/contexts/EmbedContext.tsx` — embed mode detection, postMessage auth listener, global token storage
- **Modified:** `Providers.tsx` — wraps with `EmbedModeProvider` in both dev-auth and full-Privy branches
- **Modified:** `Sidebar.tsx`, `MobileHeader.tsx`, `BottomNav.tsx`, `FeedAuthBanner.tsx` — return `null` when `isEmbedded`

## How it works

```
Milady loads Babylon in iframe with ?embedded=true
  → EmbedContext detects embedded mode
  → Hides sidebar, mobile header, bottom nav, auth banner
  → Sends { type: "BABYLON_READY" } to parent window
  → Milady responds with { type: "BABYLON_AUTH", authToken, agentId }
  → EmbedContext stores token in context + window.__babylonEmbedToken
  → Token available for authenticated API calls
```

## Test plan

- [x] `bun run typecheck` — all workspaces pass
- [ ] Manual: Load `localhost:3000?embedded=true` — sidebar/nav should be hidden
- [ ] Manual: Embed in iframe — BABYLON_READY sent, chrome hidden
- [ ] Manual: Send BABYLON_AUTH postMessage — token stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)