### PR TITLE
refactor: canonize trading capital base classification

### DIFF
--- a/packages/api/src/services/agent-evm-registration-service.ts
+++ b/packages/api/src/services/agent-evm-registration-service.ts
@@ -1,4 +1,12 @@
-import { and, balanceTransactions, db, eq, sql, users } from '@babylon/db';
+import {
+  AGENT_EVM_REGISTRATION_REFUND_BALANCE_DESCRIPTION,
+  and,
+  balanceTransactions,
+  db,
+  eq,
+  sql,
+  users,
+} from '@babylon/db';
 import {
   BusinessLogicError,
   generateSnowflakeId,
@@ -236,7 +244,7 @@ async function refundRegistrationCost(
     balanceBefore: String(balanceBefore),
     balanceAfter: String(balanceAfter),
     relatedId: agentUserId,
-    description: 'Refund - agent EVM registration failed',
+    description: AGENT_EVM_REGISTRATION_REFUND_BALANCE_DESCRIPTION,
     createdAt: new Date(),
   });
 }

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -9,7 +9,15 @@ import {
   prepareAgentSolanaRegistrationTransaction,
   SOLANA_REGISTRATION_MIN_BALANCE_LAMPORTS,
 } from '@babylon/agents/solana-registry';
-import { and, balanceTransactions, db, eq, sql, users } from '@babylon/db';
+import {
+  AGENT_SOLANA_REGISTRATION_REFUND_BALANCE_DESCRIPTION,
+  and,
+  balanceTransactions,
+  db,
+  eq,
+  sql,
+  users,
+} from '@babylon/db';
 import {
   BusinessLogicError,
   generateSnowflakeId,
@@ -234,7 +242,7 @@ async function refundRegistrationCost(
     balanceBefore: String(balanceBefore),
     balanceAfter: String(balanceAfter),
     relatedId: agentUserId,
-    description: 'Refund - agent Solana registration failed',
+    description: AGENT_SOLANA_REGISTRATION_REFUND_BALANCE_DESCRIPTION,
     createdAt: new Date(),
   });
 }

--- a/packages/api/src/services/daily-login-service.ts
+++ b/packages/api/src/services/daily-login-service.ts
@@ -19,7 +19,14 @@
  * - `DistributedLockService` requires Redis (already deployed)
  */
 
