### PR TITLE
fix: preserve pruned Next.js sourcemap paths

### DIFF
--- a/scripts/prune-next-server-sourcemaps.ts
+++ b/scripts/prune-next-server-sourcemaps.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const SOURCE_MAP_COMMENT_PATTERNS = [
@@ -76,14 +76,14 @@ async function main() {
     }
   }
 
-  let deletedMapFiles = 0;
+  let emptiedMapFiles = 0;
   for (const mapFile of serverMapFiles) {
-    await rm(mapFile, { force: true });
-    deletedMapFiles += 1;
+    await writeFile(mapFile, '', 'utf8');
+    emptiedMapFiles += 1;
   }
 
   console.log(
-    `[prune-next-server-sourcemaps] updated ${nftFiles.length} nft files, stripped ${strippedSourceMapComments} runtime sourcemap comments, removed ${removedManifestEntries} nft sourcemap references, deleted ${deletedMapFiles} server sourcemaps`
+    `[prune-next-server-sourcemaps] updated ${nftFiles.length} nft files, stripped ${strippedSourceMapComments} runtime sourcemap comments, removed ${removedManifestEntries} nft sourcemap references, emptied ${emptiedMapFiles} server sourcemaps`
   );
 }
 


### PR DESCRIPTION
## Summary
- replace deleted server sourcemaps with empty placeholder files during the prune step
- keep stripping server sourceMappingURL comments and removing .map entries from nft manifests
- avoid Vercel ENOENT failures when stale build traces still lstat server sourcemap paths

## Verification
- bun run build

## Context
- production deployment dpl_BeSHs66vdT7SREgWkg7TTNyhnyxM still fails after build completion with ENOENT on apps/web/.next/server/chunks/*.js.map
