### PR TITLE
fix: harden perp close settlement

### DIFF
--- a/apps/web/src/app/api/leaderboard/me/route.ts
+++ b/apps/web/src/app/api/leaderboard/me/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@babylon/api';
 import { type LeaderboardMetric, type LeaderboardScope } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { sanitizeForJson } from '@/lib/json/sanitize';
 import { parseLeaderboardQuery } from '../query';
 
 /**
@@ -46,10 +47,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     pageSize
   );
 
-  return successResponse({
-    success: true,
-    leaderboardType,
-    leaderboardMetric,
-    currentUser,
-  });
+  return successResponse(
+    sanitizeForJson({
+      success: true,
+      leaderboardType,
+      leaderboardMetric,
+      currentUser,
+    })
+  );
 });

--- a/apps/web/src/app/api/leaderboard/route.ts
+++ b/apps/web/src/app/api/leaderboard/route.ts
@@ -68,6 +68,7 @@ import {
 import { and, db, eq, follows, inArray } from '@babylon/db';
 import { type LeaderboardMetric, logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { sanitizeForJson } from '@/lib/json/sanitize';
 import { parseLeaderboardQuery } from './query';
 
 const CACHE_KEY_NAMESPACE = 'leaderboard';
@@ -227,7 +228,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   );
 
   return successResponse(
-    {
+    sanitizeForJson({
       leaderboard: leaderboardData.users,
       pagination: {
         page: leaderboardData.page,
@@ -241,7 +242,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       followingUserIds,
       followingUserIdsResolved,
       generatedAt,
-    },
+    }),
     200,
     {
       'x-cache': cacheHit ? 'leaderboard-hit' : 'leaderboard-miss',

--- a/apps/web/src/app/api/users/[userId]/balance/route.ts
+++ b/apps/web/src/app/api/users/[userId]/balance/route.ts
@@ -72,6 +72,7 @@ import {
 } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { sanitizeForJson } from '@/lib/json/sanitize';
 
 /**
  * GET Handler for User Balance
@@ -168,11 +169,13 @@ export const GET = withErrorHandling(
       'GET /api/users/[userId]/balance'
     );
 
-    return successResponse({
-      balance: balanceInfo.virtualBalance,
-      totalDeposited: balanceInfo.totalDeposited,
-      totalWithdrawn: balanceInfo.totalWithdrawn,
-      lifetimePnL: balanceInfo.lifetimePnL,
-    });
+    return successResponse(
+      sanitizeForJson({
+        balance: balanceInfo.virtualBalance,
+        totalDeposited: balanceInfo.totalDeposited,
+        totalWithdrawn: balanceInfo.totalWithdrawn,
+        lifetimePnL: balanceInfo.lifetimePnL,
+      })
+    );
   }
 );

--- a/apps/web/src/app/api/users/[userId]/profile/route.ts
+++ b/apps/web/src/app/api/users/[userId]/profile/route.ts
@@ -121,6 +121,7 @@ import {
 } from '@babylon/api';
 import { logger, toISO, toISOOrNull, UserIdParamSchema } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { sanitizeForJson } from '@/lib/json/sanitize';
 import { getOptionalProfileStats } from '@/lib/users/profile-stats';
 
 /**
@@ -184,9 +185,11 @@ export const GET = withErrorHandling(
         { userId },
         'GET /api/users/[userId]/profile'
       );
-      return successResponse({
-        user: null,
-      });
+      return successResponse(
+        sanitizeForJson({
+          user: null,
+        })
+      );
     }
 
     // Get cached profile stats (followers, following, posts, etc.)
@@ -201,47 +204,43 @@ export const GET = withErrorHandling(
       'GET /api/users/[userId]/profile'
     );
 
-    const res = successResponse({
-      user: {
-        id: dbUser.id,
-        walletAddress: dbUser.walletAddress,
-        username: dbUser.username,
-        displayName: dbUser.displayName,
-        bio: dbUser.bio,
-        profileImageUrl: dbUser.profileImageUrl,
-        coverImageUrl: dbUser.coverImageUrl,
-        isActor: dbUser.isActor,
-        isAgent: dbUser.isAgent,
-        managedBy: dbUser.managedBy,
-        profileComplete: dbUser.profileComplete,
-        hasUsername: dbUser.hasUsername,
-        hasBio: dbUser.hasBio,
-        hasProfileImage: dbUser.hasProfileImage,
-        onChainRegistered: dbUser.onChainRegistered,
-        nftTokenId: dbUser.nftTokenId,
-        // WHY Number() conversion? virtualBalance and lifetimePnL are decimal types
-        // stored as strings in the database. We convert to numbers for JSON response.
-        // WHY ?? 0 fallback? Defensive programming - if somehow null, default to 0
-        virtualBalance: Number(dbUser.virtualBalance ?? 0),
-        lifetimePnL: Number(dbUser.lifetimePnL ?? 0),
-        reputationPoints: dbUser.reputationPoints,
-        earnedPoints: dbUser.earnedPoints,
-        invitePoints: dbUser.invitePoints,
-        bonusPoints: dbUser.bonusPoints,
-        referralCount: dbUser.referralCount,
-        referralCode: dbUser.referralCode,
-        hasFarcaster: dbUser.hasFarcaster,
-        hasTwitter: dbUser.hasTwitter,
-        farcasterUsername: dbUser.farcasterUsername,
-        twitterUsername: dbUser.twitterUsername,
-        // WHY optional chaining for usernameChangedAt? Field is nullable (only set when username changes)
-        // WHY || null? If toISOString() somehow returns empty string, return null instead
-        usernameChangedAt: toISOOrNull(dbUser.usernameChangedAt),
-        // WHY no optional chaining for createdAt? Field is NOT NULL in schema (always present)
-        createdAt: toISO(dbUser.createdAt),
-        stats,
-      },
-    });
+    const res = successResponse(
+      sanitizeForJson({
+        user: {
+          id: dbUser.id,
+          walletAddress: dbUser.walletAddress,
+          username: dbUser.username,
+          displayName: dbUser.displayName,
+          bio: dbUser.bio,
+          profileImageUrl: dbUser.profileImageUrl,
+          coverImageUrl: dbUser.coverImageUrl,
+          isActor: dbUser.isActor,
+          isAgent: dbUser.isAgent,
+          managedBy: dbUser.managedBy,
+          profileComplete: dbUser.profileComplete,
+          hasUsername: dbUser.hasUsername,
+          hasBio: dbUser.hasBio,
+          hasProfileImage: dbUser.hasProfileImage,
+          onChainRegistered: dbUser.onChainRegistered,
+          nftTokenId: dbUser.nftTokenId,
+          virtualBalance: Number(dbUser.virtualBalance ?? 0),
+          lifetimePnL: Number(dbUser.lifetimePnL ?? 0),
+          reputationPoints: dbUser.reputationPoints,
+          earnedPoints: dbUser.earnedPoints,
+          invitePoints: dbUser.invitePoints,
+          bonusPoints: dbUser.bonusPoints,
+          referralCount: dbUser.referralCount,
+          referralCode: dbUser.referralCode,
+          hasFarcaster: dbUser.hasFarcaster,
+          hasTwitter: dbUser.hasTwitter,
+          farcasterUsername: dbUser.farcasterUsername,
+          twitterUsername: dbUser.twitterUsername,
+          usernameChangedAt: toISOOrNull(dbUser.usernameChangedAt),
+          createdAt: toISO(dbUser.createdAt),
+          stats,
+        },
+      })
+    );
     if (rateLimitInfo) addPublicReadHeaders(res, rateLimitInfo);
     return res;
   }

--- a/apps/web/src/lib/json/sanitize.ts
+++ b/apps/web/src/lib/json/sanitize.ts
@@ -1,0 +1,32 @@
+export function sanitizeForJson<T>(value: T): T {
+  const seen = new WeakSet<object>();
+
+  const visit = (input: unknown): unknown => {
+    if (typeof input === 'bigint') {
+      return input.toString();
+    }
+
+    if (input instanceof Date) {
+      return input.toISOString();
+    }
+
+    if (Array.isArray(input)) {
+      return input.map((item) => visit(item));
+    }
+
+    if (input && typeof input === 'object') {
+      if (seen.has(input)) {
+        return null;
+      }
+      seen.add(input);
+
+      return Object.fromEntries(
+        Object.entries(input).map(([key, nested]) => [key, visit(nested)])
+      );
+    }
+
+    return input;
+  };
+
+  return visit(value) as T;
+}

--- a/packages/core/markets/perps/PerpMarketService.ts
+++ b/packages/core/markets/perps/PerpMarketService.ts
@@ -683,213 +683,216 @@ export class PerpMarketService {
    * @param input.maxSlippage - Maximum price deviation from entry. Rejects if exceeded.
    */
   async closePosition(input: PerpCloseInput): Promise<PerpTradeResult> {
-    const position = await this.db.getPositionById(input.positionId);
-    if (!position) {
-      throw new Error(`Position not found: ${input.positionId}`);
-    }
-    if (position.userId !== input.userId) {
-      throw new Error('Not your position');
-    }
-    if (position.closedAt) {
-      throw new Error('Position already closed');
-    }
-
-    const markets = await this.db.listMarkets();
-    const market = markets.find((m) => m.ticker === position.ticker);
-    if (!market) {
-      throw new Error(
-        `Market not found for position ticker ${position.ticker}`
-      );
-    }
-
-    // Determine close percentage (default to full close)
-    const closePercentage = Math.min(1, Math.max(0, input.percentage ?? 1));
-    if (closePercentage <= 0) {
-      throw new Error('Close percentage must be greater than 0');
-    }
-
-    const closeSize = position.size * closePercentage;
-    const remainingSize = position.size - closeSize;
-    const isFullClose = remainingSize < 0.01; // Treat tiny remainders as full close
-
-    const requestedExitPrice =
-      input.exitPriceOverride ??
-      this.getCloseExecutionQuote(market, position.side, closeSize)
-        .executionPrice;
-
-    // Reject non-finite or extreme prices to prevent NaN/Infinity PnL
-    if (!Number.isFinite(requestedExitPrice) || requestedExitPrice <= 0) {
-      throw new Error(
-        `Invalid exit price for ${position.ticker}: ${requestedExitPrice}. Cannot close position.`
-      );
-    }
-
-    // Slippage protection: reject if execution price deviates too far from mark price
-    // This protects against executing at a price that differs significantly from fair value
-    if (input.maxSlippage !== undefined && input.maxSlippage > 0) {
-      // Use mark price as the reference (more stable), falling back to position's tracked price
-      const referencePrice = market.markPrice ?? market.currentPrice;
-      const priceDeviation =
-        Math.abs(requestedExitPrice - referencePrice) / referencePrice;
-      if (priceDeviation > input.maxSlippage) {
+    const settlement = await this.db.transaction(async (tx) => {
+      const position = await tx.lockOpenPositionById(input.positionId);
+      if (!position) {
         throw new Error(
-          `Slippage exceeded: execution price ${requestedExitPrice.toFixed(2)} deviates ` +
-            `${(priceDeviation * 100).toFixed(2)}% from mark price ${referencePrice.toFixed(2)} ` +
-            `(max allowed: ${(input.maxSlippage * 100).toFixed(2)}%)`
+          `Position not found or already closed: ${input.positionId}`
         );
       }
-    }
+      if (position.userId !== input.userId) {
+        throw new Error('Not your position');
+      }
 
-    // BF-75: determine average-fill execution price up front so persistence,
-    // events, and response all use the same close price.
-    const closeImpact = await this.previewCloseImpact({
-      ticker: position.ticker,
-      exitPrice: requestedExitPrice,
-      currentSpotPrice: market.currentPrice,
-      side: position.side,
-      closeSize,
+      const markets = await tx.listMarkets();
+      const market = markets.find((m) => m.ticker === position.ticker);
+      if (!market) {
+        throw new Error(
+          `Market not found for position ticker ${position.ticker}`
+        );
+      }
+
+      const closePercentage = Math.min(1, Math.max(0, input.percentage ?? 1));
+      if (closePercentage <= 0) {
+        throw new Error('Close percentage must be greater than 0');
+      }
+
+      const closeSize = position.size * closePercentage;
+      const remainingSize = position.size - closeSize;
+      const isFullClose = remainingSize < 0.01;
+      const minOrderSize = market.minOrderSize ?? DEFAULT_MIN_ORDER_SIZE;
+      if (!isFullClose && closeSize < minOrderSize) {
+        throw new Error(
+          `Partial close below minimum order size (${minOrderSize})`
+        );
+      }
+
+      const requestedExitPrice =
+        input.exitPriceOverride ??
+        this.getCloseExecutionQuote(market, position.side, closeSize)
+          .executionPrice;
+
+      if (!Number.isFinite(requestedExitPrice) || requestedExitPrice <= 0) {
+        throw new Error(
+          `Invalid exit price for ${position.ticker}: ${requestedExitPrice}. Cannot close position.`
+        );
+      }
+
+      if (input.maxSlippage !== undefined && input.maxSlippage > 0) {
+        const referencePrice = market.markPrice ?? market.currentPrice;
+        const priceDeviation =
+          Math.abs(requestedExitPrice - referencePrice) / referencePrice;
+        if (priceDeviation > input.maxSlippage) {
+          throw new Error(
+            `Slippage exceeded: execution price ${requestedExitPrice.toFixed(2)} deviates ` +
+              `${(priceDeviation * 100).toFixed(2)}% from mark price ${referencePrice.toFixed(2)} ` +
+              `(max allowed: ${(input.maxSlippage * 100).toFixed(2)}%)`
+          );
+        }
+      }
+
+      const closeImpact = await this.previewCloseImpact({
+        ticker: position.ticker,
+        exitPrice: requestedExitPrice,
+        currentSpotPrice: market.currentPrice,
+        side: position.side,
+        closeSize,
+      });
+      const exitPrice = closeImpact?.avgExitPrice ?? requestedExitPrice;
+
+      const { pnl } = calculateUnrealizedPnL(
+        position.entryPrice,
+        exitPrice,
+        position.side,
+        closeSize
+      );
+      const proportionalFunding = position.fundingPaid * closePercentage;
+      const realizedPnL = pnl - proportionalFunding;
+      const marginPaid = closeSize / position.leverage;
+      const grossSettlement = marginPaid + realizedPnL;
+      const fee = this.calculateFee(closeSize);
+      const netSettlement = Math.max(0, grossSettlement - fee);
+      const now = this.deps.clock?.now() ?? new Date();
+
+      if (isFullClose) {
+        await tx.closePosition(position.id, {
+          currentPrice: exitPrice,
+          closedAt: now,
+          realizedPnL: (position.realizedPnL ?? 0) + realizedPnL,
+          unrealizedPnL: 0,
+          unrealizedPnLPercent: 0,
+        });
+      } else {
+        const remainingFunding = position.fundingPaid - proportionalFunding;
+        const { pnl: remainingPnl, pnlPercent: remainingPnlPercent } =
+          calculateUnrealizedPnL(
+            position.entryPrice,
+            exitPrice,
+            position.side,
+            remainingSize
+          );
+        await tx.updateOpenPosition(position.id, {
+          size: remainingSize,
+          fundingPaid: remainingFunding,
+          currentPrice: exitPrice,
+          unrealizedPnL: remainingPnl,
+          unrealizedPnLPercent: remainingPnlPercent,
+          lastUpdated: now,
+        });
+      }
+
+      const newOpenInterest = Math.max(0, market.openInterest - closeSize);
+      await tx.updateMarketStats(position.ticker, {
+        openInterest: newOpenInterest,
+        volume24h: market.volume24h + closeSize,
+      });
+
+      return {
+        closeImpact,
+        closePercentage,
+        closeSize,
+        exitPrice,
+        fee,
+        isFullClose,
+        marginPaid,
+        market,
+        netSettlement,
+        newOpenInterest,
+        now,
+        position,
+        requestedExitPrice,
+        realizedPnL,
+        remainingSize,
+      };
     });
-    const exitPrice = closeImpact?.avgExitPrice ?? requestedExitPrice;
 
-    // Calculate PnL for the portion being closed
-    const { pnl } = calculateUnrealizedPnL(
-      position.entryPrice,
-      exitPrice,
-      position.side,
-      closeSize
-    );
-    // Proportional funding paid for the closed portion
-    const proportionalFunding = position.fundingPaid * closePercentage;
-    const realizedPnL = pnl - proportionalFunding;
-    const marginPaid = closeSize / position.leverage;
-    const grossSettlement = marginPaid + realizedPnL;
-    const fee = this.calculateFee(closeSize);
-    // Fee is deducted from settlement. Clamp at 0: the user's margin is the
-    // maximum at risk. If fee exceeds remaining settlement, it's partially
-    // collected (standard perp behavior — no negative balance).
-    const netSettlement = Math.max(0, grossSettlement - fee);
-
-    if (netSettlement > 0) {
+    if (settlement.netSettlement > 0) {
       await this.deps.wallet.credit({
         userId: input.userId,
-        amount: netSettlement,
-        reason: isFullClose ? 'perp_close' : 'perp_partial_close',
-        description: `${isFullClose ? 'Close' : `Partial close ${(closePercentage * 100).toFixed(0)}%`} ${position.leverage}x ${position.side} ${position.ticker}`,
-        relatedId: position.id,
+        amount: settlement.netSettlement,
+        reason: settlement.isFullClose ? 'perp_close' : 'perp_partial_close',
+        description: `${settlement.isFullClose ? 'Close' : `Partial close ${(settlement.closePercentage * 100).toFixed(0)}%`} ${settlement.position.leverage}x ${settlement.position.side} ${settlement.position.ticker}`,
+        relatedId: settlement.position.id,
       });
     }
 
     await this.deps.wallet.recordPnL({
       userId: input.userId,
-      // Net realized PnL excluding margin (which is principal) and including any
-      // fee actually collected (bounded by the settlement clamp).
-      pnl: netSettlement - marginPaid,
-      reason: isFullClose ? 'perp_close' : 'perp_partial_close',
-      relatedId: position.id,
+      pnl: settlement.netSettlement - settlement.marginPaid,
+      reason: settlement.isFullClose ? 'perp_close' : 'perp_partial_close',
+      relatedId: settlement.position.id,
     });
 
-    const now = this.deps.clock?.now() ?? new Date();
-
-    if (isFullClose) {
-      // Full close: mark position as closed
-      await this.db.closePosition(position.id, {
-        currentPrice: exitPrice,
-        closedAt: now,
-        realizedPnL: (position.realizedPnL ?? 0) + realizedPnL,
-        unrealizedPnL: 0,
-        unrealizedPnLPercent: 0,
-      });
-    } else {
-      // Partial close: reduce position size and funding
-      const remainingFunding = position.fundingPaid - proportionalFunding;
-      const { pnl: remainingPnl, pnlPercent: remainingPnlPercent } =
-        calculateUnrealizedPnL(
-          position.entryPrice,
-          exitPrice,
-          position.side,
-          remainingSize
-        );
-      await this.db.updateOpenPosition(position.id, {
-        size: remainingSize,
-        fundingPaid: remainingFunding,
-        currentPrice: exitPrice,
-        unrealizedPnL: remainingPnl,
-        unrealizedPnLPercent: remainingPnlPercent,
-        lastUpdated: now,
-      });
-    }
-
-    // OI decreases by the closed portion
-    const newOpenInterest = Math.max(0, market.openInterest - closeSize);
-
-    // Run market stats update and balance query in parallel — they're
-    // independent of each other and both depend only on the settlement above.
-    const [, balanceResult] = await Promise.all([
-      this.db.updateMarketStats(position.ticker, {
-        openInterest: newOpenInterest,
-        volume24h: market.volume24h + closeSize,
-      }),
-      this.deps.wallet.getBalance(input.userId),
-    ]);
+    const balanceResult = await this.deps.wallet.getBalance(input.userId);
 
     // Fee bookkeeping: retries + optional outbox (see processFeeWithRetry).
     void this.processFeeWithRetry(
       {
         userId: input.userId,
-        amount: closeSize,
+        amount: settlement.closeSize,
         type: 'perp_close',
-        relatedId: position.ticker,
-        positionId: position.id,
+        relatedId: settlement.position.ticker,
+        positionId: settlement.position.id,
       },
-      { ticker: position.ticker }
+      { ticker: settlement.position.ticker }
     ).catch(() => {
       // Error already logged in processFeeWithRetry; catch to prevent unhandled rejection
     });
 
     // Apply market-level post-close impact after settlement to keep the close
     // path fail-safe (position is already settled if this step fails).
-    const postCloseMarketPrice = closeImpact
-      ? await this.applyPostCloseMarketImpact(position.ticker)
+    const postCloseMarketPrice = settlement.closeImpact
+      ? await this.applyPostCloseMarketImpact(settlement.position.ticker)
       : undefined;
 
     // For partial closes, re-mark remaining position to the post-impact price.
     if (
-      !isFullClose &&
+      !settlement.isFullClose &&
       postCloseMarketPrice !== undefined &&
       Number.isFinite(postCloseMarketPrice) &&
-      Math.abs(postCloseMarketPrice - exitPrice) > MIN_IMPACT_DELTA
+      Math.abs(postCloseMarketPrice - settlement.exitPrice) > MIN_IMPACT_DELTA
     ) {
       const { pnl: markedPnl, pnlPercent: markedPnlPercent } =
         calculateUnrealizedPnL(
-          position.entryPrice,
+          settlement.position.entryPrice,
           postCloseMarketPrice,
-          position.side,
-          remainingSize
+          settlement.position.side,
+          settlement.remainingSize
         );
 
-      await this.db.updateOpenPosition(position.id, {
+      await this.db.updateOpenPosition(settlement.position.id, {
         currentPrice: postCloseMarketPrice,
         unrealizedPnL: markedPnl,
         unrealizedPnLPercent: markedPnlPercent,
-        lastUpdated: now,
+        lastUpdated: settlement.now,
       });
     }
 
     const result: PerpTradeResult = {
-      positionId: position.id,
-      ticker: position.ticker,
-      side: position.side,
-      size: closeSize,
-      leverage: position.leverage,
-      entryPrice: position.entryPrice,
-      exitPrice,
-      liquidationPrice: position.liquidationPrice,
-      realizedPnL,
-      feePaid: fee,
-      marginPaid,
+      positionId: settlement.position.id,
+      ticker: settlement.position.ticker,
+      side: settlement.position.side,
+      size: settlement.closeSize,
+      leverage: settlement.position.leverage,
+      entryPrice: settlement.position.entryPrice,
+      exitPrice: settlement.exitPrice,
+      liquidationPrice: settlement.position.liquidationPrice,
+      realizedPnL: settlement.realizedPnL,
+      feePaid: settlement.fee,
+      marginPaid: settlement.marginPaid,
       balance: balanceResult.balance,
-      remainingSize: isFullClose ? 0 : remainingSize,
-      fullyClosed: isFullClose,
+      remainingSize: settlement.isFullClose ? 0 : settlement.remainingSize,
+      fullyClosed: settlement.isFullClose,
     };
 
     // Broadcast trade event for real-time UI updates.
@@ -897,32 +900,32 @@ export class PerpMarketService {
     // to avoid blocking the response.
     this.emitTradeEvent({
       type: 'perp_trade',
-      action: isFullClose ? 'close' : 'partial_close',
-      ticker: position.ticker,
-      side: position.side,
-      size: closeSize,
-      leverage: position.leverage,
-      entryPrice: position.entryPrice,
-      exitPrice,
-      positionId: position.id,
-      realizedPnL,
-      openInterest: newOpenInterest,
-      volume24h: market.volume24h + closeSize,
+      action: settlement.isFullClose ? 'close' : 'partial_close',
+      ticker: settlement.position.ticker,
+      side: settlement.position.side,
+      size: settlement.closeSize,
+      leverage: settlement.position.leverage,
+      entryPrice: settlement.position.entryPrice,
+      exitPrice: settlement.exitPrice,
+      positionId: settlement.position.id,
+      realizedPnL: settlement.realizedPnL,
+      openInterest: settlement.newOpenInterest,
+      volume24h: settlement.market.volume24h + settlement.closeSize,
       timestamp: (this.deps.clock?.now() ?? new Date()).toISOString(),
     }).catch(() => {
       // Error already logged in emitTradeEvent; catch to prevent unhandled rejection
     });
 
-    if (closeImpact) {
+    if (settlement.closeImpact) {
       logger.info(
-        `Exit price adjusted to avg fill: ${requestedExitPrice.toFixed(2)} → ${exitPrice.toFixed(2)} (delta: ${closeImpact.deltaImpact.toFixed(4)})`,
+        `Exit price adjusted to avg fill: ${settlement.requestedExitPrice.toFixed(2)} → ${settlement.exitPrice.toFixed(2)} (delta: ${settlement.closeImpact.deltaImpact.toFixed(4)})`,
         {
-          positionId: position.id,
-          ticker: position.ticker,
-          side: position.side,
-          requestedExitPrice,
-          avgExitPrice: exitPrice,
-          deltaImpact: closeImpact.deltaImpact,
+          positionId: settlement.position.id,
+          ticker: settlement.position.ticker,
+          side: settlement.position.side,
+          requestedExitPrice: settlement.requestedExitPrice,
+          avgExitPrice: settlement.exitPrice,
+          deltaImpact: settlement.closeImpact.deltaImpact,
           postCloseMarketPrice,
         },
         'PerpService'

--- a/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
+++ b/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
@@ -118,6 +118,12 @@ class InMemoryPerpDb implements PerpDbPort {
     return pos ? { ...pos } : null;
   }
 
+  async lockOpenPositionById(id: string): Promise<PerpPositionRecord | null> {
+    const pos = this.positions.get(id);
+    if (!pos || pos.closedAt) return null;
+    return { ...pos };
+  }
+
   async transaction<T>(fn: (tx: PerpDbPort) => Promise<T>): Promise<T> {
     // In-memory mock just runs the function directly
     return fn(this);
@@ -167,7 +173,7 @@ class InMemoryPerpDb implements PerpDbPort {
     >
   ): Promise<void> {
     const pos = this.positions.get(positionId);
-    if (!pos) return;
+    if (!pos || pos.closedAt) return;
     this.positions.set(positionId, {
       ...pos,
       ...updates,
@@ -189,7 +195,7 @@ class InMemoryPerpDb implements PerpDbPort {
     >
   ): Promise<void> {
     const pos = this.positions.get(positionId);
-    if (!pos) return;
+    if (!pos || pos.closedAt) return;
     this.positions.set(positionId, {
       ...pos,
       closedAt: updates.closedAt ?? new Date(),
@@ -502,6 +508,28 @@ describe('PerpMarketService', () => {
     const m = markets[0]!;
     expect(m.volume24h).toBeCloseTo(150, 4); // open 100 + close 50
     expect(m.openInterest).toBeCloseTo(50, 4); // remaining
+  });
+
+  it('rejects partial close below the market minimum order size', async () => {
+    const open = await service.openPosition({
+      userId: 'u1',
+      ticker: 'ABC',
+      side: 'long',
+      size: 100,
+      leverage: 10,
+    });
+
+    await expect(
+      service.closePosition({
+        userId: 'u1',
+        positionId: open.positionId,
+        percentage: 0.05,
+      })
+    ).rejects.toThrow(/minimum order size/);
+
+    const pos = await db.getPositionById(open.positionId);
+    expect(pos?.closedAt).toBeNull();
+    expect(pos?.size).toBeCloseTo(100, 4);
   });
 
   it('slippage protection rejects open if price deviation exceeds max', async () => {

--- a/packages/core/markets/perps/adapters/drizzle/PerpDbAdapter.ts
+++ b/packages/core/markets/perps/adapters/drizzle/PerpDbAdapter.ts
@@ -153,6 +153,16 @@ export class PerpDbAdapter implements PerpDbPort {
     return pos ? mapPosition(pos) : null;
   }
 
+  async lockOpenPositionById(id: string): Promise<PerpPositionRecord | null> {
+    const [pos] = await this.dbClient
+      .select()
+      .from(perpPositions)
+      .where(and(eq(perpPositions.id, id), isNull(perpPositions.closedAt)))
+      .limit(1)
+      .for('update');
+    return pos ? mapPosition(pos) : null;
+  }
+
   async upsertPosition(
     position: Omit<PerpPositionRecord, 'id'> & { id?: string }
   ): Promise<PerpPositionRecord> {
@@ -272,7 +282,9 @@ export class PerpDbAdapter implements PerpDbPort {
     await this.dbClient
       .update(perpPositions)
       .set(setFields)
-      .where(eq(perpPositions.id, positionId));
+      .where(
+        and(eq(perpPositions.id, positionId), isNull(perpPositions.closedAt))
+      );
   }
 
   async updateMarketStats(

--- a/packages/core/markets/perps/types.ts
+++ b/packages/core/markets/perps/types.ts
@@ -93,6 +93,11 @@ export interface PerpDbPort {
     userId: string,
     ticker: string
   ): Promise<PerpPositionRecord | null>;
+  /**
+   * Lock and return an open position row for mutation.
+   * Returns null if the position does not exist or is already closed.
+   */
+  lockOpenPositionById(id: string): Promise<PerpPositionRecord | null>;
   upsertPosition(
     position: Omit<PerpPositionRecord, 'id'> & { id?: string }
   ): Promise<PerpPositionRecord>;

--- a/packages/shared/src/validation/schemas/market.ts
+++ b/packages/shared/src/validation/schemas/market.ts
@@ -32,14 +32,13 @@ export const OpenPerpPositionSchema = z.object({
 /**
  * Close perp position schema
  *
- * NOTE: percentage and slippage fields are defined for future support but
- * are not currently implemented in PerpMarketService. Positions are closed
- * entirely at market price.
+ * NOTE: Partial close is implemented in PerpMarketService. `percentage` must
+ * be strictly positive to avoid no-op or dust-close abuse.
  */
 export const ClosePerpPositionSchema = z
   .object({
     /** Close partial position (0-1, e.g., 0.5 = close 50%). Defaults to 1 (full close). */
-    percentage: z.number().min(0).max(1).optional(),
+    percentage: z.number().gt(0).max(1).optional(),
     /** Max slippage tolerance (0-1, e.g., 0.01 = 1%). Rejects if price moved beyond this. */
     slippage: z.number().min(0).max(0.1).default(0.01),
     orderType: z.enum(['market', 'limit']).default('market'),


### PR DESCRIPTION
## Summary\n- serialize perp close settlement on the position row before applying state changes\n- reject dust partial closes\n- keep closed rows immutable at the adapter level\n\n## Context\nProduction incident on SPCX showed repeated close/partial-close credits on the same open position. This forward-port keeps the staging line aligned with the prod hotfix so the issue is not reintroduced on the next release.