### PR TITLE
fix: resolve ethereum identity registry in production builds

### DIFF
--- a/packages/contracts/src/deployment/addresses.ts
+++ b/packages/contracts/src/deployment/addresses.ts
@@ -1,8 +1,12 @@
-import { getCurrentChainId, getCurrentRpcUrl } from '@babylon/shared';
+import { getCurrentChainId, getCurrentRpcUrl, PUBLIC_CONFIG } from '@babylon/shared';
 import type { Address } from 'viem';
 import baseDeployment from '../../deployments/base';
 import baseSepoliaDeployment from '../../deployments/base-sepolia';
 import localDeployment from '../../deployments/local';
+
+const ethereumDeployment = {
+  contracts: PUBLIC_CONFIG.networks.ethereum.contracts,
+};
 
 type RawContracts = Partial<Record<string, string>>;
 type RawDeployment = {
@@ -64,6 +68,9 @@ export function getContractAddresses(): DeployedContracts {
 
   if (chainId === 31337) {
     return resolveContracts(localDeployment, chainId, 'localnet');
+  }
+  if (chainId === 1) {
+    return resolveContracts(ethereumDeployment, chainId, 'ethereum');
   }
   if (chainId === 84532) {
     return resolveContracts(baseSepoliaDeployment, chainId, 'base-sepolia');


### PR DESCRIPTION
Summary:
- fix production build resolution for identity registry addresses when NEXT_PUBLIC_CHAIN_ID=1
- use Ethereum mainnet contract addresses for chain id 1 instead of falling through to Base mainnet

Why:
- the latest production deployment fails during page data collection with: base identity registry address is not configured
- root cause is packages/contracts/src/deployment/addresses.ts routing chainId 1 to the Base deployment config, which is empty
- this patch makes chainId 1 resolve against the Ethereum config already present in the shared public config

Scope:
- packages/contracts/src/deployment/addresses.ts only
- no env changes or DB changes required