### PR TITLE
fix: resolve prod 500s from cached bigint serialization

### DIFF
--- a/packages/api/src/cache/cache-service.ts
+++ b/packages/api/src/cache/cache-service.ts
@@ -16,6 +16,37 @@
 import { logger } from '@babylon/shared';
 import { getRedisClient, isRedisAvailable } from '../redis';
 
+const CACHE_BIGINT_MARKER = '__babylonCacheBigInt__';
+
+function cacheJsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === 'bigint') {
+    return { [CACHE_BIGINT_MARKER]: value.toString() };
+  }
+  return value;
+}
+
+function cacheJsonReviver(_key: string, value: unknown): unknown {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    CACHE_BIGINT_MARKER in value
+  ) {
+    const markerValue = (value as Record<string, unknown>)[CACHE_BIGINT_MARKER];
+    if (typeof markerValue === 'string') {
+      return BigInt(markerValue);
+    }
+  }
+  return value;
+}
+
+export function serializeCacheValue(value: unknown): string {
+  return JSON.stringify(value, cacheJsonReplacer);
+}
+
+export function parseCacheValue<T>(value: string): T {
+  return JSON.parse(value, cacheJsonReviver) as T;
+}
+
 /**
  * Cache options
  *
@@ -271,7 +302,7 @@ export async function getCache<T>(
       }
 
       logger.debug('Cache hit (Redis)', { key: fullKey }, 'CacheService');
-      return JSON.parse(cached) as T;
+      return parseCacheValue<T>(cached);
     }
 
     logger.debug('Cache miss (Redis)', { key: fullKey }, 'CacheService');
@@ -320,7 +351,7 @@ export async function setCache<T>(
   const fullKey = options.namespace ? `${options.namespace}:${key}` : key;
   const ttl = options.ttl || 300;
 
-  const serialized = JSON.stringify(value);
+  const serialized = serializeCacheValue(value);
   const client = getRedisClient();
 
   if (client) {
@@ -480,7 +511,7 @@ export async function getCacheOrFetch<T>(
       valueResult.trim() !== ''
     ) {
       try {
-        cached = JSON.parse(valueResult) as T;
+        cached = parseCacheValue<T>(valueResult);
         remainingTtl = ttlResult > 0 ? ttlResult : 0;
       } catch (parseError) {
         // Malformed cache entry - treat as cache miss and remove bad key
@@ -622,7 +653,7 @@ export async function getCacheBatch<T>(
           value.trim() !== ''
         ) {
           try {
-            result.set(originalKey, JSON.parse(value) as T);
+            result.set(originalKey, parseCacheValue<T>(value));
           } catch {
             logger.warn(
               'Failed to parse cached value',
@@ -705,7 +736,7 @@ export async function setCacheBatch<T>(
 
       for (const [key, value] of entriesArray) {
         const fullKey = options.namespace ? `${options.namespace}:${key}` : key;
-        const serialized = JSON.stringify(value);
+        const serialized = serializeCacheValue(value);
         pipeline.set(fullKey, serialized, 'EX', ttl);
       }
 

--- a/packages/api/src/monitoring/monitored-cache.ts
+++ b/packages/api/src/monitoring/monitored-cache.ts
@@ -6,6 +6,7 @@
  * to be injected from the application layer.
  */
 
