### PR TITLE
fix(perps): harden runtime pricing and depth calibration

### DIFF
--- a/packages/core/markets/perps/__tests__/microstructure.test.ts
+++ b/packages/core/markets/perps/__tests__/microstructure.test.ts
@@ -89,6 +89,20 @@ describe('getSyntheticPerpExecutionPrice', () => {
     expect(thin.askDepth).toBeLessThan(liquid.askDepth);
   });
 
+  it('caps quote depth for pathological OI and volume inputs', () => {
+    const quote = getSyntheticPerpQuoteState(
+      createMarket({
+        openInterest: 1e18,
+        volume24h: 1e18,
+      })
+    );
+
+    expect(quote.bidDepth).toBeLessThanOrEqual(580_000);
+    expect(quote.askDepth).toBeLessThanOrEqual(580_000);
+    expect(quote.bidDepth).toBeGreaterThan(0);
+    expect(quote.askDepth).toBeGreaterThan(0);
+  });
+
   it('exposes a stable quote state with bid below ask', () => {
     const quote = getSyntheticPerpQuoteState(createMarket());
 

--- a/packages/core/markets/perps/microstructure.ts
+++ b/packages/core/markets/perps/microstructure.ts
@@ -46,7 +46,18 @@ function safeRatio(numerator: number, denominator: number): number {
 
 function getBaseDepth(market: PerpMarketRecord): number {
   const minOrderSize = market.minOrderSize ?? 10;
-  const baseDepth = 500 + market.openInterest * 0.08 + market.volume24h * 0.02;
+  // Keep the default depth model on normal markets, but cap extreme OI/volume
+  // contributions so corrupted or highly skewed snapshots do not make a market
+  // effectively impossible to move.
+  const openInterestContribution = Math.min(
+    Math.max(market.openInterest, 0) * 0.08,
+    250_000
+  );
+  const volumeContribution = Math.min(
+    Math.max(market.volume24h, 0) * 0.02,
+    150_000
+  );
+  const baseDepth = 500 + openInterestContribution + volumeContribution;
   return Math.max(minOrderSize * 10, baseDepth);
 }
 

--- a/packages/db/src/database-service.ts
+++ b/packages/db/src/database-service.ts
@@ -64,6 +64,12 @@ export interface FeedPost {
  * Singleton pattern ensures single instance across the application.
  */
 class DatabaseService {
+  private getPositivePriceOrNull(value: number | null): number | null {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? value
+      : null;
+  }
+
   /**
    * Direct access to the database client for custom queries.
    */
@@ -652,6 +658,9 @@ class DatabaseService {
     id: string,
     currentPrice: number | null
   ): Promise<OrganizationStateRow> {
+    const normalizedCurrentPrice = this.getPositivePriceOrNull(currentPrice);
+    const normalizedBasePrice = normalizedCurrentPrice ?? 100;
+
     const existing = await db
       .select({ id: organizationState.id })
       .from(organizationState)
@@ -662,7 +671,7 @@ class DatabaseService {
       const updated = await db
         .update(organizationState)
         .set({
-          currentPrice,
+          currentPrice: normalizedCurrentPrice,
           updatedAt: new Date(),
         })
         .where(eq(organizationState.id, id))
@@ -674,8 +683,8 @@ class DatabaseService {
       .insert(organizationState)
       .values({
         id,
-        currentPrice,
-        basePrice: currentPrice ?? 100,
+        currentPrice: normalizedCurrentPrice,
+        basePrice: normalizedBasePrice,
         updatedAt: new Date(),
       })
       .returning();

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -2277,18 +2277,26 @@ export async function simulateMarketVolatility(options?: {
     }> = [];
 
     for (const market of markets) {
-      const currentPrice = Number(market.currentPrice);
+      const currentPriceCandidate = Number(market.currentPrice);
       const basePrice = basePriceByOrgId.get(market.organizationId);
+      const organization = StaticDataRegistry.getOrganization(
+        market.organizationId
+      );
       const initialPrice =
         typeof basePrice === 'number' &&
         Number.isFinite(basePrice) &&
         basePrice > 0
           ? basePrice
-          : currentPrice;
+          : typeof organization?.initialPrice === 'number' &&
+              Number.isFinite(organization.initialPrice) &&
+              organization.initialPrice > 0
+            ? organization.initialPrice
+            : 100;
+      const currentPrice =
+        Number.isFinite(currentPriceCandidate) && currentPriceCandidate > 0
+          ? currentPriceCandidate
+          : initialPrice;
 
-      const organization = StaticDataRegistry.getOrganization(
-        market.organizationId
-      );
       const profile = buildMarketSimulationProfile({
         organizationId: market.organizationId,
         ticker: market.ticker,
@@ -2316,7 +2324,11 @@ export async function simulateMarketVolatility(options?: {
 
       marketVolatilityState.set(market.ticker, nextState);
 
-      if (Math.abs(adjustedPrice - currentPrice) / currentPrice > 0.0001) {
+      if (
+        Math.abs(adjustedPrice - currentPrice) /
+          Math.max(Math.abs(currentPrice), 1) >
+        0.0001
+      ) {
         priceUpdates.push({
           organizationId: market.organizationId,
           ticker: market.ticker,

--- a/packages/engine/src/services/game-bootstrap-service.ts
+++ b/packages/engine/src/services/game-bootstrap-service.ts
@@ -61,6 +61,43 @@ export class GameBootstrapService {
   private static BOOTSTRAP_COOLDOWN_MS = 60000;
   private static isBootstrapping = false;
 
+  private static getFirstPositivePrice(
+    ...candidates: Array<number | null | undefined>
+  ): number | null {
+    for (const candidate of candidates) {
+      if (
+        typeof candidate === 'number' &&
+        Number.isFinite(candidate) &&
+        candidate > 0
+      ) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  private static async resolveCanonicalOrganizationSeedPrice(org: {
+    id: string;
+    initialPrice: number | null;
+  }): Promise<number> {
+    let realPrice: number | null = null;
+    try {
+      const { realPriceService } = await import('./real-price-service');
+      const candidate = realPriceService.getBasePriceForOrg(org.id);
+      if (
+        typeof candidate === 'number' &&
+        Number.isFinite(candidate) &&
+        candidate > 0
+      ) {
+        realPrice = candidate;
+      }
+    } catch {
+      // Real price service not available — use static price fallback.
+    }
+
+    return this.getFirstPositivePrice(realPrice, org.initialPrice) ?? 100;
+  }
+
   static async bootstrapIfNeeded(): Promise<GameBootstrapResult | null> {
     const now = Date.now();
 
@@ -298,22 +335,13 @@ export class GameBootstrapService {
     name: string;
     initialPrice: number | null;
   }): Promise<void> {
-    // Try real-world price first, fall back to static initialPrice
-    let effectivePrice = org.initialPrice;
-    try {
-      const { realPriceService } = await import('./real-price-service');
-      const realPrice = realPriceService.getBasePriceForOrg(org.id);
-      if (realPrice != null) {
-        effectivePrice = realPrice;
-      }
-    } catch {
-      // Real price service not available — use static price
-    }
+    const effectivePrice =
+      await this.resolveCanonicalOrganizationSeedPrice(org);
 
     await db.insert(organizationState).values({
       id: org.id,
       currentPrice: effectivePrice,
-      basePrice: effectivePrice ?? 100.0,
+      basePrice: effectivePrice,
       updatedAt: new Date(),
     });
 
@@ -333,6 +361,7 @@ export class GameBootstrapService {
       .select({
         id: organizationState.id,
         currentPrice: organizationState.currentPrice,
+        basePrice: organizationState.basePrice,
       })
       .from(organizationState)
       .where(eq(organizationState.id, org.id))
@@ -346,8 +375,45 @@ export class GameBootstrapService {
     const existingState = existing[0];
     if (!existingState) return { created: false, updated: false };
 
-    // Organization state only contains currentPrice - no update needed for static data
-    // Price updates happen via the normal game tick flow
+    const currentPrice =
+      typeof existingState.currentPrice === 'number'
+        ? existingState.currentPrice
+        : Number(existingState.currentPrice);
+    const basePrice =
+      typeof existingState.basePrice === 'number'
+        ? existingState.basePrice
+        : Number(existingState.basePrice);
+
+    const hasInvalidCurrentPrice =
+      !Number.isFinite(currentPrice) || currentPrice <= 0;
+    const hasInvalidBasePrice = !Number.isFinite(basePrice) || basePrice <= 0;
+
+    if (hasInvalidCurrentPrice || hasInvalidBasePrice) {
+      const canonicalPrice =
+        await this.resolveCanonicalOrganizationSeedPrice(org);
+      await db
+        .update(organizationState)
+        .set({
+          currentPrice: hasInvalidCurrentPrice ? canonicalPrice : currentPrice,
+          basePrice: hasInvalidBasePrice ? canonicalPrice : basePrice,
+          updatedAt: new Date(),
+        })
+        .where(eq(organizationState.id, org.id));
+
+      logger.warn(
+        `Repaired invalid organization state for ${org.name}`,
+        {
+          orgId: org.id,
+          previousCurrentPrice: existingState.currentPrice,
+          previousBasePrice: existingState.basePrice,
+          canonicalPrice,
+        },
+        'GameBootstrapService'
+      );
+
+      return { created: false, updated: true };
+    }
+
     return { created: false, updated: false };
   }
 
@@ -583,6 +649,7 @@ export class GameBootstrapService {
    */
   private static async ensurePerpMarketSnapshots(): Promise<number> {
     let created = 0;
+    let repaired = 0;
 
     // Get all organizations with tickers (these are tradeable as perps)
     const staticOrgs = StaticDataRegistry.getAllOrganizations();
@@ -590,15 +657,34 @@ export class GameBootstrapService {
 
     // Get existing perp market snapshots
     const existingSnapshots = await db
-      .select({ ticker: perpMarketSnapshots.ticker })
+      .select({
+        ticker: perpMarketSnapshots.ticker,
+        currentPrice: perpMarketSnapshots.currentPrice,
+        price24hAgo: perpMarketSnapshots.price24hAgo,
+        high24h: perpMarketSnapshots.high24h,
+        low24h: perpMarketSnapshots.low24h,
+        bidPrice: perpMarketSnapshots.bidPrice,
+        askPrice: perpMarketSnapshots.askPrice,
+        spreadBps: perpMarketSnapshots.spreadBps,
+        bidDepth: perpMarketSnapshots.bidDepth,
+        askDepth: perpMarketSnapshots.askDepth,
+        markPrice: perpMarketSnapshots.markPrice,
+        indexPrice: perpMarketSnapshots.indexPrice,
+      })
       .from(perpMarketSnapshots);
-    const existingTickers = new Set(existingSnapshots.map((s) => s.ticker));
+    const existingByTicker = new Map(
+      existingSnapshots.map((snapshot) => [snapshot.ticker, snapshot])
+    );
 
     // Get organization states for current prices
-    const orgStates = await db.select().from(organizationState);
-    const priceMap = new Map<string, number | null>(
-      orgStates.map((s) => [s.id, s.currentPrice])
-    );
+    const orgStates = await db
+      .select({
+        id: organizationState.id,
+        currentPrice: organizationState.currentPrice,
+        basePrice: organizationState.basePrice,
+      })
+      .from(organizationState);
+    const stateByOrgId = new Map(orgStates.map((state) => [state.id, state]));
 
     const now = new Date();
     const nextFundingTime = new Date(
@@ -606,12 +692,18 @@ export class GameBootstrapService {
     ).toISOString();
 
     for (const org of tradeableOrgs) {
-      if (!org.ticker || existingTickers.has(org.ticker)) {
+      if (!org.ticker) {
         continue;
       }
 
-      // Use current price from state, or initial price, or default
-      const currentPrice = priceMap.get(org.id) ?? org.initialPrice ?? 100;
+      const state = stateByOrgId.get(org.id);
+      const currentPrice =
+        this.getFirstPositivePrice(
+          state?.currentPrice,
+          state?.basePrice,
+          org.initialPrice
+        ) ?? (await this.resolveCanonicalOrganizationSeedPrice(org));
+      const existingSnapshot = existingByTicker.get(org.ticker);
       const initialQuote = getSyntheticPerpQuoteState({
         ticker: org.ticker,
         organizationId: org.id,
@@ -636,53 +728,123 @@ export class GameBootstrapService {
         indexPrice: currentPrice,
       });
 
-      await db.insert(perpMarketSnapshots).values({
-        ticker: org.ticker,
-        organizationId: org.id,
-        name: org.name,
-        currentPrice,
-        price24hAgo: currentPrice,
-        price24hAgoUpdatedAt: now,
-        metrics24hResetAt: now,
-        change24h: 0,
-        changePercent24h: 0,
-        high24h: currentPrice,
-        low24h: currentPrice,
-        volume24h: 0,
-        openInterest: 0,
-        fundingRate: {
+      if (!existingSnapshot) {
+        await db.insert(perpMarketSnapshots).values({
           ticker: org.ticker,
-          rate: 0.01, // 1% APR base
-          nextFundingTime,
-          predictedRate: 0.01,
-        },
-        maxLeverage: 100,
-        minOrderSize: 10,
-        bidPrice: initialQuote.bidPrice,
-        askPrice: initialQuote.askPrice,
-        spreadBps: initialQuote.spreadBps,
-        bidDepth: initialQuote.bidDepth,
-        askDepth: initialQuote.askDepth,
-        liquidityRegime: initialQuote.liquidityRegime,
-        quoteUpdatedAt: now,
-        markPrice: currentPrice,
-        indexPrice: currentPrice,
-        createdAt: now,
-        updatedAt: now,
-      });
+          organizationId: org.id,
+          name: org.name,
+          currentPrice,
+          price24hAgo: currentPrice,
+          price24hAgoUpdatedAt: now,
+          metrics24hResetAt: now,
+          change24h: 0,
+          changePercent24h: 0,
+          high24h: currentPrice,
+          low24h: currentPrice,
+          volume24h: 0,
+          openInterest: 0,
+          fundingRate: {
+            ticker: org.ticker,
+            rate: 0.01, // 1% APR base
+            nextFundingTime,
+            predictedRate: 0.01,
+          },
+          maxLeverage: 100,
+          minOrderSize: 10,
+          bidPrice: initialQuote.bidPrice,
+          askPrice: initialQuote.askPrice,
+          spreadBps: initialQuote.spreadBps,
+          bidDepth: initialQuote.bidDepth,
+          askDepth: initialQuote.askDepth,
+          liquidityRegime: initialQuote.liquidityRegime,
+          quoteUpdatedAt: now,
+          markPrice: currentPrice,
+          indexPrice: currentPrice,
+          createdAt: now,
+          updatedAt: now,
+        });
 
-      created++;
-      logger.debug(
-        `Created perp market snapshot for ${org.ticker} (${org.name})`,
-        { ticker: org.ticker, price: currentPrice },
-        'GameBootstrapService'
-      );
+        created++;
+        logger.debug(
+          `Created perp market snapshot for ${org.ticker} (${org.name})`,
+          { ticker: org.ticker, price: currentPrice },
+          'GameBootstrapService'
+        );
+        continue;
+      }
+
+      const hasInvalidSnapshotPrice =
+        !Number.isFinite(Number(existingSnapshot.currentPrice)) ||
+        Number(existingSnapshot.currentPrice) <= 0;
+      const hasInvalidQuoteState =
+        !Number.isFinite(Number(existingSnapshot.bidPrice)) ||
+        !Number.isFinite(Number(existingSnapshot.askPrice)) ||
+        !Number.isFinite(Number(existingSnapshot.spreadBps)) ||
+        !Number.isFinite(Number(existingSnapshot.bidDepth)) ||
+        !Number.isFinite(Number(existingSnapshot.askDepth)) ||
+        Number(existingSnapshot.bidPrice) <= 0 ||
+        Number(existingSnapshot.askPrice) < Number(existingSnapshot.bidPrice) ||
+        Number(existingSnapshot.bidDepth) <= 0 ||
+        Number(existingSnapshot.askDepth) <= 0;
+      const hasInvalidReferenceFields =
+        !Number.isFinite(Number(existingSnapshot.price24hAgo)) ||
+        Number(existingSnapshot.price24hAgo) <= 0 ||
+        !Number.isFinite(Number(existingSnapshot.high24h)) ||
+        Number(existingSnapshot.high24h) <= 0 ||
+        !Number.isFinite(Number(existingSnapshot.low24h)) ||
+        Number(existingSnapshot.low24h) <= 0 ||
+        !Number.isFinite(Number(existingSnapshot.markPrice)) ||
+        Number(existingSnapshot.markPrice) <= 0 ||
+        !Number.isFinite(Number(existingSnapshot.indexPrice)) ||
+        Number(existingSnapshot.indexPrice) <= 0;
+
+      if (
+        hasInvalidSnapshotPrice ||
+        hasInvalidQuoteState ||
+        hasInvalidReferenceFields
+      ) {
+        await db
+          .update(perpMarketSnapshots)
+          .set({
+            currentPrice,
+            price24hAgo: currentPrice,
+            price24hAgoUpdatedAt: now,
+            high24h: currentPrice,
+            low24h: currentPrice,
+            bidPrice: initialQuote.bidPrice,
+            askPrice: initialQuote.askPrice,
+            spreadBps: initialQuote.spreadBps,
+            bidDepth: initialQuote.bidDepth,
+            askDepth: initialQuote.askDepth,
+            liquidityRegime: initialQuote.liquidityRegime,
+            quoteUpdatedAt: now,
+            markPrice: currentPrice,
+            indexPrice: currentPrice,
+            updatedAt: now,
+          })
+          .where(eq(perpMarketSnapshots.ticker, org.ticker));
+
+        repaired++;
+        logger.warn(
+          `Repaired invalid perp market snapshot for ${org.ticker}`,
+          { ticker: org.ticker, organizationId: org.id, currentPrice },
+          'GameBootstrapService'
+        );
+      }
     }
 
     if (created > 0) {
       logger.info(
         `Created ${created} perp market snapshots`,
         { created },
+        'GameBootstrapService'
+      );
+    }
+
+    if (repaired > 0) {
+      logger.info(
+        `Repaired ${repaired} invalid perp market snapshots`,
+        { repaired },
         'GameBootstrapService'
       );
     }

--- a/packages/engine/src/services/market-realism-metrics.test.ts
+++ b/packages/engine/src/services/market-realism-metrics.test.ts
@@ -89,6 +89,7 @@ describe('market-realism-metrics', () => {
       markets: [
         {
           ticker: 'OPENAGI',
+          currentPrice: 100,
           volume24h: 50_000,
           openInterest: 20_000,
           bidPrice: 99.5,
@@ -105,6 +106,40 @@ describe('market-realism-metrics', () => {
     });
 
     expect(metrics.quoteCoverageRate).toBe(1);
+    expect(metrics.invalidQuoteRate).toBe(0);
     expect(metrics.depthRatioByOrderSize['1000']?.mean).toBeGreaterThan(0);
+  });
+
+  it('flags invalid perp quotes and invalid canonical currentPrice values', () => {
+    const metrics = computePerpRealismMetrics({
+      markets: [
+        {
+          ticker: 'BROKEN',
+          currentPrice: 0,
+          volume24h: 10_000,
+          openInterest: 500,
+          bidPrice: 100,
+          askPrice: 99,
+          spreadBps: 80,
+          bidDepth: 0,
+          askDepth: 1000,
+          liquidityRegime: 'thin',
+          quoteUpdatedAt: new Date('2026-04-02T00:00:00.000Z'),
+        },
+      ],
+      now: new Date('2026-04-02T00:10:00.000Z'),
+      sampleOrderSizes: [1000],
+    });
+
+    expect(metrics.quoteCoverageRate).toBe(1);
+    expect(metrics.invalidQuoteCount).toBe(1);
+    expect(metrics.invalidQuoteRate).toBe(1);
+    expect(metrics.invalidCurrentPriceCount).toBe(1);
+    expect(metrics.warnings).toContain(
+      '1 perp markets have invalid quote-state structure (e.g. ask < bid or non-positive depth).'
+    );
+    expect(metrics.warnings).toContain(
+      '1 perp markets have invalid canonical currentPrice values.'
+    );
   });
 });

--- a/packages/engine/src/services/market-realism-metrics.ts
+++ b/packages/engine/src/services/market-realism-metrics.ts
@@ -45,12 +45,15 @@ export interface PredictionRealismMetrics {
 export interface PerpRealismMetrics {
   activeMarkets: number;
   quoteCoverageRate: number;
+  invalidQuoteRate: number;
   spreadBps: SummaryStats | null;
   bidDepth: SummaryStats | null;
   askDepth: SummaryStats | null;
   depthRatioByOrderSize: Record<string, SummaryStats | null>;
   liquidityRegimes: Record<'thin' | 'balanced' | 'deep', number>;
   staleQuotesCount: number;
+  invalidQuoteCount: number;
+  invalidCurrentPriceCount: number;
   warnings: string[];
 }
 
@@ -58,6 +61,7 @@ export interface PerpRealismDiagnosticInput {
   ticker: string;
   openInterest: number;
   volume24h: number;
+  currentPrice?: number;
   bidPrice?: number;
   askPrice?: number;
   spreadBps?: number;
@@ -221,6 +225,32 @@ export function computePerpRealismMetrics(params: {
   const sampleOrderSizes = params.sampleOrderSizes ?? [1000, 5000];
   const liquidityRegimes = zeroCounts(['thin', 'balanced', 'deep'] as const);
 
+  const validQuotedMarkets = params.markets.filter((market) => {
+    const bidPrice = market.bidPrice;
+    const askPrice = market.askPrice;
+    const spreadBps = market.spreadBps;
+    const bidDepth = market.bidDepth;
+    const askDepth = market.askDepth;
+
+    return (
+      bidPrice !== undefined &&
+      askPrice !== undefined &&
+      spreadBps !== undefined &&
+      bidDepth !== undefined &&
+      askDepth !== undefined &&
+      Number.isFinite(bidPrice) &&
+      Number.isFinite(askPrice) &&
+      Number.isFinite(spreadBps) &&
+      Number.isFinite(bidDepth) &&
+      Number.isFinite(askDepth) &&
+      bidPrice > 0 &&
+      askPrice >= bidPrice &&
+      spreadBps >= 0 &&
+      bidDepth > 0 &&
+      askDepth > 0
+    );
+  });
+
   const coveredMarkets = params.markets.filter(
     (market) =>
       market.bidPrice !== undefined &&
@@ -241,9 +271,17 @@ export function computePerpRealismMetrics(params: {
     .filter((value): value is number => typeof value === 'number');
 
   let staleQuotesCount = 0;
+  let invalidCurrentPriceCount = 0;
   for (const market of params.markets) {
     const regime = market.liquidityRegime ?? 'thin';
     liquidityRegimes[regime]++;
+    if (
+      market.currentPrice === undefined ||
+      !Number.isFinite(market.currentPrice) ||
+      market.currentPrice <= 0
+    ) {
+      invalidCurrentPriceCount++;
+    }
     if (
       market.quoteUpdatedAt &&
       now.getTime() - market.quoteUpdatedAt.getTime() > 30 * 60 * 1000
@@ -252,11 +290,18 @@ export function computePerpRealismMetrics(params: {
     }
   }
 
+  const invalidQuoteCount = Math.max(
+    0,
+    coveredMarkets.length - validQuotedMarkets.length
+  );
+
   const depthRatioByOrderSize = Object.fromEntries(
     sampleOrderSizes.map((size) => [
       String(size),
       summarizeSeries(
-        coveredMarkets.map((market) => size / Math.max(market.askDepth ?? 1, 1))
+        validQuotedMarkets.map(
+          (market) => size / Math.max(market.askDepth ?? 1, 1)
+        )
       ),
     ])
   ) as Record<string, SummaryStats | null>;
@@ -271,6 +316,12 @@ export function computePerpRealismMetrics(params: {
     warnings.push('Some perp markets are missing quote-state fields.');
   }
 
+  if (invalidQuoteCount > 0) {
+    warnings.push(
+      `${invalidQuoteCount} perp markets have invalid quote-state structure (e.g. ask < bid or non-positive depth).`
+    );
+  }
+
   if (spreadSummary && spreadSummary.max - spreadSummary.min < 10) {
     warnings.push(
       'Perp spread dispersion is narrow; market personalities may still be too uniform.'
@@ -283,18 +334,28 @@ export function computePerpRealismMetrics(params: {
     );
   }
 
+  if (invalidCurrentPriceCount > 0) {
+    warnings.push(
+      `${invalidCurrentPriceCount} perp markets have invalid canonical currentPrice values.`
+    );
+  }
+
   return {
     activeMarkets: params.markets.length,
     quoteCoverageRate:
       params.markets.length > 0
         ? coveredMarkets.length / params.markets.length
         : 0,
+    invalidQuoteRate:
+      params.markets.length > 0 ? invalidQuoteCount / params.markets.length : 0,
     spreadBps: spreadSummary,
     bidDepth: summarizeSeries(bidDepths),
     askDepth: summarizeSeries(askDepths),
     depthRatioByOrderSize,
     liquidityRegimes,
     staleQuotesCount,
+    invalidQuoteCount,
+    invalidCurrentPriceCount,
     warnings,
   };
 }

--- a/packages/engine/src/services/price-update-service.ts
+++ b/packages/engine/src/services/price-update-service.ts
@@ -40,6 +40,21 @@ export interface AppliedPriceUpdate {
 }
 
 export class PriceUpdateService {
+  private static getFirstPositivePrice(
+    ...candidates: Array<number | null | undefined>
+  ): number | null {
+    for (const candidate of candidates) {
+      if (
+        typeof candidate === 'number' &&
+        Number.isFinite(candidate) &&
+        candidate > 0
+      ) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
   /**
    * Apply a batch of price updates with persistence, engine sync, and SSE broadcast
    */
@@ -120,9 +135,11 @@ export class PriceUpdateService {
 
       // Resolve basePrice for bounds enforcement
       // Priority: organizationState.basePrice > organization.initialPrice
-      const resolvedBasePrice = Number(
-        state?.basePrice ?? organization?.initialPrice ?? 0
-      );
+      const resolvedBasePrice =
+        this.getFirstPositivePrice(
+          state?.basePrice,
+          organization?.initialPrice
+        ) ?? 100;
 
       // Price sanity check — must be positive and finite (AMM handles bounds)
       const clampedNewPrice = update.newPrice;
@@ -163,7 +180,11 @@ export class PriceUpdateService {
         })
         .onConflictDoUpdate({
           target: organizationState.id,
-          set: { currentPrice: clampedNewPrice, updatedAt: now },
+          set: {
+            currentPrice: clampedNewPrice,
+            basePrice: resolvedBasePrice,
+            updatedAt: now,
+          },
         });
 
       await getDbInstance().recordPriceUpdate(

--- a/scripts/market-realism-report.ts
+++ b/scripts/market-realism-report.ts
@@ -95,6 +95,7 @@ async function main() {
   const perpRows = await db
     .select({
       ticker: perpMarketSnapshots.ticker,
+      currentPrice: perpMarketSnapshots.currentPrice,
       openInterest: perpMarketSnapshots.openInterest,
       volume24h: perpMarketSnapshots.volume24h,
       bidPrice: perpMarketSnapshots.bidPrice,
@@ -128,6 +129,7 @@ async function main() {
   const perpMetrics = computePerpRealismMetrics({
     markets: perpRows.map((row) => ({
       ticker: row.ticker,
+      currentPrice: Number(row.currentPrice),
       openInterest: Number(row.openInterest),
       volume24h: Number(row.volume24h),
       bidPrice: row.bidPrice ? Number(row.bidPrice) : undefined,
@@ -194,6 +196,14 @@ async function main() {
   console.log(`- Active markets: ${perpMetrics.activeMarkets}`);
   console.log(
     `- Quote coverage: ${(perpMetrics.quoteCoverageRate * 100).toFixed(1)}%`
+  );
+  console.log(
+    `- Invalid quote states: ${perpMetrics.invalidQuoteCount} (${(
+      perpMetrics.invalidQuoteRate * 100
+    ).toFixed(1)}%)`
+  );
+  console.log(
+    `- Invalid currentPrice values: ${perpMetrics.invalidCurrentPriceCount}`
   );
   console.log(`- Spread bps: ${formatStat(perpMetrics.spreadBps, 1)}`);
   console.log(`- Bid depth: ${formatStat(perpMetrics.bidDepth, 0)}`);


### PR DESCRIPTION
## Summary
- harden perp runtime pricing so invalid `initialPrice` / `currentPrice` values no longer seed dead markets
- repair invalid perp organization state and snapshot rows during bootstrap instead of leaving them stuck until manual intervention
- improve perp realism diagnostics to surface invalid canonical prices / quote-state anomalies before tuning
- cap pathological depth inputs so extreme OI/volume outliers do not make markets effectively immovable

## Context
This continues the perps-only calibration track after the market realism rollout.

The immediate goal of this PR is not broad tuning yet. It is to make the runtime and observability trustworthy enough to support the next calibration cycle.

## Changes
- `GameBootstrapService`
  - normalize canonical seed price to the first positive real/static fallback
  - repair invalid `OrganizationState` rows with non-positive or missing prices
  - repair invalid `PerpMarketSnapshot` rows with broken price/reference/quote fields
- `PriceUpdateService`
  - stop propagating invalid `basePrice` fallbacks
  - persist a valid positive `basePrice` on conflict updates
- `DatabaseService`
  - normalize `upsertOrganizationState()` so new rows never seed `basePrice <= 0`
- `simulateMarketVolatility()`
  - fall back to a sane positive anchor when snapshot `currentPrice` is invalid
- `market-realism-metrics` / `report:realism`
  - detect and report invalid canonical current prices and invalid quote-state structure
- `microstructure`
  - cap extreme OI/volume contributions in base depth calculation so pathological rows do not create absurd depth

## Why
Observed production state showed that perps are broadly usable for calibration, but not fully clean:
- stale quote timestamps still exist on a small subset of markets
- some canonical perp prices are invalid (`currentPrice <= 0`)
- a few outlier rows can generate unrealistic depth magnitudes from OI/volume

This PR fixes the runtime root causes first, then tightens diagnostics, then applies a narrow first calibration on depth.

## Scope
- perps only
- no prediction-market work
- no UI work
- no DB migration

## Validation
- `bun test packages/core/markets/perps/__tests__/microstructure.test.ts`
- `bun test packages/engine/src/services/market-realism-metrics.test.ts`
- `bunx tsc -p packages/core/tsconfig.json --noEmit`
- `bunx tsc -p packages/engine/tsconfig.json --noEmit`
- `bunx tsc -p packages/db/tsconfig.json --noEmit`

## Expected post-deploy checks
- rerun `bun run report:realism -- --json`
- confirm invalid perp `currentPrice` count drops to `0`
- confirm stale quote count is re-evaluated after fresh ticks
- confirm repaired markets no longer remain stuck at `0`

## Ops / Migration
- no env changes
- no migration
- normal `staging` deploy

## Screenshots / recordings (UI)
No visual changes. Runtime hardening + diagnostics + depth calibration only.
