### PR TITLE
feat: switch trading leaderboard to capital-adjusted return

### DIFF
--- a/apps/web/src/app/api/leaderboard/route.ts
+++ b/apps/web/src/app/api/leaderboard/route.ts
@@ -4,7 +4,8 @@
  * Supports two ranking axes:
  * - **metric**
  *   - `reputation`: general leaderboard based on reputation points
- *   - `trading`: trading leaderboard based on realized lifetime P&L
+ *   - `trading`: trading leaderboard based on realized return
+ *     (`lifetimePnL / max(capitalBase, 1000)`) with lifetime P&L included as context
  * - **type**
  *   - `wallet`: per-wallet ranking (users and agents as individuals)
  *   - `team`: user + their agents combined

--- a/apps/web/src/app/leaderboard/fetchLeaderboardData.ts
+++ b/apps/web/src/app/leaderboard/fetchLeaderboardData.ts
@@ -8,6 +8,9 @@ export interface LeaderboardUser {
   reputationPoints: number;
   balance: number;
   lifetimePnL: number;
+  capitalBase?: number;
+  effectiveCapitalBase?: number;
+  tradingReturn?: number;
   createdAt: Date;
   rank: number;
   isAgent?: boolean;
@@ -20,6 +23,9 @@ export interface LeaderboardUser {
   teamLifetimePnL?: number;
   userLifetimePnL?: number;
   agentLifetimePnL?: number;
+  teamCapitalBase?: number;
+  teamEffectiveCapitalBase?: number;
+  teamTradingReturn?: number;
   agentCount?: number;
 }
 

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -192,6 +192,9 @@ export default function LeaderboardPage() {
       reputationPoints: player.reputationPoints,
       balance: player.balance,
       lifetimePnL: player.lifetimePnL,
+      capitalBase: player.capitalBase,
+      effectiveCapitalBase: player.effectiveCapitalBase,
+      tradingReturn: player.tradingReturn,
       rank: player.rank,
       isAgent: player.isAgent,
       managedBy: player.managedBy,
@@ -201,6 +204,9 @@ export default function LeaderboardPage() {
       userReputationPoints: player.userReputationPoints,
       agentReputationPoints: player.agentReputationPoints,
       teamLifetimePnL: player.teamLifetimePnL,
+      teamCapitalBase: player.teamCapitalBase,
+      teamEffectiveCapitalBase: player.teamEffectiveCapitalBase,
+      teamTradingReturn: player.teamTradingReturn,
       userLifetimePnL: player.userLifetimePnL,
       agentLifetimePnL: player.agentLifetimePnL,
       agentCount: player.agentCount,
@@ -228,8 +234,9 @@ export default function LeaderboardPage() {
       team: 'Users + their AI agents combined, ranked by team reputation',
     },
     trading: {
-      wallet: 'Individual wallets ranked by realized lifetime trading P&L',
-      team: 'Users ranked by their lifetime trading P&L plus all managed agents',
+      wallet:
+        'Individual wallets ranked by realized trading return: lifetime P&L divided by capital base',
+      team: 'Teams ranked by combined realized return, with owner-agent transfers excluded from team capital base',
     },
   };
 
@@ -246,7 +253,7 @@ export default function LeaderboardPage() {
     return `${hours}h ago`;
   };
 
-  const formatTradingValue = (value: number): string => {
+  const formatTradingPnL = (value: number): string => {
     if (value > 0) {
       return `+${formatCurrency(value, {
         decimals: 0,
@@ -256,12 +263,27 @@ export default function LeaderboardPage() {
     return formatCurrency(value, { decimals: 0, useThousandsSeparator: true });
   };
 
+  const formatTradingReturn = (value: number): string => {
+    const percent = value * 100;
+    const formatted = `${Math.abs(percent).toFixed(1)}%`;
+    if (percent > 0) return `+${formatted}`;
+    if (percent < 0) return `-${formatted}`;
+    return '0.0%';
+  };
+
+  const getTradingReturn = (player: LeaderboardUser): number =>
+    isTeamView
+      ? (player.teamTradingReturn ?? player.tradingReturn ?? 0)
+      : (player.tradingReturn ?? 0);
+
+  const getTradingLifetimePnL = (player: LeaderboardUser): number =>
+    isTeamView
+      ? (player.teamLifetimePnL ?? player.lifetimePnL)
+      : player.lifetimePnL;
+
   const getDisplayValue = (player: LeaderboardUser): number => {
     if (selectedMetric === 'trading') {
-      if (isTeamView && player.teamLifetimePnL !== undefined) {
-        return player.teamLifetimePnL;
-      }
-      return player.lifetimePnL;
+      return getTradingReturn(player);
     }
 
     if (isTeamView && player.teamReputationPoints !== undefined) {
@@ -273,14 +295,14 @@ export default function LeaderboardPage() {
 
   const formatDisplayValue = (value: number): string => {
     if (selectedMetric === 'trading') {
-      return formatTradingValue(value);
+      return formatTradingReturn(value);
     }
     return formatNumberWithSeparators(value);
   };
 
   const getDisplayLabel = (): string => {
     if (selectedMetric === 'trading') {
-      return isTeamView ? 'Team Trading P&L' : 'Trading P&L';
+      return isTeamView ? 'Team Trading Return' : 'Trading Return';
     }
     return isTeamView ? 'Team Reputation' : 'Reputation';
   };
@@ -294,6 +316,10 @@ export default function LeaderboardPage() {
       : false;
     const displayValue = getDisplayValue(player);
     const formattedValue = formatDisplayValue(displayValue ?? 0);
+    const secondaryTradingPnL =
+      selectedMetric === 'trading'
+        ? formatTradingPnL(getTradingLifetimePnL(player))
+        : null;
     const isPinned = variant === 'pinned';
 
     const content = (
@@ -359,18 +385,25 @@ export default function LeaderboardPage() {
             </p>
           )}
           {variant === 'mobile' && (
-            <div className="flex items-center gap-2 text-xs sm:text-sm">
-              <span className="font-bold text-foreground">
-                {formattedValue} {getDisplayLabel()}
-              </span>
-              {isTeamView &&
-                player.agentCount !== undefined &&
-                player.agentCount > 0 && (
-                  <span className="text-muted-foreground">
-                    {player.agentCount}{' '}
-                    {player.agentCount === 1 ? 'agent' : 'agents'}
-                  </span>
-                )}
+            <div className="space-y-0.5 text-xs sm:text-sm">
+              <div className="flex items-center gap-2">
+                <span className="font-bold text-foreground">
+                  {formattedValue} {getDisplayLabel()}
+                </span>
+                {isTeamView &&
+                  player.agentCount !== undefined &&
+                  player.agentCount > 0 && (
+                    <span className="text-muted-foreground">
+                      {player.agentCount}{' '}
+                      {player.agentCount === 1 ? 'agent' : 'agents'}
+                    </span>
+                  )}
+              </div>
+              {secondaryTradingPnL && (
+                <div className="text-muted-foreground text-xs">
+                  Lifetime P&amp;L {secondaryTradingPnL}
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -379,13 +412,28 @@ export default function LeaderboardPage() {
             <div className="font-bold text-foreground text-lg">
               {formattedValue}
             </div>
-            <div className="text-muted-foreground text-xs">
-              {getDisplayLabel()}
-              {isTeamView &&
-                player.agentCount !== undefined &&
-                player.agentCount > 0 &&
-                ` (${player.agentCount} ${player.agentCount === 1 ? 'agent' : 'agents'})`}
-            </div>
+            {selectedMetric === 'trading' ? (
+              <div className="space-y-0.5 text-right">
+                <div className="text-muted-foreground text-xs">
+                  {getDisplayLabel()}
+                  {isTeamView &&
+                    player.agentCount !== undefined &&
+                    player.agentCount > 0 &&
+                    ` (${player.agentCount} ${player.agentCount === 1 ? 'agent' : 'agents'})`}
+                </div>
+                <div className="text-muted-foreground text-xs">
+                  Lifetime P&amp;L {secondaryTradingPnL}
+                </div>
+              </div>
+            ) : (
+              <div className="text-muted-foreground text-xs">
+                {getDisplayLabel()}
+                {isTeamView &&
+                  player.agentCount !== undefined &&
+                  player.agentCount > 0 &&
+                  ` (${player.agentCount} ${player.agentCount === 1 ? 'agent' : 'agents'})`}
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -406,8 +454,8 @@ export default function LeaderboardPage() {
           <p className="text-sm">
             {selectedMetric === 'trading'
               ? isTeamView
-                ? 'No teams have realized trading P&L yet. Start trading to appear here!'
-                : 'No wallets have realized trading P&L yet. Start trading to appear here!'
+                ? 'No teams have realized trading return yet. Start trading to appear here!'
+                : 'No wallets have realized trading return yet. Start trading to appear here!'
               : isTeamView
                 ? 'No teams have reputation yet. Start playing to appear here!'
                 : 'No wallets have reputation yet. Start playing to appear here!'}

--- a/apps/web/src/components/leaderboard/LeaderboardWidgetSidebar.tsx
+++ b/apps/web/src/components/leaderboard/LeaderboardWidgetSidebar.tsx
@@ -25,6 +25,9 @@ export interface SelectedUser {
   reputationPoints: number;
   balance: number;
   lifetimePnL: number;
+  capitalBase?: number;
+  effectiveCapitalBase?: number;
+  tradingReturn?: number;
   rank: number;
   isAgent?: boolean;
   managedBy?: string | null;
@@ -34,6 +37,9 @@ export interface SelectedUser {
   userReputationPoints?: number;
   agentReputationPoints?: number;
   teamLifetimePnL?: number;
+  teamCapitalBase?: number;
+  teamEffectiveCapitalBase?: number;
+  teamTradingReturn?: number;
   userLifetimePnL?: number;
   agentLifetimePnL?: number;
   agentCount?: number;
@@ -140,14 +146,21 @@ export function LeaderboardWidgetSidebar({
     formatNumberWithSeparators(value);
   const formatLeaderboardPnL = (value: number) =>
     formatCurrency(value, { decimals: 0, useThousandsSeparator: true });
+  const formatLeaderboardReturn = (value: number) => {
+    const percent = value * 100;
+    const formatted = `${Math.abs(percent).toFixed(1)}%`;
+    if (percent > 0) return `+${formatted}`;
+    if (percent < 0) return `-${formatted}`;
+    return '0.0%';
+  };
   const formatSignedLeaderboardPnL = (value: number) =>
     value > 0 ? `+${formatLeaderboardPnL(value)}` : formatLeaderboardPnL(value);
 
   const metricLabel =
     leaderboardMetric === 'trading'
       ? isTeamView
-        ? 'Team Trading P&L'
-        : 'Trading P&L'
+        ? 'Team Trading Return'
+        : 'Trading Return'
       : isTeamView
         ? 'Team Reputation'
         : 'Reputation';
@@ -155,13 +168,33 @@ export function LeaderboardWidgetSidebar({
   const metricValue =
     leaderboardMetric === 'trading'
       ? isTeamView
-        ? (selectedUser?.teamLifetimePnL ?? selectedUser?.lifetimePnL ?? 0)
-        : (selectedUser?.lifetimePnL ?? 0)
+        ? (selectedUser?.teamTradingReturn ?? selectedUser?.tradingReturn ?? 0)
+        : (selectedUser?.tradingReturn ?? 0)
       : isTeamView
         ? (selectedUser?.teamReputationPoints ??
           selectedUser?.reputationPoints ??
           0)
         : (selectedUser?.reputationPoints ?? 0);
+
+  const capitalBase = isTradingView
+    ? isTeamView
+      ? (selectedUser?.teamCapitalBase ?? selectedUser?.capitalBase ?? 0)
+      : (selectedUser?.capitalBase ?? 0)
+    : 0;
+
+  const effectiveCapitalBase = isTradingView
+    ? isTeamView
+      ? (selectedUser?.teamEffectiveCapitalBase ??
+        selectedUser?.effectiveCapitalBase ??
+        0)
+      : (selectedUser?.effectiveCapitalBase ?? 0)
+    : 0;
+
+  const primaryLifetimePnL = isTradingView
+    ? isTeamView
+      ? (selectedUser?.teamLifetimePnL ?? selectedUser?.lifetimePnL ?? 0)
+      : (selectedUser?.lifetimePnL ?? 0)
+    : 0;
 
   return (
     <div ref={containerRef} className="hidden w-96 shrink-0 flex-col xl:flex">
@@ -234,7 +267,7 @@ export function LeaderboardWidgetSidebar({
                 }`}
               >
                 {isTradingView
-                  ? formatSignedLeaderboardPnL(metricValue)
+                  ? formatLeaderboardReturn(metricValue)
                   : formatLeaderboardValue(metricValue)}
               </div>
             </div>
@@ -243,32 +276,56 @@ export function LeaderboardWidgetSidebar({
               <div>
                 <div className="text-muted-foreground text-xs">
                   {isTeamView && isTradingView
-                    ? 'User Lifetime P&L'
+                    ? 'Team Lifetime P&L'
                     : 'Lifetime P&L'}
                 </div>
                 <div
                   className={`font-bold ${
-                    selectedUser.lifetimePnL === 0
+                    primaryLifetimePnL === 0
                       ? 'text-muted-foreground'
-                      : selectedUser.lifetimePnL > 0
+                      : primaryLifetimePnL > 0
                         ? 'text-green-500'
                         : 'text-red-500'
                   }`}
                 >
-                  {selectedUser.lifetimePnL === 0
+                  {primaryLifetimePnL === 0
                     ? formatLeaderboardPnL(0)
-                    : `${selectedUser.lifetimePnL > 0 ? '+' : '-'}${formatLeaderboardPnL(Math.abs(selectedUser.lifetimePnL))}`}
+                    : `${primaryLifetimePnL > 0 ? '+' : '-'}${formatLeaderboardPnL(Math.abs(primaryLifetimePnL))}`}
                 </div>
               </div>
 
               <div>
                 <div className="text-muted-foreground text-xs">
-                  Trading Balance
+                  {isTradingView ? 'Capital Base' : 'Trading Balance'}
                 </div>
                 <div className="font-bold text-foreground">
-                  {formatLeaderboardValue(selectedUser.balance)}
+                  {isTradingView
+                    ? formatLeaderboardValue(capitalBase)
+                    : formatLeaderboardValue(selectedUser.balance)}
                 </div>
               </div>
+
+              {isTradingView && (
+                <div>
+                  <div className="text-muted-foreground text-xs">
+                    Effective Capital
+                  </div>
+                  <div className="font-bold text-foreground">
+                    {formatLeaderboardValue(effectiveCapitalBase)}
+                  </div>
+                </div>
+              )}
+
+              {isTradingView && (
+                <div>
+                  <div className="text-muted-foreground text-xs">
+                    Trading Balance
+                  </div>
+                  <div className="font-bold text-foreground">
+                    {formatLeaderboardValue(selectedUser.balance)}
+                  </div>
+                </div>
+              )}
 
               {isTeamView &&
                 selectedUser.agentCount !== undefined &&
@@ -359,7 +416,8 @@ export function LeaderboardWidgetSidebar({
             </p>
             <p>
               <span className="font-semibold text-foreground">Trading:</span>{' '}
-              Ranked by realized lifetime trading P&amp;L
+              Ranked by realized return: lifetime P&amp;L divided by `
+              max(capitalBase, 1000) `
             </p>
             {isTeamView && (
               <p>
@@ -367,8 +425,17 @@ export function LeaderboardWidgetSidebar({
                   {isTradingView ? 'Team Trading:' : 'Team Reputation:'}
                 </span>{' '}
                 {isTradingView
-                  ? "Your lifetime P&L combined with all your AI agents' realized P&L"
+                  ? 'Combined team lifetime P&L over external capital injected into the team, without double counting owner-agent transfers'
                   : "Your reputation combined with all your AI agents' reputation"}
+              </p>
+            )}
+            {isTradingView && effectiveCapitalBase > capitalBase && (
+              <p>
+                <span className="font-semibold text-foreground">
+                  Capital floor:
+                </span>{' '}
+                Rankings use at least 1,000 of capital base to avoid inflated
+                returns on tiny balances.
               </p>
             )}
           </div>

--- a/apps/web/src/components/shared/LeaderboardToggle.tsx
+++ b/apps/web/src/components/shared/LeaderboardToggle.tsx
@@ -21,7 +21,7 @@ export function LeaderboardToggle({
     value: LeaderboardMetric;
   }> = [
     { label: 'Reputation', value: 'reputation' },
-    { label: 'Trading', value: 'trading' },
+    { label: 'Trading Return', value: 'trading' },
   ];
 
   const scopeOptions: Array<{

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -57,5 +57,6 @@ export * from './sentry-webhook-inbox-service';
 export * from './system-status-service';
 export * from './trading-balance-funding-service';
 export * from './trading-leaderboard-service';
+export * from './trading-performance-service';
 export * from './waitlist-service';
 export * from './whitelist-service';

--- a/packages/api/src/services/leaderboard-types.ts
+++ b/packages/api/src/services/leaderboard-types.ts
@@ -12,6 +12,9 @@ export interface LeaderboardEntry {
   reputationPoints: number;
   balance: number;
   lifetimePnL: number;
+  capitalBase?: number;
+  effectiveCapitalBase?: number;
+  tradingReturn?: number;
   createdAt: Date;
   rank: number;
   isAgent: boolean;
@@ -24,6 +27,9 @@ export interface LeaderboardEntry {
   teamLifetimePnL?: number;
   userLifetimePnL?: number;
   agentLifetimePnL?: number;
+  teamCapitalBase?: number;
+  teamEffectiveCapitalBase?: number;
+  teamTradingReturn?: number;
   agentCount?: number;
 }
 

--- a/packages/api/src/services/trading-leaderboard-service.ts
+++ b/packages/api/src/services/trading-leaderboard-service.ts
@@ -1,36 +1,69 @@
-import {
-  and,
-  asc,
-  count,
-  db,
-  desc,
-  eq,
-  gt,
-  lt,
-  or,
-  sql,
-  users,
-} from '@babylon/db';
+import { and, count, db, eq, users } from '@babylon/db';
 import type {
+  LeaderboardEntry,
   LeaderboardPosition,
   LeaderboardResult,
   LeaderboardScope,
 } from './leaderboard-types';
+import {
+  type TeamTradingPerformanceRow,
+  TradingPerformanceService,
+  type WalletTradingPerformanceRow,
+} from './trading-performance-service';
 
-const leaderboardSelectFields = {
-  id: users.id,
-  username: users.username,
-  displayName: users.displayName,
-  profileImageUrl: users.profileImageUrl,
-  reputationPoints: users.reputationPoints,
-  virtualBalance: users.virtualBalance,
-  lifetimePnL: users.lifetimePnL,
-  createdAt: users.createdAt,
-  onChainRegistered: users.onChainRegistered,
-  nftTokenId: users.nftTokenId,
-  isAgent: users.isAgent,
-  managedBy: users.managedBy,
-};
+function mapWalletEntry(
+  row: WalletTradingPerformanceRow,
+  rank: number
+): LeaderboardEntry {
+  return {
+    id: row.id,
+    username: row.username,
+    displayName: row.displayName,
+    profileImageUrl: row.profileImageUrl,
+    reputationPoints: Number(row.reputationPoints ?? 0),
+    balance: Number(row.balance ?? 0),
+    lifetimePnL: Number(row.lifetimePnL ?? 0),
+    capitalBase: Number(row.capitalBase ?? 0),
+    effectiveCapitalBase: Number(row.effectiveCapitalBase ?? 0),
+    tradingReturn: Number(row.tradingReturn ?? 0),
+    createdAt: row.createdAt,
+    rank,
+    isAgent: row.isAgent,
+    managedBy: row.managedBy,
+    onChainRegistered: row.onChainRegistered,
+    nftTokenId: row.nftTokenId,
+  };
+}
+
+function mapTeamEntry(
+  row: TeamTradingPerformanceRow,
+  rank: number
+): LeaderboardEntry {
+  return {
+    id: row.id,
+    username: row.username,
+    displayName: row.displayName,
+    profileImageUrl: row.profileImageUrl,
+    reputationPoints: Number(row.reputationPoints ?? 0),
+    balance: Number(row.balance ?? 0),
+    lifetimePnL: Number(row.userLifetimePnL ?? 0),
+    capitalBase: Number(row.teamCapitalBase ?? 0),
+    effectiveCapitalBase: Number(row.teamEffectiveCapitalBase ?? 0),
+    tradingReturn: Number(row.teamTradingReturn ?? 0),
+    userLifetimePnL: Number(row.userLifetimePnL ?? 0),
+    agentLifetimePnL: Number(row.agentLifetimePnL ?? 0),
+    teamLifetimePnL: Number(row.teamLifetimePnL ?? 0),
+    teamCapitalBase: Number(row.teamCapitalBase ?? 0),
+    teamEffectiveCapitalBase: Number(row.teamEffectiveCapitalBase ?? 0),
+    teamTradingReturn: Number(row.teamTradingReturn ?? 0),
+    createdAt: row.createdAt,
+    rank,
+    isAgent: false,
+    onChainRegistered: row.onChainRegistered,
+    nftTokenId: row.nftTokenId,
+    agentCount: row.agentCount ?? 0,
+  };
+}
 
 export class TradingLeaderboardService {
   static async getWalletLeaderboard(
@@ -39,36 +72,16 @@ export class TradingLeaderboardService {
   ): Promise<LeaderboardResult> {
     const skip = (page - 1) * pageSize;
 
-    const [countResult] = await db
-      .select({ count: count() })
-      .from(users)
-      .where(eq(users.isActor, false));
+    const [countRows, rows] = await Promise.all([
+      db.select({ count: count() }).from(users).where(eq(users.isActor, false)),
+      TradingPerformanceService.getWalletLeaderboardRows(pageSize, skip),
+    ]);
 
-    const usersResult = await db
-      .select(leaderboardSelectFields)
-      .from(users)
-      .where(eq(users.isActor, false))
-      .orderBy(desc(users.lifetimePnL), asc(users.createdAt), asc(users.id))
-      .limit(pageSize)
-      .offset(skip);
+    const usersWithRank = rows.map((row, index) =>
+      mapWalletEntry(row, skip + index + 1)
+    );
 
-    const usersWithRank = usersResult.map((user, index) => ({
-      id: user.id,
-      username: user.username,
-      displayName: user.displayName,
-      profileImageUrl: user.profileImageUrl,
-      reputationPoints: user.reputationPoints ?? 0,
-      balance: Number(user.virtualBalance ?? 0),
-      lifetimePnL: Number(user.lifetimePnL ?? 0),
-      createdAt: user.createdAt,
-      isAgent: user.isAgent,
-      managedBy: user.managedBy,
-      onChainRegistered: user.onChainRegistered,
-      nftTokenId: user.nftTokenId,
-      rank: skip + index + 1,
-    }));
-
-    const totalCount = countResult?.count ?? 0;
+    const totalCount = countRows[0]?.count ?? 0;
     return {
       users: usersWithRank,
       totalCount,
@@ -86,77 +99,19 @@ export class TradingLeaderboardService {
   ): Promise<LeaderboardResult> {
     const skip = (page - 1) * pageSize;
 
-    const [countResult] = await db
-      .select({ count: count() })
-      .from(users)
-      .where(and(eq(users.isActor, false), eq(users.isAgent, false)));
+    const [countRows, rows] = await Promise.all([
+      db
+        .select({ count: count() })
+        .from(users)
+        .where(and(eq(users.isActor, false), eq(users.isAgent, false))),
+      TradingPerformanceService.getTeamLeaderboardRows(pageSize, skip),
+    ]);
 
-    const teamsResult = await db.execute(sql`
-      SELECT
-        u."id",
-        u."username",
-        u."displayName",
-        u."profileImageUrl",
-        u."reputationPoints"::numeric AS "reputationPoints",
-        u."virtualBalance"::numeric AS "balance",
-        u."lifetimePnL"::numeric AS "userLifetimePnL",
-        u."onChainRegistered",
-        u."nftTokenId",
-        u."createdAt",
-        COALESCE(agents."agentLifetimePnL", 0)::numeric AS "agentLifetimePnL",
-        COALESCE(agents."agentCount", 0)::int AS "agentCount",
-        (u."lifetimePnL"::numeric + COALESCE(agents."agentLifetimePnL", 0))::numeric AS "teamLifetimePnL"
-      FROM "User" u
-      LEFT JOIN (
-        SELECT
-          "managedBy",
-          SUM("lifetimePnL"::numeric) AS "agentLifetimePnL",
-          COUNT(*)::int AS "agentCount"
-        FROM "User"
-        WHERE "isAgent" = true AND "isActor" = false
-        GROUP BY "managedBy"
-      ) agents ON agents."managedBy" = u."id"
-      WHERE u."isActor" = false AND u."isAgent" = false
-      ORDER BY "teamLifetimePnL" DESC, u."createdAt" ASC, u."id" ASC
-      LIMIT ${pageSize} OFFSET ${skip}
-    `);
+    const usersWithRank = rows.map((row, index) =>
+      mapTeamEntry(row, skip + index + 1)
+    );
 
-    const rows = teamsResult as unknown as Array<{
-      id: string;
-      username: string | null;
-      displayName: string | null;
-      profileImageUrl: string | null;
-      reputationPoints: string;
-      balance: string;
-      userLifetimePnL: string;
-      onChainRegistered: boolean;
-      nftTokenId: number | null;
-      createdAt: Date;
-      agentLifetimePnL: string;
-      agentCount: number;
-      teamLifetimePnL: string;
-    }>;
-
-    const usersWithRank = rows.map((team, index) => ({
-      id: team.id,
-      username: team.username,
-      displayName: team.displayName,
-      profileImageUrl: team.profileImageUrl,
-      reputationPoints: Number(team.reputationPoints ?? 0),
-      balance: Number(team.balance ?? 0),
-      lifetimePnL: Number(team.userLifetimePnL ?? 0),
-      userLifetimePnL: Number(team.userLifetimePnL ?? 0),
-      agentLifetimePnL: Number(team.agentLifetimePnL ?? 0),
-      teamLifetimePnL: Number(team.teamLifetimePnL ?? 0),
-      createdAt: team.createdAt,
-      isAgent: false,
-      onChainRegistered: team.onChainRegistered,
-      nftTokenId: team.nftTokenId,
-      agentCount: team.agentCount ?? 0,
-      rank: skip + index + 1,
-    }));
-
-    const totalCount = countResult?.count ?? 0;
+    const totalCount = countRows[0]?.count ?? 0;
     return {
       users: usersWithRank,
       totalCount,
@@ -173,155 +128,56 @@ export class TradingLeaderboardService {
     leaderboardType: LeaderboardScope,
     pageSize = 100
   ): Promise<LeaderboardPosition | null> {
-    const userResult = await db
-      .select(leaderboardSelectFields)
+    const [user] = await db
+      .select({
+        id: users.id,
+        isAgent: users.isAgent,
+        managedBy: users.managedBy,
+      })
       .from(users)
       .where(eq(users.id, userId))
       .limit(1);
 
-    if (!userResult[0]) return null;
-    const user = userResult[0];
+    if (!user) return null;
 
     const effectiveUserId =
       leaderboardType === 'team' && user.isAgent && user.managedBy
         ? user.managedBy
         : user.id;
 
-    let effectiveUser = user;
-    if (effectiveUserId !== user.id) {
-      const managerResult = await db
-        .select(leaderboardSelectFields)
-        .from(users)
-        .where(eq(users.id, effectiveUserId))
-        .limit(1);
-      if (!managerResult[0]) return null;
-      effectiveUser = managerResult[0];
-    }
-
     if (leaderboardType === 'wallet') {
-      const effectiveLifetimePnL = effectiveUser.lifetimePnL ?? '0';
-      const [higherCount] = await db
-        .select({ count: count() })
-        .from(users)
-        .where(
-          and(
-            eq(users.isActor, false),
-            or(
-              gt(users.lifetimePnL, effectiveLifetimePnL),
-              and(
-                eq(users.lifetimePnL, effectiveLifetimePnL),
-                or(
-                  lt(users.createdAt, effectiveUser.createdAt),
-                  and(
-                    eq(users.createdAt, effectiveUser.createdAt),
-                    lt(users.id, effectiveUser.id)
-                  )
-                )
-              )
-            )
-          )
-        );
+      const row =
+        await TradingPerformanceService.getWalletEntry(effectiveUserId);
+      if (!row) return null;
 
-      const rank = (higherCount?.count ?? 0) + 1;
+      const higherCount = await TradingPerformanceService.countWalletsAbove({
+        id: row.id,
+        createdAt: row.createdAt,
+        tradingReturn: row.tradingReturn,
+      });
+
+      const rank = higherCount + 1;
       return {
         rank,
         page: Math.ceil(rank / pageSize),
-        entry: {
-          id: effectiveUser.id,
-          username: effectiveUser.username,
-          displayName: effectiveUser.displayName,
-          profileImageUrl: effectiveUser.profileImageUrl,
-          reputationPoints: effectiveUser.reputationPoints ?? 0,
-          balance: Number(effectiveUser.virtualBalance ?? 0),
-          lifetimePnL: Number(effectiveUser.lifetimePnL ?? 0),
-          createdAt: effectiveUser.createdAt,
-          isAgent: effectiveUser.isAgent,
-          managedBy: effectiveUser.managedBy,
-          onChainRegistered: effectiveUser.onChainRegistered,
-          nftTokenId: effectiveUser.nftTokenId,
-          rank,
-        },
+        entry: mapWalletEntry(row, rank),
       };
     }
 
-    const [agentLifetimePnL] = await db
-      .select({
-        lifetimePnLTotal: sql<string>`COALESCE(SUM("lifetimePnL"::numeric), 0)`,
-      })
-      .from(users)
-      .where(
-        and(
-          eq(users.managedBy, effectiveUserId),
-          eq(users.isAgent, true),
-          eq(users.isActor, false)
-        )
-      );
+    const row = await TradingPerformanceService.getTeamEntry(effectiveUserId);
+    if (!row) return null;
 
-    const teamLifetimePnL =
-      Number(effectiveUser.lifetimePnL ?? 0) +
-      Number(agentLifetimePnL?.lifetimePnLTotal ?? 0);
+    const higherCount = await TradingPerformanceService.countTeamsAbove({
+      id: row.id,
+      createdAt: row.createdAt,
+      teamTradingReturn: row.teamTradingReturn,
+    });
 
-    const higherResult = await db.execute(sql`
-      SELECT COUNT(*)::int AS "count" FROM (
-        SELECT u."id"
-        FROM "User" u
-        LEFT JOIN (
-          SELECT
-            "managedBy",
-            SUM("lifetimePnL"::numeric) AS "agentLifetimePnL"
-          FROM "User"
-          WHERE "isAgent" = true AND "isActor" = false
-          GROUP BY "managedBy"
-        ) a ON a."managedBy" = u."id"
-        WHERE u."isActor" = false AND u."isAgent" = false
-          AND (
-            (u."lifetimePnL"::numeric + COALESCE(a."agentLifetimePnL", 0)) > ${teamLifetimePnL}
-            OR (
-              (u."lifetimePnL"::numeric + COALESCE(a."agentLifetimePnL", 0)) = ${teamLifetimePnL}
-              AND (
-                u."createdAt" < ${effectiveUser.createdAt.toISOString()}
-                OR (u."createdAt" = ${effectiveUser.createdAt.toISOString()} AND u."id" < ${effectiveUserId})
-              )
-            )
-          )
-      ) higher
-    `);
-
-    const higherRows = higherResult as unknown as Array<{ count: number }>;
-    const rank = (higherRows[0]?.count ?? 0) + 1;
-
-    const [agentCountResult] = await db
-      .select({ count: count() })
-      .from(users)
-      .where(
-        and(
-          eq(users.managedBy, effectiveUserId),
-          eq(users.isAgent, true),
-          eq(users.isActor, false)
-        )
-      );
-
+    const rank = higherCount + 1;
     return {
       rank,
       page: Math.ceil(rank / pageSize),
-      entry: {
-        id: effectiveUser.id,
-        username: effectiveUser.username,
-        displayName: effectiveUser.displayName,
-        profileImageUrl: effectiveUser.profileImageUrl,
-        reputationPoints: Number(effectiveUser.reputationPoints ?? 0),
-        balance: Number(effectiveUser.virtualBalance ?? 0),
-        lifetimePnL: Number(effectiveUser.lifetimePnL ?? 0),
-        userLifetimePnL: Number(effectiveUser.lifetimePnL ?? 0),
-        agentLifetimePnL: Number(agentLifetimePnL?.lifetimePnLTotal ?? 0),
-        teamLifetimePnL,
-        createdAt: effectiveUser.createdAt,
-        isAgent: false,
-        onChainRegistered: effectiveUser.onChainRegistered,
-        nftTokenId: effectiveUser.nftTokenId,
-        agentCount: agentCountResult?.count ?? 0,
-        rank,
-      },
+      entry: mapTeamEntry(row, rank),
     };
   }
 }

--- a/packages/api/src/services/trading-performance-service.ts
+++ b/packages/api/src/services/trading-performance-service.ts
@@ -7,13 +7,21 @@ const EXCLUDED_DEPOSIT_DESCRIPTION_PATTERNS = [
   'Refund - agent % registration failed',
 ] as const;
 
-export type TradingCapitalScope = 'wallet' | 'team';
-
-export interface CapitalBaseTransactionInput {
-  type: string;
-  amount: number;
-  balanceUnitsRequested?: number | null;
-}
+const CAPITAL_BASE_RULES = {
+  wallet: {
+    positiveTypes: [
+      'crypto_purchase',
+      'stripe_purchase',
+      'stripe_dispute_won',
+      'owner_deposit',
+    ],
+    reversalTypes: ['stripe_refund', 'stripe_dispute', 'owner_withdraw'],
+  },
+  team: {
+    positiveTypes: ['crypto_purchase', 'stripe_purchase', 'stripe_dispute_won'],
+    reversalTypes: ['stripe_refund', 'stripe_dispute'],
+  },
+} as const;
 
 // Wallet scope counts owner -> agent funding as capital made available to that
 // specific agent wallet. Team scope excludes it so owner/agent internal moves do
@@ -53,71 +61,24 @@ function buildReversalAmountExpression(transactionAlias: string): string {
   `;
 }
 
-export function getCapitalBaseContribution(
-  transaction: CapitalBaseTransactionInput,
-  scope: TradingCapitalScope
-): number {
-  const reversalAmount = Math.abs(
-    transaction.balanceUnitsRequested ?? transaction.amount
-  );
-
-  switch (transaction.type) {
-    case 'crypto_purchase':
-    case 'stripe_purchase':
-    case 'stripe_dispute_won':
-      return Math.abs(transaction.amount);
-    case 'owner_deposit':
-      return scope === 'wallet' ? Math.abs(transaction.amount) : 0;
-    case 'owner_withdraw':
-      return scope === 'wallet' ? -reversalAmount : 0;
-    case 'stripe_refund':
-    case 'stripe_dispute':
-      return -reversalAmount;
-    default:
-      return 0;
-  }
-}
-
-function buildWalletCapitalContributionExpression(
-  transactionAlias: string
+function buildCapitalContributionExpression(
+  transactionAlias: string,
+  scope: keyof typeof CAPITAL_BASE_RULES
 ): string {
   const reversalAmount = buildReversalAmountExpression(transactionAlias);
   const depositCondition = buildDepositInclusionCondition(transactionAlias);
+  const positiveTypes = CAPITAL_BASE_RULES[scope].positiveTypes
+    .map((type) => `'${type}'`)
+    .join(', ');
+  const reversalTypes = CAPITAL_BASE_RULES[scope].reversalTypes
+    .map((type) => `'${type}'`)
+    .join(', ');
 
   return `
     CASE
-      WHEN ${transactionAlias}."type" IN (
-        'crypto_purchase',
-        'stripe_purchase',
-        'stripe_dispute_won',
-        'owner_deposit'
-      ) THEN ABS(${transactionAlias}."amount"::numeric)
-      WHEN ${transactionAlias}."type" IN (
-        'stripe_refund',
-        'stripe_dispute',
-        'owner_withdraw'
-      )
-        THEN -(${reversalAmount})
-      WHEN ${depositCondition} THEN ABS(${transactionAlias}."amount"::numeric)
-      ELSE 0::numeric
-    END
-  `;
-}
-
-function buildTeamCapitalContributionExpression(
-  transactionAlias: string
-): string {
-  const reversalAmount = buildReversalAmountExpression(transactionAlias);
-  const depositCondition = buildDepositInclusionCondition(transactionAlias);
-
-  return `
-    CASE
-      WHEN ${transactionAlias}."type" IN (
-        'crypto_purchase',
-        'stripe_purchase',
-        'stripe_dispute_won'
-      ) THEN ABS(${transactionAlias}."amount"::numeric)
-      WHEN ${transactionAlias}."type" IN ('stripe_refund', 'stripe_dispute')
+      WHEN ${transactionAlias}."type" IN (${positiveTypes})
+        THEN ABS(${transactionAlias}."amount"::numeric)
+      WHEN ${transactionAlias}."type" IN (${reversalTypes})
         THEN -(${reversalAmount})
       WHEN ${depositCondition} THEN ABS(${transactionAlias}."amount"::numeric)
       ELSE 0::numeric
@@ -191,7 +152,7 @@ export class TradingPerformanceService {
       SELECT
         bt."userId" AS "userId",
         GREATEST(
-          COALESCE(SUM(${buildWalletCapitalContributionExpression('bt')}), 0),
+          COALESCE(SUM(${buildCapitalContributionExpression('bt', 'wallet')}), 0),
           0
         )::numeric AS "capitalBase"
       FROM "BalanceTransaction" bt
@@ -204,7 +165,7 @@ export class TradingPerformanceService {
       SELECT
         COALESCE(u."managedBy", u."id") AS "teamId",
         GREATEST(
-          COALESCE(SUM(${buildTeamCapitalContributionExpression('bt')}), 0),
+          COALESCE(SUM(${buildCapitalContributionExpression('bt', 'team')}), 0),
           0
         )::numeric AS "teamCapitalBase"
       FROM "BalanceTransaction" bt

--- a/packages/api/src/services/trading-performance-service.ts
+++ b/packages/api/src/services/trading-performance-service.ts
@@ -1,0 +1,455 @@
+import { db, sql } from '@babylon/db';
+
+export const TRADING_RETURN_CAPITAL_FLOOR = 1000;
+
+const EXCLUDED_DEPOSIT_DESCRIPTION_PATTERNS = [
+  'Daily login reward%',
+  'Refund - agent % registration failed',
+] as const;
+
+// Wallet scope counts owner -> agent funding as capital made available to that
+// specific agent wallet. Team scope excludes it so owner/agent internal moves do
+// not inflate the combined team denominator. Peer transfer types are intentionally
+// left out for now: the current ledger shape does not carry canonical sender/team
+// attribution for fair team-level treatment, and transfers are out of scope here.
+
+function buildDepositInclusionCondition(transactionAlias: string): string {
+  const descriptionExclusions = EXCLUDED_DEPOSIT_DESCRIPTION_PATTERNS.map(
+    (pattern) => `${transactionAlias}."description" NOT LIKE '${pattern}'`
+  ).join(' AND ');
+
+  return `
+    ${transactionAlias}."type" = 'deposit'
+    AND ${transactionAlias}."amount"::numeric > 0
+    AND (
+      ${transactionAlias}."description" IS NULL
+      OR (${descriptionExclusions})
+    )
+  `;
+}
+
+function buildReversalAmountExpression(transactionAlias: string): string {
+  return `
+    CASE
+      WHEN ${transactionAlias}."description" IS NOT NULL
+        AND LEFT(${transactionAlias}."description", 1) = '{'
+      THEN COALESCE(
+        NULLIF(
+          (${transactionAlias}."description"::jsonb ->> 'balanceUnitsRequested'),
+          ''
+        )::numeric,
+        ABS(${transactionAlias}."amount"::numeric)
+      )
+      ELSE ABS(${transactionAlias}."amount"::numeric)
+    END
+  `;
+}
+
+function buildWalletCapitalContributionExpression(
+  transactionAlias: string
+): string {
+  const reversalAmount = buildReversalAmountExpression(transactionAlias);
+  const depositCondition = buildDepositInclusionCondition(transactionAlias);
+
+  return `
+    CASE
+      WHEN ${transactionAlias}."type" IN (
+        'crypto_purchase',
+        'stripe_purchase',
+        'stripe_dispute_won',
+        'owner_deposit'
+      ) THEN ABS(${transactionAlias}."amount"::numeric)
+      WHEN ${transactionAlias}."type" IN ('stripe_refund', 'stripe_dispute')
+        THEN -(${reversalAmount})
+      WHEN ${depositCondition} THEN ABS(${transactionAlias}."amount"::numeric)
+      ELSE 0::numeric
+    END
+  `;
+}
+
+function buildTeamCapitalContributionExpression(
+  transactionAlias: string
+): string {
+  const reversalAmount = buildReversalAmountExpression(transactionAlias);
+  const depositCondition = buildDepositInclusionCondition(transactionAlias);
+
+  return `
+    CASE
+      WHEN ${transactionAlias}."type" IN (
+        'crypto_purchase',
+        'stripe_purchase',
+        'stripe_dispute_won'
+      ) THEN ABS(${transactionAlias}."amount"::numeric)
+      WHEN ${transactionAlias}."type" IN ('stripe_refund', 'stripe_dispute')
+        THEN -(${reversalAmount})
+      WHEN ${depositCondition} THEN ABS(${transactionAlias}."amount"::numeric)
+      ELSE 0::numeric
+    END
+  `;
+}
+
+export interface TradingReturnMetrics {
+  capitalBase: number;
+  effectiveCapitalBase: number;
+  tradingReturn: number;
+}
+
+export interface WalletTradingPerformanceRow {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+  profileImageUrl: string | null;
+  reputationPoints: string;
+  balance: string;
+  lifetimePnL: string;
+  capitalBase: string;
+  effectiveCapitalBase: string;
+  tradingReturn: string;
+  createdAt: Date;
+  onChainRegistered: boolean;
+  nftTokenId: number | null;
+  isAgent: boolean;
+  managedBy: string | null;
+}
+
+export interface TeamTradingPerformanceRow {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+  profileImageUrl: string | null;
+  reputationPoints: string;
+  balance: string;
+  userLifetimePnL: string;
+  agentLifetimePnL: string;
+  teamLifetimePnL: string;
+  teamCapitalBase: string;
+  teamEffectiveCapitalBase: string;
+  teamTradingReturn: string;
+  createdAt: Date;
+  onChainRegistered: boolean;
+  nftTokenId: number | null;
+  agentCount: number;
+}
+
+export class TradingPerformanceService {
+  static calculateTradingReturnMetrics(
+    lifetimePnL: number,
+    capitalBase: number
+  ): TradingReturnMetrics {
+    const normalizedCapitalBase = Math.max(capitalBase, 0);
+    const effectiveCapitalBase = Math.max(
+      normalizedCapitalBase,
+      TRADING_RETURN_CAPITAL_FLOOR
+    );
+
+    return {
+      capitalBase: normalizedCapitalBase,
+      effectiveCapitalBase,
+      tradingReturn: lifetimePnL / effectiveCapitalBase,
+    };
+  }
+
+  private static walletCapitalCte() {
+    return sql.raw(`
+      SELECT
+        bt."userId" AS "userId",
+        GREATEST(
+          COALESCE(SUM(${buildWalletCapitalContributionExpression('bt')}), 0),
+          0
+        )::numeric AS "capitalBase"
+      FROM "BalanceTransaction" bt
+      GROUP BY bt."userId"
+    `);
+  }
+
+  private static teamCapitalCte() {
+    return sql.raw(`
+      SELECT
+        COALESCE(u."managedBy", u."id") AS "teamId",
+        GREATEST(
+          COALESCE(SUM(${buildTeamCapitalContributionExpression('bt')}), 0),
+          0
+        )::numeric AS "teamCapitalBase"
+      FROM "BalanceTransaction" bt
+      INNER JOIN "User" u ON u."id" = bt."userId"
+      WHERE u."isActor" = false
+      GROUP BY COALESCE(u."managedBy", u."id")
+    `);
+  }
+
+  private static teamAgentsCte() {
+    return sql.raw(`
+      SELECT
+        "managedBy" AS "managerId",
+        COALESCE(SUM("lifetimePnL"::numeric), 0)::numeric AS "agentLifetimePnL",
+        COUNT(*)::int AS "agentCount"
+      FROM "User"
+      WHERE "isAgent" = true AND "isActor" = false
+      GROUP BY "managedBy"
+    `);
+  }
+
+  static async getWalletLeaderboardRows(
+    limit: number,
+    offset: number
+  ): Promise<WalletTradingPerformanceRow[]> {
+    const result = await db.execute(sql`
+      WITH wallet_capital AS (${this.walletCapitalCte()})
+      SELECT
+        u."id",
+        u."username",
+        u."displayName",
+        u."profileImageUrl",
+        u."reputationPoints"::numeric AS "reputationPoints",
+        u."virtualBalance"::numeric AS "balance",
+        u."lifetimePnL"::numeric AS "lifetimePnL",
+        COALESCE(wc."capitalBase", 0)::numeric AS "capitalBase",
+        GREATEST(
+          COALESCE(wc."capitalBase", 0)::numeric,
+          ${TRADING_RETURN_CAPITAL_FLOOR}
+        )::numeric AS "effectiveCapitalBase",
+        (
+          u."lifetimePnL"::numeric /
+          GREATEST(
+            COALESCE(wc."capitalBase", 0)::numeric,
+            ${TRADING_RETURN_CAPITAL_FLOOR}
+          )
+        )::numeric AS "tradingReturn",
+        u."createdAt",
+        u."onChainRegistered",
+        u."nftTokenId",
+        u."isAgent",
+        u."managedBy"
+      FROM "User" u
+      LEFT JOIN wallet_capital wc ON wc."userId" = u."id"
+      WHERE u."isActor" = false
+      ORDER BY "tradingReturn" DESC, u."createdAt" ASC, u."id" ASC
+      LIMIT ${limit} OFFSET ${offset}
+    `);
+
+    return result as unknown as WalletTradingPerformanceRow[];
+  }
+
+  static async getWalletEntry(
+    userId: string
+  ): Promise<WalletTradingPerformanceRow | null> {
+    const result = await db.execute(sql`
+      WITH wallet_capital AS (${this.walletCapitalCte()})
+      SELECT
+        u."id",
+        u."username",
+        u."displayName",
+        u."profileImageUrl",
+        u."reputationPoints"::numeric AS "reputationPoints",
+        u."virtualBalance"::numeric AS "balance",
+        u."lifetimePnL"::numeric AS "lifetimePnL",
+        COALESCE(wc."capitalBase", 0)::numeric AS "capitalBase",
+        GREATEST(
+          COALESCE(wc."capitalBase", 0)::numeric,
+          ${TRADING_RETURN_CAPITAL_FLOOR}
+        )::numeric AS "effectiveCapitalBase",
+        (
+          u."lifetimePnL"::numeric /
+          GREATEST(
+            COALESCE(wc."capitalBase", 0)::numeric,
+            ${TRADING_RETURN_CAPITAL_FLOOR}
+          )
+        )::numeric AS "tradingReturn",
+        u."createdAt",
+        u."onChainRegistered",
+        u."nftTokenId",
+        u."isAgent",
+        u."managedBy"
+      FROM "User" u
+      LEFT JOIN wallet_capital wc ON wc."userId" = u."id"
+      WHERE u."isActor" = false AND u."id" = ${userId}
+      LIMIT 1
+    `);
+
+    const rows = result as unknown as WalletTradingPerformanceRow[];
+    return rows[0] ?? null;
+  }
+
+  static async countWalletsAbove(entry: {
+    id: string;
+    createdAt: Date;
+    tradingReturn: string;
+  }): Promise<number> {
+    const result = await db.execute(sql`
+      WITH wallet_capital AS (${this.walletCapitalCte()}),
+      wallet_rows AS (
+        SELECT
+          u."id",
+          u."createdAt",
+          (
+            u."lifetimePnL"::numeric /
+            GREATEST(
+              COALESCE(wc."capitalBase", 0)::numeric,
+              ${TRADING_RETURN_CAPITAL_FLOOR}
+            )
+          )::numeric AS "tradingReturn"
+        FROM "User" u
+        LEFT JOIN wallet_capital wc ON wc."userId" = u."id"
+        WHERE u."isActor" = false
+      )
+      SELECT COUNT(*)::int AS "count"
+      FROM wallet_rows wr
+      WHERE
+        wr."tradingReturn" > ${entry.tradingReturn}
+        OR (
+          wr."tradingReturn" = ${entry.tradingReturn}
+          AND (
+            wr."createdAt" < ${entry.createdAt.toISOString()}
+            OR (
+              wr."createdAt" = ${entry.createdAt.toISOString()}
+              AND wr."id" < ${entry.id}
+            )
+          )
+        )
+    `);
+
+    const rows = result as unknown as Array<{ count: number }>;
+    return rows[0]?.count ?? 0;
+  }
+
+  static async getTeamLeaderboardRows(
+    limit: number,
+    offset: number
+  ): Promise<TeamTradingPerformanceRow[]> {
+    const result = await db.execute(sql`
+      WITH team_capital AS (${this.teamCapitalCte()}),
+      team_agents AS (${this.teamAgentsCte()})
+      SELECT
+        u."id",
+        u."username",
+        u."displayName",
+        u."profileImageUrl",
+        u."reputationPoints"::numeric AS "reputationPoints",
+        u."virtualBalance"::numeric AS "balance",
+        u."lifetimePnL"::numeric AS "userLifetimePnL",
+        COALESCE(ta."agentLifetimePnL", 0)::numeric AS "agentLifetimePnL",
+        (
+          u."lifetimePnL"::numeric + COALESCE(ta."agentLifetimePnL", 0)
+        )::numeric AS "teamLifetimePnL",
+        COALESCE(tc."teamCapitalBase", 0)::numeric AS "teamCapitalBase",
+        GREATEST(
+          COALESCE(tc."teamCapitalBase", 0)::numeric,
+          ${TRADING_RETURN_CAPITAL_FLOOR}
+        )::numeric AS "teamEffectiveCapitalBase",
+        (
+          (
+            u."lifetimePnL"::numeric + COALESCE(ta."agentLifetimePnL", 0)
+          ) /
+          GREATEST(
+            COALESCE(tc."teamCapitalBase", 0)::numeric,
+            ${TRADING_RETURN_CAPITAL_FLOOR}
+          )
+        )::numeric AS "teamTradingReturn",
+        u."createdAt",
+        u."onChainRegistered",
+        u."nftTokenId",
+        COALESCE(ta."agentCount", 0)::int AS "agentCount"
+      FROM "User" u
+      LEFT JOIN team_agents ta ON ta."managerId" = u."id"
+      LEFT JOIN team_capital tc ON tc."teamId" = u."id"
+      WHERE u."isActor" = false AND u."isAgent" = false
+      ORDER BY "teamTradingReturn" DESC, u."createdAt" ASC, u."id" ASC
+      LIMIT ${limit} OFFSET ${offset}
+    `);
+
+    return result as unknown as TeamTradingPerformanceRow[];
+  }
+
+  static async getTeamEntry(
+    teamOwnerId: string
+  ): Promise<TeamTradingPerformanceRow | null> {
+    const result = await db.execute(sql`
+      WITH team_capital AS (${this.teamCapitalCte()}),
+      team_agents AS (${this.teamAgentsCte()})
+      SELECT
+        u."id",
+        u."username",
+        u."displayName",
+        u."profileImageUrl",
+        u."reputationPoints"::numeric AS "reputationPoints",
+        u."virtualBalance"::numeric AS "balance",
+        u."lifetimePnL"::numeric AS "userLifetimePnL",
+        COALESCE(ta."agentLifetimePnL", 0)::numeric AS "agentLifetimePnL",
+        (
+          u."lifetimePnL"::numeric + COALESCE(ta."agentLifetimePnL", 0)
+        )::numeric AS "teamLifetimePnL",
+        COALESCE(tc."teamCapitalBase", 0)::numeric AS "teamCapitalBase",
+        GREATEST(
+          COALESCE(tc."teamCapitalBase", 0)::numeric,
+          ${TRADING_RETURN_CAPITAL_FLOOR}
+        )::numeric AS "teamEffectiveCapitalBase",
+        (
+          (
+            u."lifetimePnL"::numeric + COALESCE(ta."agentLifetimePnL", 0)
+          ) /
+          GREATEST(
+            COALESCE(tc."teamCapitalBase", 0)::numeric,
+            ${TRADING_RETURN_CAPITAL_FLOOR}
+          )
+        )::numeric AS "teamTradingReturn",
+        u."createdAt",
+        u."onChainRegistered",
+        u."nftTokenId",
+        COALESCE(ta."agentCount", 0)::int AS "agentCount"
+      FROM "User" u
+      LEFT JOIN team_agents ta ON ta."managerId" = u."id"
+      LEFT JOIN team_capital tc ON tc."teamId" = u."id"
+      WHERE u."isActor" = false AND u."isAgent" = false AND u."id" = ${teamOwnerId}
+      LIMIT 1
+    `);
+
+    const rows = result as unknown as TeamTradingPerformanceRow[];
+    return rows[0] ?? null;
+  }
+
+  static async countTeamsAbove(entry: {
+    id: string;
+    createdAt: Date;
+    teamTradingReturn: string;
+  }): Promise<number> {
+    const result = await db.execute(sql`
+      WITH team_capital AS (${this.teamCapitalCte()}),
+      team_agents AS (${this.teamAgentsCte()}),
+      team_rows AS (
+        SELECT
+          u."id",
+          u."createdAt",
+          (
+            (
+              u."lifetimePnL"::numeric + COALESCE(ta."agentLifetimePnL", 0)
+            ) /
+            GREATEST(
+              COALESCE(tc."teamCapitalBase", 0)::numeric,
+              ${TRADING_RETURN_CAPITAL_FLOOR}
+            )
+          )::numeric AS "teamTradingReturn"
+        FROM "User" u
+        LEFT JOIN team_agents ta ON ta."managerId" = u."id"
+        LEFT JOIN team_capital tc ON tc."teamId" = u."id"
+        WHERE u."isActor" = false AND u."isAgent" = false
+      )
+      SELECT COUNT(*)::int AS "count"
+      FROM team_rows tr
+      WHERE
+        tr."teamTradingReturn" > ${entry.teamTradingReturn}
+        OR (
+          tr."teamTradingReturn" = ${entry.teamTradingReturn}
+          AND (
+            tr."createdAt" < ${entry.createdAt.toISOString()}
+            OR (
+              tr."createdAt" = ${entry.createdAt.toISOString()}
+              AND tr."id" < ${entry.id}
+            )
+          )
+        )
+    `);
+
+    const rows = result as unknown as Array<{ count: number }>;
+    return rows[0]?.count ?? 0;
+  }
+}

--- a/packages/api/src/services/trading-performance-service.ts
+++ b/packages/api/src/services/trading-performance-service.ts
@@ -7,6 +7,14 @@ const EXCLUDED_DEPOSIT_DESCRIPTION_PATTERNS = [
   'Refund - agent % registration failed',
 ] as const;
 
+export type TradingCapitalScope = 'wallet' | 'team';
+
+export interface CapitalBaseTransactionInput {
+  type: string;
+  amount: number;
+  balanceUnitsRequested?: number | null;
+}
+
 // Wallet scope counts owner -> agent funding as capital made available to that
 // specific agent wallet. Team scope excludes it so owner/agent internal moves do
 // not inflate the combined team denominator. Peer transfer types are intentionally
@@ -45,6 +53,31 @@ function buildReversalAmountExpression(transactionAlias: string): string {
   `;
 }
 
+export function getCapitalBaseContribution(
+  transaction: CapitalBaseTransactionInput,
+  scope: TradingCapitalScope
+): number {
+  const reversalAmount = Math.abs(
+    transaction.balanceUnitsRequested ?? transaction.amount
+  );
+
+  switch (transaction.type) {
+    case 'crypto_purchase':
+    case 'stripe_purchase':
+    case 'stripe_dispute_won':
+      return Math.abs(transaction.amount);
+    case 'owner_deposit':
+      return scope === 'wallet' ? Math.abs(transaction.amount) : 0;
+    case 'owner_withdraw':
+      return scope === 'wallet' ? -reversalAmount : 0;
+    case 'stripe_refund':
+    case 'stripe_dispute':
+      return -reversalAmount;
+    default:
+      return 0;
+  }
+}
+
 function buildWalletCapitalContributionExpression(
   transactionAlias: string
 ): string {
@@ -59,7 +92,11 @@ function buildWalletCapitalContributionExpression(
         'stripe_dispute_won',
         'owner_deposit'
       ) THEN ABS(${transactionAlias}."amount"::numeric)
-      WHEN ${transactionAlias}."type" IN ('stripe_refund', 'stripe_dispute')
+      WHEN ${transactionAlias}."type" IN (
+        'stripe_refund',
+        'stripe_dispute',
+        'owner_withdraw'
+      )
         THEN -(${reversalAmount})
       WHEN ${depositCondition} THEN ABS(${transactionAlias}."amount"::numeric)
       ELSE 0::numeric

--- a/packages/testing/unit/leaderboard-cache.test.ts
+++ b/packages/testing/unit/leaderboard-cache.test.ts
@@ -59,6 +59,14 @@ const mockGetTeamLeaderboard = mock(async () => ({
 }));
 const mockGetTradingWalletLeaderboard = mock(async () => ({
   ...mockLeaderboardResult,
+  users: [
+    {
+      ...mockLeaderboardResult.users[0],
+      capitalBase: 1500,
+      effectiveCapitalBase: 1500,
+      tradingReturn: 0.3,
+    },
+  ],
   leaderboardMetric: 'trading' as const,
 }));
 const mockGetTradingTeamLeaderboard = mock(async () => ({
@@ -270,6 +278,7 @@ describe('Leaderboard caching — generatedAt', () => {
     expect(body.leaderboardMetric).toBe('trading');
     expect(mockGetTradingWalletLeaderboard).toHaveBeenCalledTimes(1);
     expect(mockSetCache.mock.calls[0]?.[0]).toBe('trading-wallet-1-100');
+    expect(body.leaderboard[0].tradingReturn).toBe(0.3);
   });
 
   test('x-cache header reflects cache hit/miss', async () => {

--- a/packages/testing/unit/leaderboard-route.test.ts
+++ b/packages/testing/unit/leaderboard-route.test.ts
@@ -50,11 +50,30 @@ const mockGetTeamLeaderboard = mock(async () => ({
   leaderboardMetric: 'reputation' as const,
 }));
 const mockGetTradingWalletLeaderboard = mock(async () => ({
-  users: [],
-  totalCount: 0,
+  users: [
+    {
+      id: 'trader-1',
+      username: 'gamma',
+      displayName: 'Gamma',
+      profileImageUrl: null,
+      reputationPoints: 80,
+      balance: 4000,
+      lifetimePnL: 1200,
+      capitalBase: 2000,
+      effectiveCapitalBase: 2000,
+      tradingReturn: 0.6,
+      createdAt: new Date('2026-03-09T00:00:00.000Z'),
+      rank: 1,
+      isAgent: false,
+      managedBy: null,
+      onChainRegistered: false,
+      nftTokenId: null,
+    },
+  ],
+  totalCount: 1,
   page: 1,
   pageSize: 100,
-  totalPages: 0,
+  totalPages: 1,
   leaderboardType: 'wallet' as const,
   leaderboardMetric: 'trading' as const,
 }));
@@ -257,5 +276,7 @@ describe('Leaderboard route follow state enrichment', () => {
     const body = await response.json();
     expect(body.leaderboardMetric).toBe('trading');
     expect(body.leaderboardType).toBe('wallet');
+    expect(body.leaderboard[0].tradingReturn).toBeDefined();
+    expect(body.leaderboard[0].capitalBase).toBeDefined();
   });
 });

--- a/packages/testing/unit/trading-performance-service.test.ts
+++ b/packages/testing/unit/trading-performance-service.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  TRADING_RETURN_CAPITAL_FLOOR,
+  TradingPerformanceService,
+} from '../../api/src/services/trading-performance-service';
+
+describe('TradingPerformanceService.calculateTradingReturnMetrics', () => {
+  it('uses the raw capital base when it is above the floor', () => {
+    const result = TradingPerformanceService.calculateTradingReturnMetrics(
+      500,
+      2000
+    );
+
+    expect(result.capitalBase).toBe(2000);
+    expect(result.effectiveCapitalBase).toBe(2000);
+    expect(result.tradingReturn).toBe(0.25);
+  });
+
+  it('applies the canonical floor when capital base is below 1000', () => {
+    const result = TradingPerformanceService.calculateTradingReturnMetrics(
+      500,
+      300
+    );
+
+    expect(result.capitalBase).toBe(300);
+    expect(result.effectiveCapitalBase).toBe(TRADING_RETURN_CAPITAL_FLOOR);
+    expect(result.tradingReturn).toBe(0.5);
+  });
+
+  it('clamps negative capital base to zero before applying the floor', () => {
+    const result = TradingPerformanceService.calculateTradingReturnMetrics(
+      -200,
+      -50
+    );
+
+    expect(result.capitalBase).toBe(0);
+    expect(result.effectiveCapitalBase).toBe(TRADING_RETURN_CAPITAL_FLOOR);
+    expect(result.tradingReturn).toBe(-0.2);
+  });
+});

--- a/packages/testing/unit/trading-performance-service.test.ts
+++ b/packages/testing/unit/trading-performance-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  getCapitalBaseContribution,
   TRADING_RETURN_CAPITAL_FLOOR,
   TradingPerformanceService,
 } from '../../api/src/services/trading-performance-service';
@@ -36,5 +37,50 @@ describe('TradingPerformanceService.calculateTradingReturnMetrics', () => {
     expect(result.capitalBase).toBe(0);
     expect(result.effectiveCapitalBase).toBe(TRADING_RETURN_CAPITAL_FLOOR);
     expect(result.tradingReturn).toBe(-0.2);
+  });
+});
+
+describe('getCapitalBaseContribution', () => {
+  it('counts owner deposits for wallet scope only', () => {
+    expect(
+      getCapitalBaseContribution(
+        { type: 'owner_deposit', amount: 500 },
+        'wallet'
+      )
+    ).toBe(500);
+    expect(
+      getCapitalBaseContribution(
+        { type: 'owner_deposit', amount: 500 },
+        'team'
+      )
+    ).toBe(0);
+  });
+
+  it('treats owner withdrawals as wallet-scope capital reversals', () => {
+    expect(
+      getCapitalBaseContribution(
+        { type: 'owner_withdraw', amount: -200 },
+        'wallet'
+      )
+    ).toBe(-200);
+    expect(
+      getCapitalBaseContribution(
+        { type: 'owner_withdraw', amount: -200 },
+        'team'
+      )
+    ).toBe(0);
+  });
+
+  it('uses requested balance units for external reversals when present', () => {
+    expect(
+      getCapitalBaseContribution(
+        {
+          type: 'stripe_refund',
+          amount: -120,
+          balanceUnitsRequested: 300,
+        },
+        'wallet'
+      )
+    ).toBe(-300);
   });
 });

--- a/packages/testing/unit/trading-performance-service.test.ts
+++ b/packages/testing/unit/trading-performance-service.test.ts
@@ -49,10 +49,7 @@ describe('getCapitalBaseContribution', () => {
       )
     ).toBe(500);
     expect(
-      getCapitalBaseContribution(
-        { type: 'owner_deposit', amount: 500 },
-        'team'
-      )
+      getCapitalBaseContribution({ type: 'owner_deposit', amount: 500 }, 'team')
     ).toBe(0);
   });
 

--- a/packages/testing/unit/trading-performance-service.test.ts
+++ b/packages/testing/unit/trading-performance-service.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'bun:test';
 import {
-  getCapitalBaseContribution,
   TRADING_RETURN_CAPITAL_FLOOR,
   TradingPerformanceService,
 } from '../../api/src/services/trading-performance-service';
@@ -37,47 +36,5 @@ describe('TradingPerformanceService.calculateTradingReturnMetrics', () => {
     expect(result.capitalBase).toBe(0);
     expect(result.effectiveCapitalBase).toBe(TRADING_RETURN_CAPITAL_FLOOR);
     expect(result.tradingReturn).toBe(-0.2);
-  });
-});
-
-describe('getCapitalBaseContribution', () => {
-  it('counts owner deposits for wallet scope only', () => {
-    expect(
-      getCapitalBaseContribution(
-        { type: 'owner_deposit', amount: 500 },
-        'wallet'
-      )
-    ).toBe(500);
-    expect(
-      getCapitalBaseContribution({ type: 'owner_deposit', amount: 500 }, 'team')
-    ).toBe(0);
-  });
-
-  it('treats owner withdrawals as wallet-scope capital reversals', () => {
-    expect(
-      getCapitalBaseContribution(
-        { type: 'owner_withdraw', amount: -200 },
-        'wallet'
-      )
-    ).toBe(-200);
-    expect(
-      getCapitalBaseContribution(
-        { type: 'owner_withdraw', amount: -200 },
-        'team'
-      )
-    ).toBe(0);
-  });
-
-  it('uses requested balance units for external reversals when present', () => {
-    expect(
-      getCapitalBaseContribution(
-        {
-          type: 'stripe_refund',
-          amount: -120,
-          balanceUnitsRequested: 300,
-        },
-        'wallet'
-      )
-    ).toBe(-300);
   });
 });


### PR DESCRIPTION
## Summary
- switch the trading leaderboard from raw lifetime PnL to capital-adjusted return
- add a canonical `TradingPerformanceService` to compute wallet/team capital base, effective capital, and trading return
- update the trading leaderboard payload and UI to rank on return while still showing lifetime PnL as secondary context

## Trading return formula
- `tradingReturn = lifetimePnL / max(capitalBase, 1000)`
- wallet capital base is derived from canonical balance funding ledger entries
- team capital base excludes owner-agent internal funding to avoid double counting

## Validation
- `bun test packages/testing/unit/trading-performance-service.test.ts`
- `bun test packages/testing/unit/leaderboard-route.test.ts`
- `bun test packages/testing/unit/leaderboard-cache.test.ts`

## Notes
- local working tree still contains unrelated modified files from prior formatting churn and untracked local files; they are intentionally not part of this PR
- the main technical debt left after this PR is that some capital-base classification still relies on ledger heuristics/transaction descriptions and should be canonized before reintroducing trading balance transfers