+import { serializeCacheValue } from '../cache/cache-service';
 import { performanceMonitor } from './performance-monitor';
 
 export interface CacheOptions {
@@ -50,7 +51,7 @@ export async function getMonitoredCache<T>(
   const hit = value !== null;
 
   // Estimate size (rough approximation)
-  const bytes = value ? JSON.stringify(value).length : 0;
+  const bytes = value ? serializeCacheValue(value).length : 0;
 
   performanceMonitor.recordCacheOperation('get', hit, latency, bytes);
 
@@ -72,7 +73,7 @@ export async function setMonitoredCache<T>(
   const latency = performance.now() - startTime;
 
   // Estimate size
-  const bytes = JSON.stringify(value).length;
+  const bytes = serializeCacheValue(value).length;
 
   performanceMonitor.recordCacheOperation('set', true, latency, bytes);
 }

--- a/packages/api/src/services/reputation-service.ts
+++ b/packages/api/src/services/reputation-service.ts
@@ -33,6 +33,7 @@ import {
   logger,
   POINTS,
   type PointsReason,
+  toISO,
 } from '@babylon/shared';
 import type {
   LeaderboardPosition,
@@ -1310,7 +1311,7 @@ export class ReputationService {
       reputationPoints: user.reputationPoints ?? 0,
       balance: Number(user.virtualBalance ?? 0),
       lifetimePnL: Number(user.lifetimePnL ?? 0),
-      createdAt: user.createdAt,
+      createdAt: new Date(user.createdAt),
       isAgent: user.isAgent,
       managedBy: user.managedBy,
       onChainRegistered: user.onChainRegistered,
@@ -1318,7 +1319,7 @@ export class ReputationService {
       rank: skip + index + 1,
     }));
 
-    const totalCount = countResult?.count ?? 0;
+    const totalCount = Number(countResult?.count ?? 0);
     return {
       users: usersWithRank,
       totalCount,
@@ -1401,14 +1402,14 @@ export class ReputationService {
       agentCount: team.agentCount ?? 0,
       balance: Number(team.balance ?? 0),
       lifetimePnL: Number(team.lifetimePnL ?? 0),
-      createdAt: team.createdAt,
+      createdAt: new Date(team.createdAt),
       isAgent: false,
       onChainRegistered: team.onChainRegistered,
       nftTokenId: team.nftTokenId,
       rank: skip + index + 1,
     }));
 
-    const totalCount = countResult?.count ?? 0;
+    const totalCount = Number(countResult?.count ?? 0);
     return {
       users: usersWithRank,
       totalCount,
@@ -1493,7 +1494,7 @@ export class ReputationService {
           )
         );
 
-      const rank = (higherCount?.count ?? 0) + 1;
+      const rank = Number(higherCount?.count ?? 0) + 1;
       return {
         rank,
         page: Math.ceil(rank / pageSize),
@@ -1505,7 +1506,7 @@ export class ReputationService {
           reputationPoints: effectiveUser.reputationPoints ?? 0,
           balance: Number(effectiveUser.virtualBalance ?? 0),
           lifetimePnL: Number(effectiveUser.lifetimePnL ?? 0),
-          createdAt: effectiveUser.createdAt,
+          createdAt: new Date(effectiveUser.createdAt),
           isAgent: effectiveUser.isAgent,
           managedBy: effectiveUser.managedBy,
           onChainRegistered: effectiveUser.onChainRegistered,
@@ -1549,8 +1550,8 @@ export class ReputationService {
             OR (
               (u."reputationPoints"::numeric + COALESCE(a."agentReputationPoints", 0)) = ${teamReputation}
               AND (
-                u."createdAt" < ${effectiveUser.createdAt.toISOString()}
-                OR (u."createdAt" = ${effectiveUser.createdAt.toISOString()} AND u."id" < ${effectiveUserId})
+                u."createdAt" < ${toISO(effectiveUser.createdAt)}
+                OR (u."createdAt" = ${toISO(effectiveUser.createdAt)} AND u."id" < ${effectiveUserId})
               )
             )
           )
@@ -1558,7 +1559,7 @@ export class ReputationService {
     `);
 
     const higherRows = higherResult as unknown as Array<{ count: number }>;
-    const rank = (higherRows[0]?.count ?? 0) + 1;
+    const rank = Number(higherRows[0]?.count ?? 0) + 1;
 
     const [agentCountResult] = await db
       .select({ count: count() })
@@ -1583,10 +1584,10 @@ export class ReputationService {
         teamReputationPoints: teamReputation,
         userReputationPoints: Number(effectiveUser.reputationPoints ?? 0),
         agentReputationPoints: Number(agentSum?.reputationTotal ?? 0),
-        agentCount: agentCountResult?.count ?? 0,
+        agentCount: Number(agentCountResult?.count ?? 0),
         balance: Number(effectiveUser.virtualBalance ?? 0),
         lifetimePnL: Number(effectiveUser.lifetimePnL ?? 0),
-        createdAt: effectiveUser.createdAt,
+        createdAt: new Date(effectiveUser.createdAt),
         isAgent: false,
         onChainRegistered: effectiveUser.onChainRegistered,
         nftTokenId: effectiveUser.nftTokenId,

--- a/packages/api/src/services/trading-leaderboard-service.ts
+++ b/packages/api/src/services/trading-leaderboard-service.ts
@@ -26,7 +26,7 @@ function mapWalletEntry(
     capitalBase: Number(row.capitalBase ?? 0),
     effectiveCapitalBase: Number(row.effectiveCapitalBase ?? 0),
     tradingReturn: Number(row.tradingReturn ?? 0),
-    createdAt: row.createdAt,
+    createdAt: new Date(row.createdAt),
     rank,
     isAgent: row.isAgent,
     managedBy: row.managedBy,
@@ -56,7 +56,7 @@ function mapTeamEntry(
     teamCapitalBase: Number(row.teamCapitalBase ?? 0),
     teamEffectiveCapitalBase: Number(row.teamEffectiveCapitalBase ?? 0),
     teamTradingReturn: Number(row.teamTradingReturn ?? 0),
-    createdAt: row.createdAt,
+    createdAt: new Date(row.createdAt),
     rank,
     isAgent: false,
     onChainRegistered: row.onChainRegistered,
@@ -81,7 +81,7 @@ export class TradingLeaderboardService {
       mapWalletEntry(row, skip + index + 1)
     );
 
-    const totalCount = countRows[0]?.count ?? 0;
+    const totalCount = Number(countRows[0]?.count ?? 0);
     return {
       users: usersWithRank,
       totalCount,
@@ -111,7 +111,7 @@ export class TradingLeaderboardService {
       mapTeamEntry(row, skip + index + 1)
     );
 
-    const totalCount = countRows[0]?.count ?? 0;
+    const totalCount = Number(countRows[0]?.count ?? 0);
     return {
       users: usersWithRank,
       totalCount,

--- a/packages/api/src/services/trading-performance-service.ts
+++ b/packages/api/src/services/trading-performance-service.ts
@@ -1,4 +1,5 @@
 import { buildCapitalBaseContributionSql, db, sql } from '@babylon/db';
+import { toISO } from '@babylon/shared';
 
 export const TRADING_RETURN_CAPITAL_FLOOR = 1000;
 
@@ -26,7 +27,7 @@ export interface WalletTradingPerformanceRow {
   capitalBase: string;
   effectiveCapitalBase: string;
   tradingReturn: string;
-  createdAt: Date;
+  createdAt: Date | string;
   onChainRegistered: boolean;
   nftTokenId: number | null;
   isAgent: boolean;
@@ -46,7 +47,7 @@ export interface TeamTradingPerformanceRow {
   teamCapitalBase: string;
   teamEffectiveCapitalBase: string;
   teamTradingReturn: string;
-  createdAt: Date;
+  createdAt: Date | string;
   onChainRegistered: boolean;
   nftTokenId: number | null;
   agentCount: number;
@@ -193,9 +194,10 @@ export class TradingPerformanceService {
 
   static async countWalletsAbove(entry: {
     id: string;
-    createdAt: Date;
+    createdAt: Date | string;
     tradingReturn: string;
   }): Promise<number> {
+    const createdAtISO = toISO(entry.createdAt);
     const result = await db.execute(sql`
       WITH wallet_capital AS (${this.walletCapitalCte()}),
       wallet_rows AS (
@@ -220,9 +222,9 @@ export class TradingPerformanceService {
         OR (
           wr."tradingReturn" = ${entry.tradingReturn}
           AND (
-            wr."createdAt" < ${entry.createdAt.toISOString()}
+            wr."createdAt" < ${createdAtISO}
             OR (
-              wr."createdAt" = ${entry.createdAt.toISOString()}
+              wr."createdAt" = ${createdAtISO}
               AND wr."id" < ${entry.id}
             )
           )
@@ -330,9 +332,10 @@ export class TradingPerformanceService {
 
   static async countTeamsAbove(entry: {
     id: string;
-    createdAt: Date;
+    createdAt: Date | string;
     teamTradingReturn: string;
   }): Promise<number> {
+    const createdAtISO = toISO(entry.createdAt);
     const result = await db.execute(sql`
       WITH team_capital AS (${this.teamCapitalCte()}),
       team_agents AS (${this.teamAgentsCte()}),
@@ -361,9 +364,9 @@ export class TradingPerformanceService {
         OR (
           tr."teamTradingReturn" = ${entry.teamTradingReturn}
           AND (
-            tr."createdAt" < ${entry.createdAt.toISOString()}
+            tr."createdAt" < ${createdAtISO}
             OR (
-              tr."createdAt" = ${entry.createdAt.toISOString()}
+              tr."createdAt" = ${createdAtISO}
               AND tr."id" < ${entry.id}
             )
           )

--- a/packages/contracts/src/deployment/addresses.ts
+++ b/packages/contracts/src/deployment/addresses.ts
@@ -1,4 +1,8 @@
-import { getCurrentChainId, getCurrentRpcUrl, PUBLIC_CONFIG } from '@babylon/shared';
+import {
+  getCurrentChainId,
+  getCurrentRpcUrl,
+  PUBLIC_CONFIG,
+} from '@babylon/shared';
 import type { Address } from 'viem';
 import baseDeployment from '../../deployments/base';
 import baseSepoliaDeployment from '../../deployments/base-sepolia';

--- a/packages/testing/unit/cache-service-serialization.test.ts
+++ b/packages/testing/unit/cache-service-serialization.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  parseCacheValue,
+  serializeCacheValue,
+} from '../../api/src/cache/cache-service';
+
+describe('cache-service bigint serialization', () => {
+  test('round-trips nested bigint values through cache serialization', () => {
+    const payload = {
+      id: 'user-1',
+      registrationBlockNumber: 1234567890123456789n,
+      nested: {
+        registrationGasUsed: 21000n,
+      },
+      values: [1n, 2n, 3n],
+    };
+
+    const serialized = serializeCacheValue(payload);
+    const parsed = parseCacheValue<typeof payload>(serialized);
+
+    expect(parsed).toEqual(payload);
+    expect(typeof parsed.registrationBlockNumber).toBe('bigint');
+    expect(typeof parsed.nested.registrationGasUsed).toBe('bigint');
+    expect(typeof parsed.values[0]).toBe('bigint');
+  });
+
+  test('keeps ordinary JSON payloads unchanged', () => {
+    const payload = {
+      id: 'user-2',
+      createdAt: '2026-04-07T11:35:04.013Z',
+      points: 42,
+    };
+
+    const serialized = serializeCacheValue(payload);
+    const parsed = parseCacheValue<typeof payload>(serialized);
+
+    expect(parsed).toEqual(payload);
+  });
+});

--- a/packages/testing/unit/trading-performance-date-normalization.test.ts
+++ b/packages/testing/unit/trading-performance-date-normalization.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const mockExecute = mock(async () => [{ count: 0 }]);
+
+const actualDb = await import('@babylon/db');
+mock.module('@babylon/db', () => ({
+  ...actualDb,
+  buildCapitalBaseContributionSql: () => '0',
+  db: {
+    execute: mockExecute,
+  },
+}));
+
+const moduleUrl = new URL(
+  '../../api/src/services/trading-performance-service.ts',
+  import.meta.url
+);
+moduleUrl.searchParams.set('test', 'trading-performance-date-normalization');
+const { TradingPerformanceService } = await import(moduleUrl.href);
+
+describe('TradingPerformanceService date normalization', () => {
+  beforeEach(() => {
+    mockExecute.mockClear();
+    mockExecute.mockResolvedValue([{ count: 0 }]);
+  });
+
+  test('countWalletsAbove accepts cached ISO string dates', async () => {
+    await expect(
+      TradingPerformanceService.countWalletsAbove({
+        id: 'user-1',
+        createdAt: '2026-04-07T11:35:04.013Z',
+        tradingReturn: '0.42',
+      })
+    ).resolves.toBe(0);
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  test('countTeamsAbove accepts cached ISO string dates', async () => {
+    await expect(
+      TradingPerformanceService.countTeamsAbove({
+        id: 'team-1',
+        createdAt: '2026-04-07T11:35:04.013Z',
+        teamTradingReturn: '0.84',
+      })
+    ).resolves.toBe(0);
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- make cache serialization/deserialization bigint-safe so identifier/user caches stop throwing before responses are built
- normalize leaderboard date/count fields when rows come back from SQL/cache as strings
- add regression tests for cache bigint round-tripping and cached ISO date handling in leaderboard ranking

## Prod errors addressed
- /api/users/[userId]/profile
- /api/users/[userId]/balance
- /api/users/[userId]/portfolio-breakdown
- /api/markets/positions/[userId]
- /api/agents/team-dashboard
- /api/leaderboard
- /api/leaderboard/me
- /api/users/[userId]/pnl-history is expected to benefit too because it uses the same cached identifier lookup path

## Validation
- bun run check
- bun run typecheck
- bun run lint
- bun run test:unit
- bun test packages/testing/unit/cache-service-serialization.test.ts packages/testing/unit/trading-performance-date-normalization.test.ts
- bun test packages/testing/unit/leaderboard-route.test.ts packages/testing/unit/leaderboard-cache.test.ts
- bun test apps/web/src/app/api/agents/team-dashboard/route.test.ts

## Notes
- local bun run build reaches the Next.js page-data phase and then fails on an existing environment/config issue unrelated to this patch: base identity registry address is not configured while collecting /api/auth/twitter/scopes/callback
- Vercel prod logs before this patch showed the same Do not know how to serialize a BigInt error across balance, portfolio-breakdown, markets/positions, team-dashboard and leaderboard routes
