### PR TITLE
fix: strip stale Next.js sourcemap references

### DIFF
--- a/scripts/prune-next-server-sourcemaps.ts
+++ b/scripts/prune-next-server-sourcemaps.ts
@@ -1,6 +1,11 @@
 import { readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+const SOURCE_MAP_COMMENT_PATTERNS = [
+  /\n\/\/# sourceMappingURL=.*?(?=\n|$)/g,
+  /\n\/\*# sourceMappingURL=.*?\*\/(?=\n|$)/g,
+];
+
 async function walk(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
   const files = await Promise.all(
@@ -30,11 +35,17 @@ async function main() {
 
   const allFiles = await walk(nextDir);
   const nftFiles = allFiles.filter((file) => file.endsWith('.nft.json'));
+  const serverRuntimeFiles = allFiles.filter(
+    (file) =>
+      file.startsWith(serverDir) &&
+      (file.endsWith('.js') || file.endsWith('.mjs') || file.endsWith('.cjs'))
+  );
   const serverMapFiles = allFiles.filter(
     (file) => file.startsWith(serverDir) && file.endsWith('.map')
   );
 
   let removedManifestEntries = 0;
+  let strippedSourceMapComments = 0;
 
   for (const nftFile of nftFiles) {
     const raw = await readFile(nftFile, 'utf8');
@@ -51,6 +62,20 @@ async function main() {
     }
   }
 
+  for (const runtimeFile of serverRuntimeFiles) {
+    const raw = await readFile(runtimeFile, 'utf8');
+    let next = raw;
+
+    for (const pattern of SOURCE_MAP_COMMENT_PATTERNS) {
+      next = next.replace(pattern, '');
+    }
+
+    if (next !== raw) {
+      strippedSourceMapComments += 1;
+      await writeFile(runtimeFile, next, 'utf8');
+    }
+  }
+
   let deletedMapFiles = 0;
   for (const mapFile of serverMapFiles) {
     await rm(mapFile, { force: true });
@@ -58,7 +83,7 @@ async function main() {
   }
 
   console.log(
-    `[prune-next-server-sourcemaps] updated ${nftFiles.length} nft files, removed ${removedManifestEntries} sourcemap references, deleted ${deletedMapFiles} server sourcemaps`
+    `[prune-next-server-sourcemaps] updated ${nftFiles.length} nft files, stripped ${strippedSourceMapComments} runtime sourcemap comments, removed ${removedManifestEntries} nft sourcemap references, deleted ${deletedMapFiles} server sourcemaps`
   );
 }
 


### PR DESCRIPTION
## Summary
- strip trailing server-side sourceMappingURL comments before deleting Next.js sourcemaps
- keep .nft.json manifests free of deleted .map entries
- preserve the Vercel post-build prune step without leaving broken sourcemap references

## Verification
- bun run build