-import { balanceTransactions, db, eq, sql, users } from '@babylon/db';
+import {
+  balanceTransactions,
+  buildDailyLoginRewardBalanceDescription,
+  db,
+  eq,
+  sql,
+  users,
+} from '@babylon/db';
 import {
   DAILY_LOGIN,
   generateSnowflakeId,
@@ -366,7 +373,10 @@ export class DailyLoginService {
           amount: totalAwarded.toString(),
           balanceBefore: balanceBefore.toString(),
           balanceAfter: (balanceBefore + totalAwarded).toString(),
-          description: `Daily login reward (Day ${newStreak})${milestoneBonus ? ` + ${newStreak}-day milestone` : ''}`,
+          description: buildDailyLoginRewardBalanceDescription(
+            newStreak,
+            milestoneBonus
+          ),
         });
 
         return {

--- a/packages/api/src/services/trading-balance-funding-service.ts
+++ b/packages/api/src/services/trading-balance-funding-service.ts
@@ -7,6 +7,7 @@ import {
   inArray,
   sql,
   users,
+  WELCOME_BONUS_BALANCE_DESCRIPTION,
 } from '@babylon/db';
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import { CACHE_KEYS, invalidateCache } from '../cache';
@@ -19,8 +20,6 @@ const FUNDING_TRANSACTION_TYPES = [
   'stripe_dispute',
   'stripe_dispute_won',
 ] as const;
-
-const WELCOME_BONUS_DESCRIPTION = 'Welcome bonus - initial signup';
 
 export interface TradingBalanceFundingResult {
   success: boolean;
@@ -107,7 +106,10 @@ export class TradingBalanceFundingService {
         .where(
           and(
             eq(balanceTransactions.userId, userId),
-            eq(balanceTransactions.description, WELCOME_BONUS_DESCRIPTION)
+            eq(
+              balanceTransactions.description,
+              WELCOME_BONUS_BALANCE_DESCRIPTION
+            )
           )
         )
         .limit(1);
@@ -161,7 +163,7 @@ export class TradingBalanceFundingService {
         amount: String(amount),
         balanceBefore: String(balanceBefore),
         balanceAfter: String(balanceAfter),
-        description: WELCOME_BONUS_DESCRIPTION,
+        description: WELCOME_BONUS_BALANCE_DESCRIPTION,
       });
 
       return {

--- a/packages/api/src/services/trading-performance-service.ts
+++ b/packages/api/src/services/trading-performance-service.ts
@@ -1,89 +1,12 @@
-import { db, sql } from '@babylon/db';
+import { buildCapitalBaseContributionSql, db, sql } from '@babylon/db';
 
 export const TRADING_RETURN_CAPITAL_FLOOR = 1000;
 
-const EXCLUDED_DEPOSIT_DESCRIPTION_PATTERNS = [
-  'Daily login reward%',
-  'Refund - agent % registration failed',
-] as const;
-
-const CAPITAL_BASE_RULES = {
-  wallet: {
-    positiveTypes: [
-      'crypto_purchase',
-      'stripe_purchase',
-      'stripe_dispute_won',
-      'owner_deposit',
-    ],
-    reversalTypes: ['stripe_refund', 'stripe_dispute', 'owner_withdraw'],
-  },
-  team: {
-    positiveTypes: ['crypto_purchase', 'stripe_purchase', 'stripe_dispute_won'],
-    reversalTypes: ['stripe_refund', 'stripe_dispute'],
-  },
-} as const;
-
-// Wallet scope counts owner -> agent funding as capital made available to that
-// specific agent wallet. Team scope excludes it so owner/agent internal moves do
-// not inflate the combined team denominator. Peer transfer types are intentionally
-// left out for now: the current ledger shape does not carry canonical sender/team
-// attribution for fair team-level treatment, and transfers are out of scope here.
-
-function buildDepositInclusionCondition(transactionAlias: string): string {
-  const descriptionExclusions = EXCLUDED_DEPOSIT_DESCRIPTION_PATTERNS.map(
-    (pattern) => `${transactionAlias}."description" NOT LIKE '${pattern}'`
-  ).join(' AND ');
-
-  return `
-    ${transactionAlias}."type" = 'deposit'
-    AND ${transactionAlias}."amount"::numeric > 0
-    AND (
-      ${transactionAlias}."description" IS NULL
-      OR (${descriptionExclusions})
-    )
-  `;
-}
-
-function buildReversalAmountExpression(transactionAlias: string): string {
-  return `
-    CASE
-      WHEN ${transactionAlias}."description" IS NOT NULL
-        AND LEFT(${transactionAlias}."description", 1) = '{'
-      THEN COALESCE(
-        NULLIF(
-          (${transactionAlias}."description"::jsonb ->> 'balanceUnitsRequested'),
-          ''
-        )::numeric,
-        ABS(${transactionAlias}."amount"::numeric)
-      )
-      ELSE ABS(${transactionAlias}."amount"::numeric)
-    END
-  `;
-}
-
 function buildCapitalContributionExpression(
   transactionAlias: string,
-  scope: keyof typeof CAPITAL_BASE_RULES
+  scope: 'wallet' | 'team'
 ): string {
-  const reversalAmount = buildReversalAmountExpression(transactionAlias);
-  const depositCondition = buildDepositInclusionCondition(transactionAlias);
-  const positiveTypes = CAPITAL_BASE_RULES[scope].positiveTypes
-    .map((type) => `'${type}'`)
-    .join(', ');
-  const reversalTypes = CAPITAL_BASE_RULES[scope].reversalTypes
-    .map((type) => `'${type}'`)
-    .join(', ');
-
-  return `
-    CASE
-      WHEN ${transactionAlias}."type" IN (${positiveTypes})
-        THEN ABS(${transactionAlias}."amount"::numeric)
-      WHEN ${transactionAlias}."type" IN (${reversalTypes})
-        THEN -(${reversalAmount})
-      WHEN ${depositCondition} THEN ABS(${transactionAlias}."amount"::numeric)
-      ELSE 0::numeric
-    END
-  `;
+  return buildCapitalBaseContributionSql(transactionAlias, scope);
 }
 
 export interface TradingReturnMetrics {

--- a/packages/db/src/balance-transaction-classification.ts
+++ b/packages/db/src/balance-transaction-classification.ts
@@ -1,0 +1,479 @@
+import type { BalanceTransaction } from './model-types';
+
+export const WELCOME_BONUS_BALANCE_DESCRIPTION =
+  'Welcome bonus - initial signup';
+export const DAILY_LOGIN_REWARD_BALANCE_DESCRIPTION_PREFIX =
+  'Daily login reward';
+export const AGENT_EVM_REGISTRATION_REFUND_BALANCE_DESCRIPTION =
+  'Refund - agent EVM registration failed';
+export const AGENT_SOLANA_REGISTRATION_REFUND_BALANCE_DESCRIPTION =
+  'Refund - agent Solana registration failed';
+
+export type CapitalBaseScope = 'wallet' | 'team';
+export type CapitalBaseEffect = 'credit' | 'debit' | 'none';
+export type BalanceTransactionCapitalKind =
+  | 'external_funding'
+  | 'capital_reversal'
+  | 'capital_restoration'
+  | 'internal_transfer'
+  | 'non_capital_activity'
+  | 'unknown';
+export type DepositClassificationReason =
+  | 'default_wallet_funding'
+  | 'daily_login_reward'
+  | 'agent_registration_refund';
+export type CapitalAmountStrategy =
+  | 'absolute_amount'
+  | 'balance_units_requested';
+
+type ClassifiedBalanceTransactionInput = Pick<
+  BalanceTransaction,
+  'type' | 'amount' | 'description'
+>;
+
+interface BaseCapitalClassification {
+  capitalKind: BalanceTransactionCapitalKind;
+  walletCapitalBaseEffect: CapitalBaseEffect;
+  teamCapitalBaseEffect: CapitalBaseEffect;
+  isExternalCapitalInflow: boolean;
+  isInternalTransfer: boolean;
+  isReversal: boolean;
+  isCapitalRestoration: boolean;
+  isCapitalNeutralActivity: boolean;
+  amountStrategy: CapitalAmountStrategy;
+  depositReason: DepositClassificationReason | null;
+  descriptionDriven: boolean;
+}
+
+export interface BalanceTransactionCapitalClassification
+  extends BaseCapitalClassification {
+  type: string;
+}
+
+type FixedTransactionTypeRule = Omit<
+  BaseCapitalClassification,
+  'depositReason' | 'descriptionDriven'
+>;
+
+type DepositDescriptionRule = {
+  reason: Exclude<DepositClassificationReason, 'default_wallet_funding'>;
+  matches: (description: string | null) => boolean;
+  matchesSql: (transactionAlias: string) => string;
+  classification: Omit<
+    BaseCapitalClassification,
+    'depositReason' | 'descriptionDriven'
+  >;
+};
+
+const FIXED_TRANSACTION_TYPE_RULES: Record<string, FixedTransactionTypeRule> = {
+  crypto_purchase: {
+    capitalKind: 'external_funding',
+    walletCapitalBaseEffect: 'credit',
+    teamCapitalBaseEffect: 'credit',
+    isExternalCapitalInflow: true,
+    isInternalTransfer: false,
+    isReversal: false,
+    isCapitalRestoration: false,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'absolute_amount',
+  },
+  stripe_purchase: {
+    capitalKind: 'external_funding',
+    walletCapitalBaseEffect: 'credit',
+    teamCapitalBaseEffect: 'credit',
+    isExternalCapitalInflow: true,
+    isInternalTransfer: false,
+    isReversal: false,
+    isCapitalRestoration: false,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'absolute_amount',
+  },
+  stripe_refund: {
+    capitalKind: 'capital_reversal',
+    walletCapitalBaseEffect: 'debit',
+    teamCapitalBaseEffect: 'debit',
+    isExternalCapitalInflow: false,
+    isInternalTransfer: false,
+    isReversal: true,
+    isCapitalRestoration: false,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'balance_units_requested',
+  },
+  stripe_dispute: {
+    capitalKind: 'capital_reversal',
+    walletCapitalBaseEffect: 'debit',
+    teamCapitalBaseEffect: 'debit',
+    isExternalCapitalInflow: false,
+    isInternalTransfer: false,
+    isReversal: true,
+    isCapitalRestoration: false,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'balance_units_requested',
+  },
+  stripe_dispute_won: {
+    capitalKind: 'capital_restoration',
+    walletCapitalBaseEffect: 'credit',
+    teamCapitalBaseEffect: 'credit',
+    isExternalCapitalInflow: false,
+    isInternalTransfer: false,
+    isReversal: false,
+    isCapitalRestoration: true,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'absolute_amount',
+  },
+  owner_deposit: {
+    capitalKind: 'internal_transfer',
+    walletCapitalBaseEffect: 'credit',
+    teamCapitalBaseEffect: 'none',
+    isExternalCapitalInflow: false,
+    isInternalTransfer: true,
+    isReversal: false,
+    isCapitalRestoration: false,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'absolute_amount',
+  },
+  owner_withdraw: {
+    capitalKind: 'internal_transfer',
+    walletCapitalBaseEffect: 'debit',
+    teamCapitalBaseEffect: 'none',
+    isExternalCapitalInflow: false,
+    isInternalTransfer: true,
+    isReversal: false,
+    isCapitalRestoration: false,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'absolute_amount',
+  },
+  agent_deposit: {
+    capitalKind: 'internal_transfer',
+    walletCapitalBaseEffect: 'none',
+    teamCapitalBaseEffect: 'none',
+    isExternalCapitalInflow: false,
+    isInternalTransfer: true,
+    isReversal: false,
+    isCapitalRestoration: false,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'absolute_amount',
+  },
+  agent_withdraw: {
+    capitalKind: 'internal_transfer',
+    walletCapitalBaseEffect: 'none',
+    teamCapitalBaseEffect: 'none',
+    isExternalCapitalInflow: false,
+    isInternalTransfer: true,
+    isReversal: false,
+    isCapitalRestoration: false,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'absolute_amount',
+  },
+  agent_balance_return: {
+    capitalKind: 'internal_transfer',
+    walletCapitalBaseEffect: 'none',
+    teamCapitalBaseEffect: 'none',
+    isExternalCapitalInflow: false,
+    isInternalTransfer: true,
+    isReversal: false,
+    isCapitalRestoration: false,
+    isCapitalNeutralActivity: false,
+    amountStrategy: 'absolute_amount',
+  },
+};
+
+const DEPOSIT_DESCRIPTION_RULES: DepositDescriptionRule[] = [
+  {
+    reason: 'daily_login_reward',
+    matches: (description) =>
+      typeof description === 'string' &&
+      description.startsWith(DAILY_LOGIN_REWARD_BALANCE_DESCRIPTION_PREFIX),
+    matchesSql: (transactionAlias) =>
+      `${transactionAlias}."description" LIKE '${escapeSqlLiteral(
+        `${DAILY_LOGIN_REWARD_BALANCE_DESCRIPTION_PREFIX}%`
+      )}'`,
+    classification: {
+      capitalKind: 'non_capital_activity',
+      walletCapitalBaseEffect: 'none',
+      teamCapitalBaseEffect: 'none',
+      isExternalCapitalInflow: false,
+      isInternalTransfer: false,
+      isReversal: false,
+      isCapitalRestoration: false,
+      isCapitalNeutralActivity: true,
+      amountStrategy: 'absolute_amount',
+    },
+  },
+  {
+    reason: 'agent_registration_refund',
+    matches: (description) =>
+      description === AGENT_EVM_REGISTRATION_REFUND_BALANCE_DESCRIPTION ||
+      description === AGENT_SOLANA_REGISTRATION_REFUND_BALANCE_DESCRIPTION,
+    matchesSql: (transactionAlias) =>
+      `${transactionAlias}."description" IN (${[
+        AGENT_EVM_REGISTRATION_REFUND_BALANCE_DESCRIPTION,
+        AGENT_SOLANA_REGISTRATION_REFUND_BALANCE_DESCRIPTION,
+      ]
+        .map(quoteSqlLiteral)
+        .join(', ')})`,
+    classification: {
+      capitalKind: 'non_capital_activity',
+      walletCapitalBaseEffect: 'none',
+      teamCapitalBaseEffect: 'none',
+      isExternalCapitalInflow: false,
+      isInternalTransfer: false,
+      isReversal: false,
+      isCapitalRestoration: false,
+      isCapitalNeutralActivity: true,
+      amountStrategy: 'absolute_amount',
+    },
+  },
+];
+
+const DEFAULT_DEPOSIT_CLASSIFICATION: BaseCapitalClassification = {
+  capitalKind: 'external_funding',
+  walletCapitalBaseEffect: 'credit',
+  teamCapitalBaseEffect: 'credit',
+  isExternalCapitalInflow: true,
+  isInternalTransfer: false,
+  isReversal: false,
+  isCapitalRestoration: false,
+  isCapitalNeutralActivity: false,
+  amountStrategy: 'absolute_amount',
+  depositReason: 'default_wallet_funding',
+  descriptionDriven: true,
+};
+
+const UNKNOWN_TRANSACTION_CLASSIFICATION: BaseCapitalClassification = {
+  capitalKind: 'unknown',
+  walletCapitalBaseEffect: 'none',
+  teamCapitalBaseEffect: 'none',
+  isExternalCapitalInflow: false,
+  isInternalTransfer: false,
+  isReversal: false,
+  isCapitalRestoration: false,
+  isCapitalNeutralActivity: false,
+  amountStrategy: 'absolute_amount',
+  depositReason: null,
+  descriptionDriven: false,
+};
+
+function quoteSqlLiteral(value: string): string {
+  return `'${escapeSqlLiteral(value)}'`;
+}
+
+function escapeSqlLiteral(value: string): string {
+  return value.replaceAll("'", "''");
+}
+
+function buildScopedTypes(effect: CapitalBaseEffect, scope: CapitalBaseScope) {
+  return Object.entries(FIXED_TRANSACTION_TYPE_RULES)
+    .filter(([, rule]) =>
+      scope === 'wallet'
+        ? rule.walletCapitalBaseEffect === effect
+        : rule.teamCapitalBaseEffect === effect
+    )
+    .map(([type]) => type);
+}
+
+export function buildDailyLoginRewardBalanceDescription(
+  streak: number,
+  milestoneBonus: number
+): string {
+  return `${DAILY_LOGIN_REWARD_BALANCE_DESCRIPTION_PREFIX} (Day ${streak})${milestoneBonus ? ` + ${streak}-day milestone` : ''}`;
+}
+
+export function classifyBalanceTransaction(
+  transaction: ClassifiedBalanceTransactionInput
+): BalanceTransactionCapitalClassification {
+  if (transaction.type === 'deposit') {
+    const matchedRule = DEPOSIT_DESCRIPTION_RULES.find((rule) =>
+      rule.matches(transaction.description)
+    );
+
+    if (matchedRule) {
+      return {
+        type: transaction.type,
+        ...matchedRule.classification,
+        depositReason: matchedRule.reason,
+        descriptionDriven: true,
+      };
+    }
+
+    return {
+      type: transaction.type,
+      ...DEFAULT_DEPOSIT_CLASSIFICATION,
+    };
+  }
+
+  const fixedRule = FIXED_TRANSACTION_TYPE_RULES[transaction.type];
+  if (fixedRule) {
+    return {
+      type: transaction.type,
+      ...fixedRule,
+      depositReason: null,
+      descriptionDriven: false,
+    };
+  }
+
+  return {
+    type: transaction.type,
+    ...UNKNOWN_TRANSACTION_CLASSIFICATION,
+  };
+}
+
+export function extractCapitalBaseAmount(
+  transaction: ClassifiedBalanceTransactionInput
+): number {
+  const classification = classifyBalanceTransaction(transaction);
+  const fallbackAmount = Math.abs(Number(transaction.amount ?? 0));
+
+  if (classification.amountStrategy !== 'balance_units_requested') {
+    return fallbackAmount;
+  }
+
+  const requestedUnits = extractRequestedBalanceUnits(transaction.description);
+  return requestedUnits ?? fallbackAmount;
+}
+
+export function getCapitalBaseContributionAmount(
+  transaction: ClassifiedBalanceTransactionInput,
+  scope: CapitalBaseScope
+): number {
+  const classification = classifyBalanceTransaction(transaction);
+  const effect =
+    scope === 'wallet'
+      ? classification.walletCapitalBaseEffect
+      : classification.teamCapitalBaseEffect;
+
+  if (effect === 'none') {
+    return 0;
+  }
+
+  const amount = extractCapitalBaseAmount(transaction);
+  return effect === 'credit' ? amount : -amount;
+}
+
+export function buildCapitalBaseContributionSql(
+  transactionAlias: string,
+  scope: CapitalBaseScope
+): string {
+  const positiveTypes = buildScopedTypes('credit', scope);
+  const negativeTypes = buildScopedTypes('debit', scope);
+  const reversalAmountExpression = buildReversalAmountSql(transactionAlias);
+  const depositContributionCondition = buildDepositContributionSql(
+    transactionAlias,
+    scope
+  );
+
+  const cases: string[] = [];
+
+  if (positiveTypes.length > 0) {
+    cases.push(`
+      WHEN ${transactionAlias}."type" IN (${positiveTypes
+        .map(quoteSqlLiteral)
+        .join(', ')})
+        THEN ABS(${transactionAlias}."amount"::numeric)
+    `);
+  }
+
+  if (negativeTypes.length > 0) {
+    cases.push(`
+      WHEN ${transactionAlias}."type" IN (${negativeTypes
+        .map(quoteSqlLiteral)
+        .join(', ')})
+        THEN -(${reversalAmountExpression})
+    `);
+  }
+
+  if (depositContributionCondition) {
+    cases.push(`
+      WHEN ${depositContributionCondition}
+        THEN ABS(${transactionAlias}."amount"::numeric)
+    `);
+  }
+
+  return `
+    CASE
+      ${cases.join('\n')}
+      ELSE 0::numeric
+    END
+  `;
+}
+
+function buildDepositContributionSql(
+  transactionAlias: string,
+  scope: CapitalBaseScope
+): string | null {
+  if (scope === 'team') {
+    if (DEFAULT_DEPOSIT_CLASSIFICATION.teamCapitalBaseEffect !== 'credit') {
+      return null;
+    }
+  } else if (
+    DEFAULT_DEPOSIT_CLASSIFICATION.walletCapitalBaseEffect !== 'credit'
+  ) {
+    return null;
+  }
+
+  const exclusionClauses = DEPOSIT_DESCRIPTION_RULES.filter(
+    (rule) =>
+      (scope === 'wallet'
+        ? rule.classification.walletCapitalBaseEffect
+        : rule.classification.teamCapitalBaseEffect) === 'none'
+  ).map((rule) => `NOT (${rule.matchesSql(transactionAlias)})`);
+
+  const exclusionCondition =
+    exclusionClauses.length > 0 ? exclusionClauses.join(' AND ') : 'TRUE';
+
+  return `
+    ${transactionAlias}."type" = 'deposit'
+    AND ${transactionAlias}."amount"::numeric > 0
+    AND (
+      ${transactionAlias}."description" IS NULL
+      OR (${exclusionCondition})
+    )
+  `;
+}
+
+function buildReversalAmountSql(transactionAlias: string): string {
+  return `
+    CASE
+      WHEN ${transactionAlias}."description" IS NOT NULL
+        AND LEFT(${transactionAlias}."description", 1) = '{'
+      THEN COALESCE(
+        NULLIF(
+          (${transactionAlias}."description"::jsonb ->> 'balanceUnitsRequested'),
+          ''
+        )::numeric,
+        ABS(${transactionAlias}."amount"::numeric)
+      )
+      ELSE ABS(${transactionAlias}."amount"::numeric)
+    END
+  `;
+}
+
+function extractRequestedBalanceUnits(
+  description: string | null
+): number | null {
+  if (!description || !description.startsWith('{')) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(description) as {
+      balanceUnitsRequested?: unknown;
+    };
+    const requested = parsed.balanceUnitsRequested;
+
+    if (typeof requested === 'number' && Number.isFinite(requested)) {
+      return Math.abs(requested);
+    }
+
+    if (typeof requested === 'string') {
+      const numericValue = Number(requested);
+      if (Number.isFinite(numericValue)) {
+        return Math.abs(numericValue);
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}

--- a/packages/db/src/balance-transaction-classification.ts
+++ b/packages/db/src/balance-transaction-classification.ts
@@ -321,6 +321,10 @@ export function classifyBalanceTransaction(
 export function extractCapitalBaseAmount(
   transaction: ClassifiedBalanceTransactionInput
 ): number {
+  if (transaction.type === 'deposit' && Number(transaction.amount ?? 0) <= 0) {
+    return 0;
+  }
+
   const classification = classifyBalanceTransaction(transaction);
   const fallbackAmount = Math.abs(Number(transaction.amount ?? 0));
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -47,6 +47,7 @@ import {
   getStorageMode,
 } from './db';
 
+export * from './balance-transaction-classification';
 /**
  * Re-export unique relation types from model-types.
  *

--- a/packages/testing/unit/balance-transaction-classification.test.ts
+++ b/packages/testing/unit/balance-transaction-classification.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  AGENT_EVM_REGISTRATION_REFUND_BALANCE_DESCRIPTION,
+  buildDailyLoginRewardBalanceDescription,
+  classifyBalanceTransaction,
+  getCapitalBaseContributionAmount,
+  WELCOME_BONUS_BALANCE_DESCRIPTION,
+} from '../../db/src/balance-transaction-classification';
+
+describe('balance transaction capital-base classification', () => {
+  it('includes external funding in both wallet and team capital base', () => {
+    const transaction = {
+      type: 'stripe_purchase',
+      amount: '5000',
+      description: 'card top-up',
+    };
+
+    const classification = classifyBalanceTransaction(transaction);
+
+    expect(classification.capitalKind).toBe('external_funding');
+    expect(classification.isExternalCapitalInflow).toBe(true);
+    expect(classification.descriptionDriven).toBe(false);
+    expect(getCapitalBaseContributionAmount(transaction, 'wallet')).toBe(5000);
+    expect(getCapitalBaseContributionAmount(transaction, 'team')).toBe(5000);
+  });
+
+  it('counts owner funding for wallet scope but excludes it from team scope', () => {
+    const transaction = {
+      type: 'owner_deposit',
+      amount: '1250',
+      description: 'Deposit from owner',
+    };
+
+    const classification = classifyBalanceTransaction(transaction);
+
+    expect(classification.capitalKind).toBe('internal_transfer');
+    expect(classification.isInternalTransfer).toBe(true);
+    expect(getCapitalBaseContributionAmount(transaction, 'wallet')).toBe(1250);
+    expect(getCapitalBaseContributionAmount(transaction, 'team')).toBe(0);
+  });
+
+  it('deducts reversals using requested balance units when present', () => {
+    const transaction = {
+      type: 'stripe_refund',
+      amount: '-2000',
+      description: JSON.stringify({
+        amountUSD: 50,
+        balanceUnitsRequested: 5000,
+        balanceUnitsDeducted: 2000,
+      }),
+    };
+
+    const classification = classifyBalanceTransaction(transaction);
+
+    expect(classification.capitalKind).toBe('capital_reversal');
+    expect(classification.isReversal).toBe(true);
+    expect(getCapitalBaseContributionAmount(transaction, 'wallet')).toBe(-5000);
+    expect(getCapitalBaseContributionAmount(transaction, 'team')).toBe(-5000);
+  });
+
+  it('restores capital explicitly when a dispute is won', () => {
+    const transaction = {
+      type: 'stripe_dispute_won',
+      amount: '5000',
+      description: JSON.stringify({
+        amountUSD: 50,
+        balanceUnitsCredited: 5000,
+      }),
+    };
+
+    const classification = classifyBalanceTransaction(transaction);
+
+    expect(classification.capitalKind).toBe('capital_restoration');
+    expect(classification.isCapitalRestoration).toBe(true);
+    expect(getCapitalBaseContributionAmount(transaction, 'wallet')).toBe(5000);
+    expect(getCapitalBaseContributionAmount(transaction, 'team')).toBe(5000);
+  });
+
+  it('excludes non-capital deposit activity through canonical deposit reasons', () => {
+    const dailyLoginReward = {
+      type: 'deposit',
+      amount: '150',
+      description: buildDailyLoginRewardBalanceDescription(7, 50),
+    };
+    const agentRefund = {
+      type: 'deposit',
+      amount: '1000',
+      description: AGENT_EVM_REGISTRATION_REFUND_BALANCE_DESCRIPTION,
+    };
+
+    expect(classifyBalanceTransaction(dailyLoginReward).depositReason).toBe(
+      'daily_login_reward'
+    );
+    expect(getCapitalBaseContributionAmount(dailyLoginReward, 'wallet')).toBe(
+      0
+    );
+    expect(getCapitalBaseContributionAmount(dailyLoginReward, 'team')).toBe(0);
+
+    expect(classifyBalanceTransaction(agentRefund).depositReason).toBe(
+      'agent_registration_refund'
+    );
+    expect(getCapitalBaseContributionAmount(agentRefund, 'wallet')).toBe(0);
+    expect(getCapitalBaseContributionAmount(agentRefund, 'team')).toBe(0);
+  });
+
+  it('defaults legitimate wallet deposit funding to capital base without brittle text matching', () => {
+    const welcomeBonusDeposit = {
+      type: 'deposit',
+      amount: '1000',
+      description: WELCOME_BONUS_BALANCE_DESCRIPTION,
+    };
+
+    const classification = classifyBalanceTransaction(welcomeBonusDeposit);
+
+    expect(classification.depositReason).toBe('default_wallet_funding');
+    expect(classification.descriptionDriven).toBe(true);
+    expect(
+      getCapitalBaseContributionAmount(welcomeBonusDeposit, 'wallet')
+    ).toBe(1000);
+    expect(getCapitalBaseContributionAmount(welcomeBonusDeposit, 'team')).toBe(
+      1000
+    );
+  });
+});

--- a/packages/testing/unit/balance-transaction-classification.test.ts
+++ b/packages/testing/unit/balance-transaction-classification.test.ts
@@ -121,4 +121,19 @@ describe('balance transaction capital-base classification', () => {
       1000
     );
   });
+
+  it('ignores non-positive legacy deposits to match the SQL capital-base path', () => {
+    const legacyNegativeDeposit = {
+      type: 'deposit',
+      amount: '-250',
+      description: 'legacy correction row',
+    };
+
+    expect(
+      getCapitalBaseContributionAmount(legacyNegativeDeposit, 'wallet')
+    ).toBe(0);
+    expect(getCapitalBaseContributionAmount(legacyNegativeDeposit, 'team')).toBe(
+      0
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- introduce a canonical balance-transaction capital-base classification helper in `packages/db`
- refactor `TradingPerformanceService` to consume centralized wallet/team capital-base rules instead of inline heuristics
- reuse canonical balance description constants for daily login and agent registration refunds so capital-base exclusions are explicit and shared
- add focused unit coverage for classification behavior and trading performance floor behavior

## Notes
- wallet/team capital-base treatment is now explicit per balance transaction type
- the only remaining description-based logic is the intentionally bounded compatibility handling for legacy `deposit` rows, now centralized in one helper
- unrelated modified files remain in the local working tree due to prior formatting churn and are intentionally not part of this PR

## Validation
- `bun test packages/testing/unit/balance-transaction-classification.test.ts packages/testing/unit/trading-performance-service.test.ts`
