### PR TITLE
feat: Feed QA — DB-backed dedup, cross-NPC similarity, chat quality guards

### DIFF
--- a/apps/web/src/app/api/cron/article-tick/route.ts
+++ b/apps/web/src/app/api/cron/article-tick/route.ts
@@ -412,9 +412,9 @@ export const POST = withErrorHandling(async function POST(_req: NextRequest) {
       const event = activeEventsData.activeEvents[eventIndex];
 
       if (event) {
-        // Check if we've already covered this event using explicit tracking
+        // Check if we've already covered this event using DB-backed tracking
         const eventId = event.questionId;
-        const alreadyCovered = hasEventBeenCovered(eventId);
+        const alreadyCovered = await hasEventBeenCovered(eventId);
 
         if (!alreadyCovered) {
           // Pick a random news org to write the article
@@ -432,8 +432,8 @@ export const POST = withErrorHandling(async function POST(_req: NextRequest) {
 
           if (result.status === 'success') {
             articlesCreated++;
-            // Mark this event as covered for future duplicate detection
-            markEventAsCovered(eventId, org.id, result.id);
+            // Mark this event as covered for future duplicate detection (DB-backed)
+            await markEventAsCovered(eventId, org.id, result.id);
             logger.info(
               `Article created by ${org.name}`,
               { eventId: event.questionId, articleId: result.id },

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "solana:registration:debug": "bun run scripts/debug-solana-registration.ts",
     "seed:nft-snapshot:csv": "bun run scripts/seed-nft-snapshot-csv.ts",
     "users:export:newsletter": "bun run scripts/export-newsletter-users-csv.ts",
+    "report:feed": "bun run scripts/feed-health.ts",
     "report:markets": "bun run scripts/market-diversity-report.ts",
     "report:markets:health": "bun run scripts/market-health.ts",
     "report:realism": "bun run scripts/market-realism-report.ts",

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -32,6 +32,7 @@ import {
   chats,
   comments,
   db,
+  desc,
   dmAcceptances,
   eq,
   follows,
@@ -40,6 +41,7 @@ import {
   gte,
   isNull,
   messages,
+  ne,
   perpPositions,
   posts,
   reactions,
@@ -1212,7 +1214,7 @@ export async function executeDirectPost(
 
   const cleanContent = content.trim();
 
-  // DIVERSITY CHECK: Validate content before creating post
+  // DIVERSITY CHECK: Validate content before creating post (per-agent, in-process)
   const diversityIssues = topicDiversityService.validateContent(
     agentUserId,
     cleanContent
@@ -1233,6 +1235,42 @@ export async function executeDirectPost(
       success: false,
       error: `Content rejected: ${diversityIssues[0]}`,
     };
+  }
+
+  // CROSS-NPC DEDUP CHECK: query the last 20 NPC posts in the past 10 minutes
+  // and reject if any other NPC posted sufficiently similar content. This closes
+  // the gap left by the per-agent in-process TopicDiversityService singleton.
+  const crossNpcWindow = new Date(Date.now() - 10 * 60 * 1000);
+  const recentNpcPosts = await db
+    .select({ content: posts.content })
+    .from(posts)
+    .where(
+      and(
+        gte(posts.timestamp, crossNpcWindow),
+        isNull(posts.deletedAt),
+        isNull(posts.commentOnPostId),
+        ne(posts.authorId, agentUserId)
+      )
+    )
+    .orderBy(desc(posts.timestamp))
+    .limit(20);
+
+  for (const recent of recentNpcPosts) {
+    const sim = topicDiversityService.calculateSimilarity(
+      cleanContent,
+      recent.content
+    );
+    if (sim >= 0.5) {
+      logger.warn(
+        `[DirectExecutor] Post rejected — cross-NPC similarity ${(sim * 100).toFixed(0)}%`,
+        { agentUserId, contentPreview: cleanContent.substring(0, 80) },
+        'DirectExecutors'
+      );
+      return {
+        success: false,
+        error: 'Content too similar to a recent post by another NPC',
+      };
+    }
   }
 
   // Check if this is an NPC (system-defined actor from static data files).

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -39,9 +39,9 @@ import {
   groupMembers,
   groups,
   gte,
+  inArray,
   isNull,
   messages,
-  ne,
   perpPositions,
   posts,
   reactions,
@@ -1237,39 +1237,51 @@ export async function executeDirectPost(
     };
   }
 
-  // CROSS-NPC DEDUP CHECK: query the last 20 NPC posts in the past 10 minutes
-  // and reject if any other NPC posted sufficiently similar content. This closes
-  // the gap left by the per-agent in-process TopicDiversityService singleton.
-  const crossNpcWindow = new Date(Date.now() - 10 * 60 * 1000);
-  const recentNpcPosts = await db
-    .select({ content: posts.content })
-    .from(posts)
-    .where(
-      and(
-        gte(posts.timestamp, crossNpcWindow),
-        isNull(posts.deletedAt),
-        isNull(posts.commentOnPostId),
-        ne(posts.authorId, agentUserId)
-      )
-    )
-    .orderBy(desc(posts.timestamp))
-    .limit(20);
+  // CROSS-NPC DEDUP CHECK (NPC actors only):
+  // Query the last 20 NPC posts in the past 10 minutes and reject if any other
+  // NPC posted sufficiently similar content. This closes the gap left by the
+  // per-agent in-process TopicDiversityService singleton.
+  // Only applies to NPC actors — user autonomous agents are NOT subject to this
+  // cross-agent check to avoid blocking them based on unrelated user posts.
+  const isNpcForDedup = !!StaticDataRegistry.getActor(agentUserId);
+  if (isNpcForDedup) {
+    const allNpcIds = StaticDataRegistry.getAllActors()
+      .map((a) => a.id)
+      .filter((id) => id !== agentUserId);
 
-  for (const recent of recentNpcPosts) {
-    const sim = topicDiversityService.calculateSimilarity(
-      cleanContent,
-      recent.content
-    );
-    if (sim >= 0.5) {
-      logger.warn(
-        `[DirectExecutor] Post rejected — cross-NPC similarity ${(sim * 100).toFixed(0)}%`,
-        { agentUserId, contentPreview: cleanContent.substring(0, 80) },
-        'DirectExecutors'
-      );
-      return {
-        success: false,
-        error: 'Content too similar to a recent post by another NPC',
-      };
+    if (allNpcIds.length > 0) {
+      const crossNpcWindow = new Date(Date.now() - 10 * 60 * 1000);
+      const recentNpcPosts = await db
+        .select({ content: posts.content })
+        .from(posts)
+        .where(
+          and(
+            gte(posts.timestamp, crossNpcWindow),
+            isNull(posts.deletedAt),
+            isNull(posts.commentOnPostId),
+            inArray(posts.authorId, allNpcIds)
+          )
+        )
+        .orderBy(desc(posts.timestamp))
+        .limit(20);
+
+      for (const recent of recentNpcPosts) {
+        const sim = topicDiversityService.calculateSimilarity(
+          cleanContent,
+          recent.content
+        );
+        if (sim >= 0.5) {
+          logger.warn(
+            `[DirectExecutor] Post rejected — cross-NPC similarity ${(sim * 100).toFixed(0)}%`,
+            { agentUserId, contentPreview: cleanContent.substring(0, 80) },
+            'DirectExecutors'
+          );
+          return {
+            success: false,
+            error: 'Content too similar to a recent post by another NPC',
+          };
+        }
+      }
     }
   }
 

--- a/packages/agents/src/autonomous/TopicDiversityService.ts
+++ b/packages/agents/src/autonomous/TopicDiversityService.ts
@@ -13,6 +13,7 @@
  */
 
 import { db, desc, gte, posts } from '@babylon/db';
+import { jaccardSimilarity } from '@babylon/shared';
 import { StaticDataRegistry } from '@babylon/engine';
 import { logger } from '../shared/logger';
 
@@ -268,27 +269,7 @@ export class TopicDiversityService {
    * Uses Jaccard similarity on word sets
    */
   calculateSimilarity(content1: string, content2: string): number {
-    const words1 = new Set(
-      content1
-        .toLowerCase()
-        .replace(/[^\w\s]/g, '')
-        .split(/\s+/)
-        .filter((w) => w.length > 3)
-    );
-    const words2 = new Set(
-      content2
-        .toLowerCase()
-        .replace(/[^\w\s]/g, '')
-        .split(/\s+/)
-        .filter((w) => w.length > 3)
-    );
-
-    if (words1.size === 0 || words2.size === 0) return 0;
-
-    const intersection = new Set([...words1].filter((w) => words2.has(w)));
-    const union = new Set([...words1, ...words2]);
-
-    return intersection.size / union.size;
+    return jaccardSimilarity(content1, content2);
   }
 
   /**

--- a/packages/db/drizzle/migrations/0068_add_arc_event_coverage.sql
+++ b/packages/db/drizzle/migrations/0068_add_arc_event_coverage.sql
@@ -1,0 +1,16 @@
+-- Migration: Add arc_event_coverage table for DB-backed arc event dedup
+-- Replaces in-memory NewsArticlePacingEngine.arcEventCoverage map so
+-- duplicate-article prevention survives server restarts and cold starts.
+
+CREATE TABLE IF NOT EXISTS "arc_event_coverage" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "event_id" text NOT NULL,
+  "org_id" text NOT NULL,
+  "status" text NOT NULL,
+  "article_id" text,
+  "covered_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "arc_coverage_event_org_status" ON "arc_event_coverage" ("event_id", "org_id", "status");
+CREATE INDEX IF NOT EXISTS "arc_coverage_event_status_idx" ON "arc_event_coverage" ("event_id", "status");
+CREATE INDEX IF NOT EXISTS "arc_coverage_covered_at_idx" ON "arc_event_coverage" ("covered_at");

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1775710454009,
       "tag": "0067_add_steward_id",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1744262400000,
+      "tag": "0068_add_arc_event_coverage",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/narrative.ts
+++ b/packages/db/src/schema/narrative.ts
@@ -6,9 +6,11 @@ import {
   jsonb,
   type PgColumn,
   pgTable,
+  serial,
   text,
   timestamp,
   unique,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core';
 import { questions } from './markets';
 
@@ -443,3 +445,32 @@ export const subMarketSpawnLogsRelations = relations(
 
 export type SubMarketSpawnLog = typeof subMarketSpawnLogs.$inferSelect;
 export type NewSubMarketSpawnLog = typeof subMarketSpawnLogs.$inferInsert;
+
+/**
+ * ArcEventCoverage - DB-backed tracking of which orgs have covered which arc
+ * events at which status. Replaces the in-memory NewsArticlePacingEngine
+ * arcEventCoverage map so tracking survives restarts and serverless cold starts.
+ */
+export const arcEventCoverage = pgTable(
+  'arc_event_coverage',
+  {
+    id: serial('id').primaryKey(),
+    eventId: text('event_id').notNull(),
+    orgId: text('org_id').notNull(),
+    status: text('status').notNull(),
+    articleId: text('article_id'),
+    coveredAt: timestamp('covered_at', { mode: 'date' }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('arc_coverage_event_org_status').on(
+      t.eventId,
+      t.orgId,
+      t.status
+    ),
+    index('arc_coverage_event_status_idx').on(t.eventId, t.status),
+    index('arc_coverage_covered_at_idx').on(t.coveredAt),
+  ]
+);
+
+export type ArcEventCoverage = typeof arcEventCoverage.$inferSelect;
+export type NewArcEventCoverage = typeof arcEventCoverage.$inferInsert;

--- a/packages/engine/src/services/article-rate-limiter.ts
+++ b/packages/engine/src/services/article-rate-limiter.ts
@@ -293,10 +293,17 @@ export function createArticleRateLimiter(
 
 /**
  * Default breaking article rate limit per hour.
- * Breaking articles are event-triggered (scandals, leaks, revelations)
- * and have their own allocation separate from regular articles.
+ *
+ * Because the DB-backed `BreakingArticleRateLimiterService` counts ALL articles
+ * (regular + breaking) in the posts table, this threshold must be set to
+ * REGULAR_MAX + BREAKING_BUDGET to preserve the original intent:
+ *
+ *   DEFAULT_MAX_ARTICLES_PER_HOUR (2) + 1 extra breaking slot = 3
+ *
+ * Breaking articles bypass the regular rate limiter via `skipRateLimit: true`,
+ * so the breaking limiter is the only guard that prevents overflow beyond 3/hr.
  */
-const DEFAULT_BREAKING_RATE_LIMIT_PER_HOUR = 1;
+const DEFAULT_BREAKING_RATE_LIMIT_PER_HOUR = DEFAULT_MAX_ARTICLES_PER_HOUR + 1;
 
 /**
  * Parse the BREAKING_RATE_LIMIT_PER_HOUR environment variable.

--- a/packages/engine/src/services/article-rate-limiter.ts
+++ b/packages/engine/src/services/article-rate-limiter.ts
@@ -473,6 +473,10 @@ export class BreakingArticleRateLimiterService {
   /**
    * No-op: DB-backed counting means we don't need to manually record articles.
    * Kept for API compatibility.
+   *
+   * @deprecated This method is a no-op since the service was migrated to
+   * DB-backed counting. The post row itself is the source of truth.
+   * Safe to call but has no effect.
    */
   recordBreakingArticle(_timestamp?: number): void {
     // DB-backed — the post row is already counted on next query

--- a/packages/engine/src/services/article-rate-limiter.ts
+++ b/packages/engine/src/services/article-rate-limiter.ts
@@ -312,29 +312,25 @@ function parseBreakingRateLimit(): number {
 /**
  * Breaking Article Rate Limiter Service
  *
- * Tracks breaking articles separately from regular articles using in-memory timestamps.
- * This is necessary because the posts table doesn't have a field to distinguish
- * breaking articles from regular articles, so database queries would count all articles.
+ * Tracks breaking article count via a DB query against the posts table.
+ * DB-backed — survives restarts and serverless cold starts, so redeployment
+ * no longer causes breaking-article bursts.
  *
  * Breaking articles are event-triggered (scandals, leaks, revelations) and have
- * their own rate limit separate from regular scheduled articles.
+ * their own rate limit (default 1/hr) separate from regular scheduled articles.
+ *
+ * The in-flight `reservations` map prevents TOCTOU races within a single process
+ * run (short-lived; cleared when the process exits, which is fine).
  *
  * @remarks
- * **In-Memory Tracking**: This service uses in-memory timestamp tracking because:
- * 1. The posts table lacks an isBreaking/subtype field to filter by
- * 2. Breaking articles are infrequent (default 1/hour)
- * 3. Tracking is reset on server restart, which is acceptable:
- *    - Breaking events are time-sensitive and don't span restarts
- *    - Worst case: one extra breaking article after restart
- *
  * **Concurrency Note**: Same TOCTOU considerations as ArticleRateLimiterService apply.
+ * The check-then-act pattern may allow one extra article in concurrent environments,
+ * which is acceptable for feed quality purposes.
  */
 export class BreakingArticleRateLimiterService {
   private readonly maxArticlesPerHour: number;
   private readonly windowMs: number;
-  /** Timestamps of breaking articles created within the current window (for non-reservation flow) */
-  private breakingArticleTimestamps: number[] = [];
-  /** Reservations keyed by reservationId -> timestamp (for reservation flow) */
+  /** In-flight reservations for TOCTOU protection within a single process run */
   private reservations: Map<string, number> = new Map();
 
   constructor(config: { maxArticlesPerHour?: number; windowMs?: number } = {}) {
@@ -343,15 +339,9 @@ export class BreakingArticleRateLimiterService {
     this.windowMs = config.windowMs ?? 60 * 60 * 1000; // 1 hour
   }
 
-  /**
-   * Clean up expired timestamps outside the current window
-   */
-  private cleanupExpiredTimestamps(): void {
+  /** Clean up stale in-flight reservations (older than windowMs) */
+  private cleanupReservations(): void {
     const windowStart = Date.now() - this.windowMs;
-    this.breakingArticleTimestamps = this.breakingArticleTimestamps.filter(
-      (ts) => ts > windowStart
-    );
-    // Also clean up expired reservations
     for (const [id, ts] of this.reservations) {
       if (ts <= windowStart) {
         this.reservations.delete(id);
@@ -360,31 +350,38 @@ export class BreakingArticleRateLimiterService {
   }
 
   /**
-   * Get the count of breaking articles created in the current time window
-   * (includes both reservations and recorded timestamps)
+   * Get the count of articles created in the current time window from the DB,
+   * plus any in-flight reservations.
    */
-  getRecentArticleCount(): number {
-    this.cleanupExpiredTimestamps();
-    return this.breakingArticleTimestamps.length + this.reservations.size;
+  async getRecentArticleCount(): Promise<number> {
+    this.cleanupReservations();
+    const windowStart = new Date(Date.now() - this.windowMs);
+
+    const [result] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(posts)
+      .where(
+        and(
+          eq(posts.type, 'article'),
+          gte(posts.timestamp, windowStart),
+          isNull(posts.deletedAt)
+        )
+      );
+
+    const dbCount = result?.count ?? 0;
+    return dbCount + this.reservations.size;
   }
 
   /**
-   * Check if more breaking articles can be generated
-   *
-   * @returns Object with allowed status and remaining slots
+   * Check if more breaking articles can be generated.
    */
-  canGenerateArticle(): {
+  async canGenerateArticle(): Promise<{
     allowed: boolean;
     currentCount: number;
     maxAllowed: number;
     remaining: number;
-  } {
-    // Clean up expired timestamps on every check to prevent memory accumulation
-    // when canGenerateArticle() is called repeatedly without recording
-    this.cleanupExpiredTimestamps();
-
-    const currentCount =
-      this.breakingArticleTimestamps.length + this.reservations.size;
+  }> {
+    const currentCount = await this.getRecentArticleCount();
     const remaining = Math.max(0, this.maxArticlesPerHour - currentCount);
 
     const result = {
@@ -411,33 +408,24 @@ export class BreakingArticleRateLimiterService {
 
   /**
    * Try to reserve a slot for a breaking article.
-   * This implements a reservation pattern to prevent race conditions.
-   *
-   * The slot is reserved by adding a timestamp immediately with a unique ID.
-   * If article generation fails, call `releaseSlot(reservationId)` to free
-   * the reservation. On success, the reservation automatically counts toward
-   * the rate limit (no need to call `recordBreakingArticle()`).
+   * Reserves a short-lived in-process slot to prevent race conditions.
+   * After persisting the article, the slot is superseded by the DB record.
    *
    * @returns A unique reservationId if a slot was reserved, or null if rate limit would be exceeded
    */
-  tryReserveSlot(): string | null {
-    this.cleanupExpiredTimestamps();
+  async tryReserveSlot(): Promise<string | null> {
+    this.cleanupReservations();
 
-    const currentCount =
-      this.breakingArticleTimestamps.length + this.reservations.size;
+    const currentCount = await this.getRecentArticleCount();
     if (currentCount >= this.maxArticlesPerHour) {
       logger.debug(
         'Breaking article slot reservation failed - rate limit reached',
-        {
-          currentCount,
-          maxAllowed: this.maxArticlesPerHour,
-        },
+        { currentCount, maxAllowed: this.maxArticlesPerHour },
         'BreakingArticleRateLimiter'
       );
       return null;
     }
 
-    // Reserve the slot with a unique ID
     const reservationId = crypto.randomUUID();
     this.reservations.set(reservationId, Date.now());
 
@@ -464,72 +452,30 @@ export class BreakingArticleRateLimiterService {
   releaseSlot(reservationId: string): boolean {
     const existed = this.reservations.delete(reservationId);
 
-    if (existed) {
-      logger.debug(
-        'Breaking article slot released',
-        {
-          reservationId,
-          currentCount:
-            this.breakingArticleTimestamps.length + this.reservations.size,
-          maxAllowed: this.maxArticlesPerHour,
-        },
-        'BreakingArticleRateLimiter'
-      );
-    } else {
-      logger.debug(
-        'Breaking article slot release failed - reservation not found',
-        { reservationId },
-        'BreakingArticleRateLimiter'
-      );
-    }
+    logger.debug(
+      existed
+        ? 'Breaking article slot released'
+        : 'Breaking article slot release failed - reservation not found',
+      { reservationId },
+      'BreakingArticleRateLimiter'
+    );
 
     return existed;
   }
 
   /**
-   * Record that a breaking article was created.
-   *
-   * **IMPORTANT**: Do not call if you used `tryReserveSlot()` — that method
-   * already records a timestamp on success. Calling both will double-count
-   * and prematurely exhaust the rate limit.
-   *
-   * This method is intended for callers that do NOT use the reservation pattern
-   * (e.g., external systems or legacy code paths).
-   *
-   * @param timestamp - Optional timestamp of creation (defaults to now)
+   * No-op: DB-backed counting means we don't need to manually record articles.
+   * Kept for API compatibility.
    */
-  recordBreakingArticle(timestamp?: number): void {
-    this.breakingArticleTimestamps.push(timestamp ?? Date.now());
-    this.cleanupExpiredTimestamps();
-
-    logger.debug(
-      'Recorded breaking article creation',
-      {
-        currentCount:
-          this.breakingArticleTimestamps.length + this.reservations.size,
-        maxAllowed: this.maxArticlesPerHour,
-      },
-      'BreakingArticleRateLimiter'
-    );
+  recordBreakingArticle(_timestamp?: number): void {
+    // DB-backed — the post row is already counted on next query
   }
 
   /**
    * Get the number of breaking articles that can still be generated this hour.
-   *
-   * @remarks
-   * **Intentionally synchronous**: Unlike `ArticleRateLimiterService.getRemainingSlots()`
-   * which returns `Promise<number>`, this method is synchronous because the
-   * `BreakingArticleRateLimiterService` uses in-memory tracking instead of database
-   * queries. All methods in this class (`canGenerateArticle()`, `getRecentArticleCount()`,
-   * etc.) are synchronous by design for performance and simplicity.
-   *
-   * If you need a unified interface across both services, wrap the call:
-   * ```typescript
-   * const remaining = await Promise.resolve(breakingArticleRateLimiter.getRemainingSlots());
-   * ```
    */
-  getRemainingSlots(): number {
-    const { remaining } = this.canGenerateArticle();
+  async getRemainingSlots(): Promise<number> {
+    const { remaining } = await this.canGenerateArticle();
     return remaining;
   }
 
@@ -544,10 +490,9 @@ export class BreakingArticleRateLimiterService {
   }
 
   /**
-   * Reset the in-memory tracking (for testing purposes)
+   * Reset in-flight reservations (for testing purposes)
    */
   reset(): void {
-    this.breakingArticleTimestamps = [];
     this.reservations.clear();
   }
 }

--- a/packages/engine/src/services/event-generation-helpers.ts
+++ b/packages/engine/src/services/event-generation-helpers.ts
@@ -960,6 +960,7 @@ async function dbRecordArcEventCoverage(
 
 /**
  * Get arc event coverage statistics from the DB.
+ * Scoped to the last 30 days to avoid unbounded growth.
  */
 export async function getArcEventCoverageStats(): Promise<{
   totalEvents: number;
@@ -967,9 +968,11 @@ export async function getArcEventCoverageStats(): Promise<{
   eventIds: string[];
 }> {
   const rawDb = getRawDrizzle();
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   const rows = await rawDb
     .select({ eventId: arcEventCoverage.eventId })
-    .from(arcEventCoverage);
+    .from(arcEventCoverage)
+    .where(gte(arcEventCoverage.coveredAt, since));
 
   const eventIdSet = new Set(rows.map((r) => r.eventId));
   return {

--- a/packages/engine/src/services/event-generation-helpers.ts
+++ b/packages/engine/src/services/event-generation-helpers.ts
@@ -2,18 +2,19 @@ import {
   and,
   db,
   desc,
+  eq,
+  getRawDrizzle,
   gte,
   inArray,
   type Question,
+  sql,
   worldEvents,
 } from '@babylon/db';
+import { arcEventCoverage } from '@babylon/db/schema';
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import { ArticleGenerator } from '../ArticleGenerator';
 import type { BabylonLLMClient } from '../llm/openai-client';
-import {
-  type ArcEventStatus,
-  NewsArticlePacingEngine,
-} from '../NewsArticlePacingEngine';
+import type { ArcEventStatus } from '../NewsArticlePacingEngine';
 import { toDateString, toSafeDayNumber } from '../utils/date-utils';
 import { secureRandom, weightedPick } from '../utils/entropy';
 import { formatError } from '../utils/error-utils';
@@ -29,24 +30,6 @@ import {
   getSignalDirection,
 } from './narrative-state-service';
 import { StaticDataRegistry } from './static-data-registry';
-
-/**
- * Singleton pacing engine for arc event coverage tracking.
- *
- * @remarks
- * **In-memory only** - This singleton tracks which events have been covered
- * by which organizations to prevent duplicate articles. The state is NOT
- * persisted to the database and will be lost on:
- * - Server restart/redeploy
- * - Serverless cold start
- * - Process termination
- *
- * This is acceptable because:
- * 1. The article rate limiter (DB-backed) provides primary flood protection
- * 2. Occasional duplicate articles after restart are not harmful
- * 3. Most events are covered within the typical serverless warm period
- */
-const arcEventPacer = new NewsArticlePacingEngine();
 
 // Minimal question type for event generation (only fields actually used)
 // outcome is optional - only used for arc plan signal direction, and the code handles missing outcome
@@ -607,10 +590,10 @@ export async function generateArticlesForArcEvent(
     return 0;
   }
 
-  // Select orgs that haven't covered this event status yet
+  // Select orgs that haven't covered this event status yet (DB-backed)
   // Limit to remaining rate limit slots (not just max 2)
   const maxOrgsAllowed = Math.min(2, remaining);
-  const orgsToPublish = arcEventPacer.selectOrgsForArcEvent(
+  const orgsToPublish = await dbSelectOrgsForArcEvent(
     arcEventId,
     eventStatus,
     newsOrgs,
@@ -778,8 +761,8 @@ export async function generateArticlesForArcEvent(
 
       const articleId = persistResult.articleId;
 
-      // Record that this org has covered this event status
-      arcEventPacer.recordArcEventCoverage(
+      // Record that this org has covered this event status (DB-backed)
+      await dbRecordArcEventCoverage(
         arcEventId,
         org.id,
         eventStatus,
@@ -872,10 +855,10 @@ export async function maybeGenerateBreakingArticle(
 
   // Use reservation pattern to prevent race conditions:
   // Reserve a slot before generation, release if it fails
-  const reservationId = breakingArticleRateLimiter.tryReserveSlot();
+  const reservationId = await breakingArticleRateLimiter.tryReserveSlot();
   if (reservationId === null) {
     const { currentCount, maxAllowed } =
-      breakingArticleRateLimiter.canGenerateArticle();
+      await breakingArticleRateLimiter.canGenerateArticle();
     logger.debug(
       'Breaking article skipped - rate limit reached',
       { eventId, eventType, currentCount, maxAllowed },
@@ -923,61 +906,120 @@ export async function maybeGenerateBreakingArticle(
   }
 }
 
+// ---------------------------------------------------------------------------
+// DB-backed arc event coverage helpers (replaces in-memory arcEventPacer for arc events)
+// ---------------------------------------------------------------------------
+
 /**
- * Get arc event coverage statistics
+ * Select news orgs that have not yet covered `arcEventId` at `currentStatus`.
+ * DB-backed — survives restarts and serverless cold starts.
  */
-export function getArcEventCoverageStats() {
-  return arcEventPacer.getArcEventCoverageStats();
+async function dbSelectOrgsForArcEvent<T extends { id: string; name: string }>(
+  arcEventId: string,
+  currentStatus: ArcEventStatus,
+  availableOrgs: T[],
+  maxOrgs = 2
+): Promise<T[]> {
+  if (!arcEventId || availableOrgs.length === 0 || maxOrgs <= 0) return [];
+
+  const rawDb = getRawDrizzle();
+  const covered = await rawDb
+    .select({ orgId: arcEventCoverage.orgId })
+    .from(arcEventCoverage)
+    .where(
+      and(
+        eq(arcEventCoverage.eventId, arcEventId),
+        eq(arcEventCoverage.status, currentStatus)
+      )
+    );
+
+  const coveredOrgIds = new Set(covered.map((r) => r.orgId));
+  const eligible = availableOrgs.filter((o) => !coveredOrgIds.has(o.id));
+
+  // Shuffle and cap
+  const shuffled = eligible.slice().sort(() => secureRandom() - 0.5);
+  return shuffled.slice(0, maxOrgs);
+}
+
+/**
+ * Upsert a coverage record for (eventId, orgId, status).
+ * Duplicate inserts are silently ignored via ON CONFLICT DO NOTHING.
+ */
+async function dbRecordArcEventCoverage(
+  eventId: string,
+  orgId: string,
+  status: ArcEventStatus,
+  articleId: string
+): Promise<void> {
+  const rawDb = getRawDrizzle();
+  await rawDb
+    .insert(arcEventCoverage)
+    .values({ eventId, orgId, status, articleId })
+    .onConflictDoNothing();
+}
+
+/**
+ * Get arc event coverage statistics from the DB.
+ */
+export async function getArcEventCoverageStats(): Promise<{
+  totalEvents: number;
+  totalCoverage: number;
+  eventIds: string[];
+}> {
+  const rawDb = getRawDrizzle();
+  const rows = await rawDb
+    .select({ eventId: arcEventCoverage.eventId })
+    .from(arcEventCoverage);
+
+  const eventIdSet = new Set(rows.map((r) => r.eventId));
+  return {
+    totalEvents: eventIdSet.size,
+    totalCoverage: rows.length,
+    eventIds: Array.from(eventIdSet),
+  };
 }
 
 /**
  * Check if an event has already been covered by any organization at a specific status.
- * Uses the arcEventPacer to determine if the event has received coverage for the given status.
+ * DB-backed — survives restarts and serverless cold starts.
  *
  * @param eventId - The event/question ID to check
  * @param status - The status level to check (default: 'created')
  * @returns True if the event has been covered by at least one org at the specified status
- *
- * @remarks
- * **LIMITATION: In-memory tracking** - Event coverage tracking is stored in-memory
- * using a singleton `NewsArticlePacingEngine`. This means:
- * - Tracking is lost on server restart/redeploy (cold start)
- * - Multiple serverless instances don't share tracking state
- * - Occasional duplicate coverage is possible after deployments
- *
- * This is acceptable for our use case because:
- * 1. Duplicate articles occasionally are not harmful to user experience
- * 2. The article rate limiter provides the primary flood protection
- * 3. Events are typically covered within minutes, before most restarts
- *
- * For stricter duplicate prevention, consider DB-backed tracking with:
- * - A `covered_events` table with (eventId, orgId, status, articleId, timestamp)
- * - Query before generating to check existing coverage
  */
-export function hasEventBeenCovered(
+export async function hasEventBeenCovered(
   eventId: string,
   status: ArcEventStatus = 'created'
-): boolean {
-  // Check if any org has covered this event at the specified status
-  return arcEventPacer.hasEventBeenCoveredForStatus(eventId, status);
+): Promise<boolean> {
+  const rawDb = getRawDrizzle();
+  const result = await rawDb
+    .select({ cnt: sql<number>`count(*)::int` })
+    .from(arcEventCoverage)
+    .where(
+      and(
+        eq(arcEventCoverage.eventId, eventId),
+        eq(arcEventCoverage.status, status)
+      )
+    );
+  return (result[0]?.cnt ?? 0) > 0;
 }
 
 /**
- * Mark an event as covered by recording it in the pacer.
- * This prevents future duplicate coverage of the same event.
+ * Mark an event as covered by recording it in the DB.
+ * Survives restarts and serverless cold starts.
  *
  * @param eventId - The event/question ID that was covered
  * @param orgId - The organization that covered it
  * @param articleId - The generated article ID
  * @param status - The status at time of coverage (default: 'created')
  */
-export function markEventAsCovered(
+export async function markEventAsCovered(
   eventId: string,
   orgId: string,
   articleId: string,
   status: ArcEventStatus = 'created'
-): void {
-  arcEventPacer.recordArcEventCoverage(eventId, orgId, status, articleId);
+): Promise<void> {
+  await dbRecordArcEventCoverage(eventId, orgId, status, articleId);
 }
 
 /** @internal Exported for testing only */

--- a/packages/engine/src/services/npc-group-dynamics-service.ts
+++ b/packages/engine/src/services/npc-group-dynamics-service.ts
@@ -39,7 +39,12 @@ import {
   userInteractions,
   users,
 } from '@babylon/db';
-import { GROUP_CONFIG, generateSnowflakeId, logger } from '@babylon/shared';
+import {
+  GROUP_CONFIG,
+  generateSnowflakeId,
+  jaccardSimilarity,
+  logger,
+} from '@babylon/shared';
 import { NPC_GROUP_DYNAMICS_CONFIG } from '../config/npc-activity';
 import { BabylonLLMClient } from '../llm/openai-client';
 import { generateWorldContext, validateNoRealNames } from '../prompts';
@@ -805,30 +810,9 @@ Return your response as XML:
       );
       let tooSimilar = false;
       for (const recent of recentChatMsgs) {
-        const words1 = new Set(
-          messageContent
-            .toLowerCase()
-            .replace(/[^\w\s]/g, '')
-            .split(/\s+/)
-            .filter((w) => w.length > 3)
-        );
-        const words2 = new Set(
-          recent.content
-            .toLowerCase()
-            .replace(/[^\w\s]/g, '')
-            .split(/\s+/)
-            .filter((w) => w.length > 3)
-        );
-        if (words1.size > 0 && words2.size > 0) {
-          const intersection = new Set(
-            [...words1].filter((w) => words2.has(w))
-          );
-          const union = new Set([...words1, ...words2]);
-          const similarity = intersection.size / union.size;
-          if (similarity >= 0.5) {
-            tooSimilar = true;
-            break;
-          }
+        if (jaccardSimilarity(messageContent, recent.content) >= 0.5) {
+          tooSimilar = true;
+          break;
         }
       }
       if (tooSimilar) {

--- a/packages/engine/src/services/npc-group-dynamics-service.ts
+++ b/packages/engine/src/services/npc-group-dynamics-service.ts
@@ -781,6 +781,65 @@ Return your response as XML:
         continue;
       }
 
+      // Minimum length guard: reject one-word or very short messages
+      if (
+        messageContent.length < 20 ||
+        messageContent.trim().split(/\s+/).length < 3
+      ) {
+        logger.warn(
+          'NPC group message too short, skipping',
+          {
+            npcId: randomNpc.id,
+            length: messageContent.length,
+            message: messageContent,
+          },
+          'NPCGroupDynamicsService'
+        );
+        continue;
+      }
+
+      // Similarity guard: reject if too similar to any recent message in this chat (5-min window)
+      const recentChatWindow = new Date(Date.now() - 5 * 60 * 1000);
+      const recentChatMsgs = recentMsgs.filter(
+        (m) => m.createdAt >= recentChatWindow
+      );
+      let tooSimilar = false;
+      for (const recent of recentChatMsgs) {
+        const words1 = new Set(
+          messageContent
+            .toLowerCase()
+            .replace(/[^\w\s]/g, '')
+            .split(/\s+/)
+            .filter((w) => w.length > 3)
+        );
+        const words2 = new Set(
+          recent.content
+            .toLowerCase()
+            .replace(/[^\w\s]/g, '')
+            .split(/\s+/)
+            .filter((w) => w.length > 3)
+        );
+        if (words1.size > 0 && words2.size > 0) {
+          const intersection = new Set(
+            [...words1].filter((w) => words2.has(w))
+          );
+          const union = new Set([...words1, ...words2]);
+          const similarity = intersection.size / union.size;
+          if (similarity >= 0.5) {
+            tooSimilar = true;
+            break;
+          }
+        }
+      }
+      if (tooSimilar) {
+        logger.warn(
+          'NPC group message too similar to recent message, skipping',
+          { npcId: randomNpc.id, chatId: group.id },
+          'NPCGroupDynamicsService'
+        );
+        continue;
+      }
+
       // Create the message
       await db.insert(messages).values({
         id: await generateSnowflakeId(),

--- a/packages/engine/src/services/token-stats-service.ts
+++ b/packages/engine/src/services/token-stats-service.ts
@@ -125,7 +125,6 @@ class TickUsageCollector implements TokenUsageCollector {
       string,
       {
         provider: LLMProviderName;
-        provider: 'elizacloud' | 'groq' | 'claude' | 'openai';
         calls: LLMCallTokenUsage[];
         totalInput: number;
         totalOutput: number;

--- a/packages/engine/src/types/token-stats.ts
+++ b/packages/engine/src/types/token-stats.ts
@@ -15,8 +15,6 @@ export interface LLMCallTokenUsage {
   callId: string;
   /** Provider used (elizacloud, groq, claude, openai) */
   provider: LLMProviderName;
-  /** Provider used (groq, claude, openai) */
-  provider: 'elizacloud' | 'groq' | 'claude' | 'openai';
   /** Model used for the call */
   model: string;
   /** Number of input/prompt tokens */
@@ -67,7 +65,6 @@ export interface PromptTypeStats {
 export interface ModelStats {
   /** Provider */
   provider: LLMProviderName;
-  provider: 'elizacloud' | 'groq' | 'claude' | 'openai';
   /** Model name */
   model: string;
   /** Number of calls made */

--- a/packages/shared/src/utils/content-analysis.ts
+++ b/packages/shared/src/utils/content-analysis.ts
@@ -8,6 +8,44 @@
  */
 
 /**
+ * Compute Jaccard similarity between two text strings.
+ *
+ * Tokenizes each string into lowercase words longer than 3 characters,
+ * then returns |intersection| / |union|.  Returns 0 when either input
+ * produces an empty token set (very short strings).
+ *
+ * @param text1 - First text to compare
+ * @param text2 - Second text to compare
+ * @returns Similarity score in [0, 1]
+ *
+ * @example
+ * ```typescript
+ * jaccardSimilarity("hello world today", "hello world tomorrow"); // 0.5
+ * jaccardSimilarity("completely different", "nothing alike"); // 0
+ * ```
+ */
+export function jaccardSimilarity(text1: string, text2: string): number {
+  const tokenize = (t: string): Set<string> =>
+    new Set(
+      t
+        .toLowerCase()
+        .replace(/[^\w\s]/g, '')
+        .split(/\s+/)
+        .filter((w) => w.length > 3)
+    );
+
+  const words1 = tokenize(text1);
+  const words2 = tokenize(text2);
+
+  if (words1.size === 0 || words2.size === 0) return 0;
+
+  const intersection = new Set([...words1].filter((w) => words2.has(w)));
+  const union = new Set([...words1, ...words2]);
+
+  return intersection.size / union.size;
+}
+
+/**
  * Analyze certainty level in content
  *
  * Detects certainty markers (definitely, confirmed) and hedging words

--- a/packages/testing/integration/feed-health.integration.test.ts
+++ b/packages/testing/integration/feed-health.integration.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Feed Health Integration Tests
+ *
+ * Validates the feed health report and dedup guards using pure in-memory
+ * logic — no DB required. Simulates the same checks used by scripts/feed-health.ts
+ * and the cross-NPC dedup guard in DirectExecutors.
+ *
+ * NOTE: The arc event coverage and breaking article rate limiter now use DB queries.
+ * Those paths are tested via the unit tests in feed-dedup.test.ts (logic layer)
+ * and would be validated with a live DB in E2E / manual testing.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Helpers — mirror the feed-health.ts logic exactly
+// ---------------------------------------------------------------------------
+
+function jaccardSimilarity(content1: string, content2: string): number {
+  const words1 = new Set(
+    content1
+      .toLowerCase()
+      .replace(/[^\w\s]/g, '')
+      .split(/\s+/)
+      .filter((w) => w.length > 3)
+  );
+  const words2 = new Set(
+    content2
+      .toLowerCase()
+      .replace(/[^\w\s]/g, '')
+      .split(/\s+/)
+      .filter((w) => w.length > 3)
+  );
+  if (words1.size === 0 || words2.size === 0) return 0;
+  const intersection = new Set([...words1].filter((w) => words2.has(w)));
+  const union = new Set([...words1, ...words2]);
+  return intersection.size / union.size;
+}
+
+function firstNWords(text: string, n: number): string {
+  return text
+    .trim()
+    .split(/\s+/)
+    .slice(0, n)
+    .join(' ')
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, '');
+}
+
+interface Post {
+  id: string;
+  content: string;
+  authorId: string;
+  type: string;
+  timestamp: Date;
+}
+
+function detectExactDupes(
+  posts: Post[],
+  windowMs: number
+): Array<{ content: string; count: number; authors: string[] }> {
+  const windowStart = new Date(Date.now() - windowMs);
+  const recent = posts.filter((p) => p.timestamp >= windowStart);
+  const contentMap = new Map<string, { count: number; authors: string[] }>();
+
+  for (const p of recent) {
+    const key = p.content.trim().toLowerCase();
+    const entry = contentMap.get(key) ?? { count: 0, authors: [] };
+    entry.count++;
+    if (!entry.authors.includes(p.authorId)) entry.authors.push(p.authorId);
+    contentMap.set(key, entry);
+  }
+
+  return Array.from(contentMap.entries())
+    .filter(([, v]) => v.count > 1)
+    .map(([content, v]) => ({ content, ...v }));
+}
+
+function detectFirstWordsDupes(
+  posts: Post[],
+  windowMs: number,
+  n = 8
+): Array<{ prefix: string; count: number; authors: string[] }> {
+  const windowStart = new Date(Date.now() - windowMs);
+  const recent = posts.filter((p) => p.timestamp >= windowStart);
+  const prefixMap = new Map<string, { count: number; authors: string[] }>();
+
+  for (const p of recent) {
+    const prefix = firstNWords(p.content, n);
+    if (prefix.split(' ').length < 4) continue;
+    const entry = prefixMap.get(prefix) ?? { count: 0, authors: [] };
+    entry.count++;
+    if (!entry.authors.includes(p.authorId)) entry.authors.push(p.authorId);
+    prefixMap.set(prefix, entry);
+  }
+
+  return Array.from(prefixMap.entries())
+    .filter(([, v]) => v.count > 1 && v.authors.length > 1)
+    .map(([prefix, v]) => ({ prefix, ...v }));
+}
+
+function detectArticleFlood(
+  posts: Post[],
+  windowHours: number,
+  maxPerHour: number
+): Array<{ hour: string; count: number; isFlood: boolean }> {
+  const now = Date.now();
+  const buckets: Array<{ hour: string; count: number; isFlood: boolean }> = [];
+
+  for (let h = 0; h < windowHours; h++) {
+    const bucketStart = new Date(now - (h + 1) * 3600_000);
+    const bucketEnd = new Date(now - h * 3600_000);
+    const count = posts.filter(
+      (p) =>
+        p.type === 'article' &&
+        p.timestamp >= bucketStart &&
+        p.timestamp < bucketEnd
+    ).length;
+    buckets.unshift({
+      hour: bucketStart.toISOString().slice(0, 13),
+      count,
+      isFlood: count > maxPerHour,
+    });
+  }
+  return buckets;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Exact duplicate detection
+// ---------------------------------------------------------------------------
+describe('feed health — exact duplicate detection', () => {
+  const base = new Date(Date.now() - 5 * 60_000); // 5 min ago
+
+  test('no duplicates when all content is unique', () => {
+    const posts: Post[] = [
+      {
+        id: '1',
+        content: 'Bitcoin surges to new highs',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: base,
+      },
+      {
+        id: '2',
+        content: 'Federal reserve holds rates steady',
+        authorId: 'npc-b',
+        type: 'post',
+        timestamp: base,
+      },
+    ];
+    expect(detectExactDupes(posts, 60 * 60_000)).toHaveLength(0);
+  });
+
+  test('detects exact duplicate from two different NPCs', () => {
+    const posts: Post[] = [
+      {
+        id: '1',
+        content: 'Bitcoin hits 100k',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: base,
+      },
+      {
+        id: '2',
+        content: 'Bitcoin hits 100k',
+        authorId: 'npc-b',
+        type: 'post',
+        timestamp: base,
+      },
+    ];
+    const dupes = detectExactDupes(posts, 60 * 60_000);
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0]?.count).toBe(2);
+    expect(dupes[0]?.authors).toContain('npc-a');
+    expect(dupes[0]?.authors).toContain('npc-b');
+  });
+
+  test('ignores posts outside time window', () => {
+    const old = new Date(Date.now() - 2 * 60 * 60_000); // 2h ago
+    const posts: Post[] = [
+      {
+        id: '1',
+        content: 'Old duplicate post content here',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: old,
+      },
+      {
+        id: '2',
+        content: 'Old duplicate post content here',
+        authorId: 'npc-b',
+        type: 'post',
+        timestamp: old,
+      },
+    ];
+    // Window is only 30 min
+    expect(detectExactDupes(posts, 30 * 60_000)).toHaveLength(0);
+  });
+
+  test('same author posting same content twice is flagged', () => {
+    const posts: Post[] = [
+      {
+        id: '1',
+        content: 'Interesting development in markets today',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: base,
+      },
+      {
+        id: '2',
+        content: 'Interesting development in markets today',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: base,
+      },
+    ];
+    const dupes = detectExactDupes(posts, 60 * 60_000);
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0]?.count).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. First-N-words near-dupe detection
+// ---------------------------------------------------------------------------
+describe('feed health — first-N-words near-dupe detection', () => {
+  const base = new Date(Date.now() - 5 * 60_000);
+
+  test('catches near-duplicates across different authors', () => {
+    const posts: Post[] = [
+      {
+        id: '1',
+        content:
+          'Babylon social platform launches exciting prediction markets feature today',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: base,
+      },
+      {
+        id: '2',
+        content:
+          'Babylon social platform launches exciting prediction markets feature now',
+        authorId: 'npc-b',
+        type: 'post',
+        timestamp: base,
+      },
+    ];
+    const dupes = detectFirstWordsDupes(posts, 30 * 60_000, 8);
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0]?.authors).toContain('npc-a');
+    expect(dupes[0]?.authors).toContain('npc-b');
+  });
+
+  test('does NOT flag same prefix from same author', () => {
+    const posts: Post[] = [
+      {
+        id: '1',
+        content:
+          'Babylon social platform launches exciting prediction markets today',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: base,
+      },
+      {
+        id: '2',
+        content:
+          'Babylon social platform launches exciting prediction markets now',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: base,
+      },
+    ];
+    // Same author — first-words dedup requires authors.length > 1
+    const dupes = detectFirstWordsDupes(posts, 30 * 60_000, 8);
+    expect(dupes).toHaveLength(0);
+  });
+
+  test('ignores very short prefixes (< 4 words)', () => {
+    const posts: Post[] = [
+      {
+        id: '1',
+        content: 'ok good',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: base,
+      },
+      {
+        id: '2',
+        content: 'ok good',
+        authorId: 'npc-b',
+        type: 'post',
+        timestamp: base,
+      },
+    ];
+    const dupes = detectFirstWordsDupes(posts, 30 * 60_000, 8);
+    expect(dupes).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Article flood detection
+// ---------------------------------------------------------------------------
+describe('feed health — article flood detection', () => {
+  test('flags hour with more than maxPerHour articles', () => {
+    const now = Date.now();
+    const posts: Post[] = Array.from({ length: 8 }, (_, i) => ({
+      id: `art-${i}`,
+      content: `Article ${i} content here`,
+      authorId: 'org-media',
+      type: 'article',
+      timestamp: new Date(now - 30 * 60_000), // 30 min ago (in current bucket)
+    }));
+
+    const buckets = detectArticleFlood(posts, 1, 6);
+    expect(buckets[0]?.isFlood).toBe(true);
+    expect(buckets[0]?.count).toBe(8);
+  });
+
+  test('does not flag hour within limit', () => {
+    const now = Date.now();
+    const posts: Post[] = Array.from({ length: 2 }, (_, i) => ({
+      id: `art-${i}`,
+      content: `Article ${i}`,
+      authorId: 'org-media',
+      type: 'article',
+      timestamp: new Date(now - 30 * 60_000),
+    }));
+
+    const buckets = detectArticleFlood(posts, 1, 6);
+    expect(buckets[0]?.isFlood).toBe(false);
+  });
+
+  test('only counts article type posts', () => {
+    const now = Date.now();
+    const posts: Post[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `p-${i}`,
+      content: `Post ${i} content here`,
+      authorId: 'npc-a',
+      type: 'post', // NOT article
+      timestamp: new Date(now - 30 * 60_000),
+    }));
+
+    const buckets = detectArticleFlood(posts, 1, 6);
+    expect(buckets[0]?.count).toBe(0);
+    expect(buckets[0]?.isFlood).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Cross-NPC dedup guard (mirrors DirectExecutors logic)
+// ---------------------------------------------------------------------------
+describe('cross-NPC dedup guard (integration)', () => {
+  const THRESHOLD = 0.5;
+
+  function wouldBeBlocked(newContent: string, recentPosts: Post[]): boolean {
+    for (const p of recentPosts) {
+      const sim = jaccardSimilarity(newContent, p.content);
+      if (sim >= THRESHOLD) return true;
+    }
+    return false;
+  }
+
+  test('first NPC to post a topic is always allowed', () => {
+    const recent: Post[] = [];
+    const newContent =
+      'Federal Reserve announces surprise rate cut of fifty basis points today';
+    expect(wouldBeBlocked(newContent, recent)).toBe(false);
+  });
+
+  test('second NPC posting near-identical content is blocked', () => {
+    const recent: Post[] = [
+      {
+        id: '1',
+        content:
+          'Federal Reserve announces surprise rate cut of fifty basis points today',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: new Date(),
+      },
+    ];
+    const newContent =
+      'Federal Reserve announces surprise rate cut of fifty basis points today';
+    expect(wouldBeBlocked(newContent, recent)).toBe(true);
+  });
+
+  test('NPC posting about a completely different topic is allowed', () => {
+    const recent: Post[] = [
+      {
+        id: '1',
+        content:
+          'Federal Reserve announces surprise rate cut of fifty basis points today',
+        authorId: 'npc-a',
+        type: 'post',
+        timestamp: new Date(),
+      },
+    ];
+    const newContent =
+      'Scientists discover massive undersea volcano erupting near Pacific coast';
+    expect(wouldBeBlocked(newContent, recent)).toBe(false);
+  });
+});

--- a/packages/testing/unit/cron/article-tick.test.ts
+++ b/packages/testing/unit/cron/article-tick.test.ts
@@ -316,9 +316,9 @@ const registerMocks = () => {
       }
     },
     getActiveEventsForPosting: async () => ({ activeEvents: [] }),
-    hasEventBeenCovered: (eventId: string) =>
+    hasEventBeenCovered: async (eventId: string) =>
       cronMockState.articleCoveredEventIds.has(eventId),
-    markEventAsCovered: (eventId: string) => {
+    markEventAsCovered: async (eventId: string) => {
       cronMockState.articleCoveredEventIds.add(eventId);
     },
     persistArticle: async (input: { id: string }) => ({

--- a/packages/testing/unit/cron/markets-tick.test.ts
+++ b/packages/testing/unit/cron/markets-tick.test.ts
@@ -437,9 +437,9 @@ const registerMocks = () => {
       }
     },
     getActiveEventsForPosting: async () => ({ activeEvents: [] }),
-    hasEventBeenCovered: (eventId: string) =>
+    hasEventBeenCovered: async (eventId: string) =>
       cronMockState.articleCoveredEventIds.has(eventId),
-    markEventAsCovered: (eventId: string) => {
+    markEventAsCovered: async (eventId: string) => {
       cronMockState.articleCoveredEventIds.add(eventId);
     },
     persistArticle: async (input: { id: string }) => ({

--- a/packages/testing/unit/feed-dedup.test.ts
+++ b/packages/testing/unit/feed-dedup.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Feed Dedup Unit Tests
+ *
+ * Tests for:
+ * 1. Jaccard similarity function (same logic as TopicDiversityService.calculateSimilarity)
+ * 2. Cross-NPC dedup guard logic (mirrors executeDirectPost check)
+ * 3. Group chat message quality guards (length + similarity)
+ * 4. Arc event coverage helpers (DB-backed hasEventBeenCovered / markEventAsCovered)
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// 1. Jaccard similarity (extracted for isolated testing)
+// ---------------------------------------------------------------------------
+
+function jaccardSimilarity(content1: string, content2: string): number {
+  const words1 = new Set(
+    content1
+      .toLowerCase()
+      .replace(/[^\w\s]/g, '')
+      .split(/\s+/)
+      .filter((w) => w.length > 3)
+  );
+  const words2 = new Set(
+    content2
+      .toLowerCase()
+      .replace(/[^\w\s]/g, '')
+      .split(/\s+/)
+      .filter((w) => w.length > 3)
+  );
+
+  if (words1.size === 0 || words2.size === 0) return 0;
+
+  const intersection = new Set([...words1].filter((w) => words2.has(w)));
+  const union = new Set([...words1, ...words2]);
+
+  return intersection.size / union.size;
+}
+
+describe('jaccardSimilarity', () => {
+  test('identical text returns 1.0', () => {
+    const text = 'Bitcoin prices surge as market optimism returns';
+    expect(jaccardSimilarity(text, text)).toBe(1);
+  });
+
+  test('completely different text returns 0', () => {
+    const a = 'The president announces new trade policy tomorrow';
+    const b = 'Scientists discover massive volcanic eruption on Jupiter';
+    expect(jaccardSimilarity(a, b)).toBeLessThan(0.1);
+  });
+
+  test('high overlap returns >= 0.5', () => {
+    const a = 'Babylon social platform launches new prediction markets feature';
+    const b =
+      'Babylon platform launches social prediction markets feature today';
+    expect(jaccardSimilarity(a, b)).toBeGreaterThanOrEqual(0.5);
+  });
+
+  test('short words (<=3 chars) are ignored', () => {
+    // All meaningful words are <= 3 chars — filter removes them, leaving empty set → similarity 0
+    const a = 'to be or not to be the way and but for';
+    const b = 'some very long words that should matter here clearly';
+    expect(jaccardSimilarity(a, b)).toBe(0);
+  });
+
+  test('empty strings return 0', () => {
+    expect(jaccardSimilarity('', 'something important')).toBe(0);
+    expect(jaccardSimilarity('something important', '')).toBe(0);
+  });
+
+  test('partial overlap returns intermediate value', () => {
+    const a =
+      'market rally crypto bitcoin ethereum blockchain technology surge';
+    const b =
+      'market correction stock bitcoin decline traditional finance sector';
+    const sim = jaccardSimilarity(a, b);
+    expect(sim).toBeGreaterThan(0);
+    expect(sim).toBeLessThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Cross-NPC dedup guard logic
+// ---------------------------------------------------------------------------
+
+const CROSS_NPC_THRESHOLD = 0.5;
+
+function crossNpcDedupCheck(
+  newContent: string,
+  recentContents: string[]
+): { isDuplicate: boolean; similarity: number } {
+  for (const recent of recentContents) {
+    const sim = jaccardSimilarity(newContent, recent);
+    if (sim >= CROSS_NPC_THRESHOLD) {
+      return { isDuplicate: true, similarity: sim };
+    }
+  }
+  return { isDuplicate: false, similarity: 0 };
+}
+
+describe('cross-NPC dedup guard', () => {
+  test('allows unique post when no similar recent content', () => {
+    const recent = [
+      'Scientists confirm breakthrough in quantum computing field',
+      'Sports league announces expansion to three new cities',
+    ];
+    const newPost =
+      'Political debate heats up over infrastructure spending bill';
+    const result = crossNpcDedupCheck(newPost, recent);
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  test('blocks near-identical post from different NPC', () => {
+    const recent = [
+      'Bitcoin prices surge as market optimism returns strongly today',
+    ];
+    const newPost = 'Bitcoin prices surge as market optimism returns today';
+    const result = crossNpcDedupCheck(newPost, recent);
+    expect(result.isDuplicate).toBe(true);
+    expect(result.similarity).toBeGreaterThanOrEqual(CROSS_NPC_THRESHOLD);
+  });
+
+  test('allows post when similarity is just below threshold', () => {
+    const recent = [
+      'The Federal Reserve increases interest rates by half a percentage point',
+    ];
+    const newPost =
+      'Markets react to Federal Reserve decision on interest rates today';
+    const result = crossNpcDedupCheck(newPost, recent);
+    // Should be below 0.5 (overlapping only on "Federal", "Reserve", "interest", "rates")
+    expect(result.isDuplicate).toBe(result.similarity >= CROSS_NPC_THRESHOLD);
+  });
+
+  test('empty recent list always allows', () => {
+    const result = crossNpcDedupCheck('any content here matters a lot', []);
+    expect(result.isDuplicate).toBe(false);
+  });
+
+  test('checks all recent posts, blocks if ANY exceeds threshold', () => {
+    const recent = [
+      'Unrelated science content about biology research',
+      'Bitcoin prices surge as market optimism returns strongly today',
+      'Another unrelated story about sports events',
+    ];
+    const newPost = 'Bitcoin prices surge as market optimism returns today';
+    const result = crossNpcDedupCheck(newPost, recent);
+    expect(result.isDuplicate).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Group chat message quality guards
+// ---------------------------------------------------------------------------
+
+const GROUP_MSG_MIN_CHARS = 20;
+const GROUP_MSG_MIN_WORDS = 3;
+const GROUP_MSG_SIMILARITY_THRESHOLD = 0.5;
+
+function validateGroupMessage(
+  content: string,
+  recentMessages: string[]
+): { valid: boolean; reason?: string } {
+  if (content.length < GROUP_MSG_MIN_CHARS) {
+    return {
+      valid: false,
+      reason: `too short (${content.length} < ${GROUP_MSG_MIN_CHARS} chars)`,
+    };
+  }
+  if (content.trim().split(/\s+/).length < GROUP_MSG_MIN_WORDS) {
+    return { valid: false, reason: 'too few words' };
+  }
+  for (const recent of recentMessages) {
+    const sim = jaccardSimilarity(content, recent);
+    if (sim >= GROUP_MSG_SIMILARITY_THRESHOLD) {
+      return {
+        valid: false,
+        reason: `too similar to recent message (${(sim * 100).toFixed(0)}%)`,
+      };
+    }
+  }
+  return { valid: true };
+}
+
+describe('group chat message quality guards', () => {
+  test('rejects message under 20 chars', () => {
+    const result = validateGroupMessage('ok', []);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('too short');
+  });
+
+  test('rejects single-word message even if long chars', () => {
+    const result = validateGroupMessage('cryptocurrency', []);
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects two-word message under min_words', () => {
+    // "market crash" has only 12 chars → fails min length check (< 20)
+    const result2 = validateGroupMessage('market crash', []);
+    expect(result2.valid).toBe(false);
+    // "market is crashing everywhere now" has 5 words and > 20 chars → should pass
+    const result = validateGroupMessage(
+      'market is crashing everywhere now',
+      []
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  test('rejects message too similar to recent chat message', () => {
+    const recent = ['Bitcoin markets surge as crypto optimism grows today'];
+    const newMsg = 'Bitcoin markets surge as crypto optimism grows today again';
+    const result = validateGroupMessage(newMsg, recent);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain('similar');
+  });
+
+  test('accepts quality message with no overlap', () => {
+    const recent = ['Federal reserve raises rates unexpectedly this morning'];
+    const newMsg =
+      'Scientists discover new method to predict volcanic eruptions with high accuracy';
+    const result = validateGroupMessage(newMsg, recent);
+    expect(result.valid).toBe(true);
+  });
+
+  test('accepts quality message even with some overlap below threshold', () => {
+    const recent = [
+      'Markets are showing signs of recovery after recent volatility',
+    ];
+    const newMsg =
+      'Markets seem stable today despite global economic uncertainty and concerns';
+    const result = validateGroupMessage(newMsg, recent);
+    // "markets" overlaps but similarity should be well below 0.5
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Arc event coverage — pure logic tests (no DB needed)
+// ---------------------------------------------------------------------------
+
+// Simulate DB-backed coverage as a simple in-memory Map for testing the logic
+
+type ArcEventStatus = 'created' | 'breaking' | 'commentary' | 'resolution';
+
+class TestArcCoverageStore {
+  private records = new Map<string, Set<string>>();
+
+  private key(eventId: string, orgId: string, status: string): string {
+    return `${eventId}:${orgId}:${status}`;
+  }
+
+  async markCovered(
+    eventId: string,
+    orgId: string,
+    status: ArcEventStatus
+  ): Promise<void> {
+    const k = this.key(eventId, orgId, status);
+    if (!this.records.has(k)) {
+      this.records.set(k, new Set());
+    }
+  }
+
+  async hasAnyCoverage(
+    eventId: string,
+    status: ArcEventStatus
+  ): Promise<boolean> {
+    for (const k of this.records.keys()) {
+      if (k.startsWith(`${eventId}:`) && k.endsWith(`:${status}`)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  async selectEligibleOrgs<T extends { id: string }>(
+    eventId: string,
+    status: ArcEventStatus,
+    orgs: T[]
+  ): Promise<T[]> {
+    const covered = new Set<string>();
+    for (const k of this.records.keys()) {
+      const [eid, orgId, st] = k.split(':');
+      if (eid === eventId && st === status && orgId) {
+        covered.add(orgId);
+      }
+    }
+    return orgs.filter((o) => !covered.has(o.id));
+  }
+
+  reset(): void {
+    this.records.clear();
+  }
+}
+
+describe('arc event coverage (DB-backed logic)', () => {
+  const store = new TestArcCoverageStore();
+  const orgs = [
+    { id: 'cnn', name: 'CNN' },
+    { id: 'bbc', name: 'BBC' },
+    { id: 'abc', name: 'ABC' },
+  ];
+
+  test('no coverage initially → hasAnyCoverage returns false', async () => {
+    store.reset();
+    expect(await store.hasAnyCoverage('arc-1', 'created')).toBe(false);
+  });
+
+  test('after marking, hasAnyCoverage returns true', async () => {
+    store.reset();
+    await store.markCovered('arc-1', 'cnn', 'created');
+    expect(await store.hasAnyCoverage('arc-1', 'created')).toBe(true);
+  });
+
+  test('coverage for one status does not affect another', async () => {
+    store.reset();
+    await store.markCovered('arc-1', 'cnn', 'created');
+    expect(await store.hasAnyCoverage('arc-1', 'breaking')).toBe(false);
+  });
+
+  test('covered org is excluded from eligible orgs', async () => {
+    store.reset();
+    await store.markCovered('arc-1', 'cnn', 'created');
+    const eligible = await store.selectEligibleOrgs('arc-1', 'created', orgs);
+    expect(eligible.map((o) => o.id)).not.toContain('cnn');
+    expect(eligible.length).toBe(2);
+  });
+
+  test('all orgs eligible when no coverage', async () => {
+    store.reset();
+    const eligible = await store.selectEligibleOrgs('arc-2', 'created', orgs);
+    expect(eligible.length).toBe(3);
+  });
+
+  test('duplicate marks for same org/event/status are idempotent', async () => {
+    store.reset();
+    await store.markCovered('arc-1', 'cnn', 'created');
+    await store.markCovered('arc-1', 'cnn', 'created'); // duplicate
+    const eligible = await store.selectEligibleOrgs('arc-1', 'created', orgs);
+    // Should still only exclude cnn once
+    expect(eligible.length).toBe(2);
+  });
+
+  test('coverage is per-event — different events are independent', async () => {
+    store.reset();
+    await store.markCovered('arc-1', 'cnn', 'created');
+    expect(await store.hasAnyCoverage('arc-2', 'created')).toBe(false);
+    const eligible = await store.selectEligibleOrgs('arc-2', 'created', orgs);
+    expect(eligible.length).toBe(3);
+  });
+});

--- a/scripts/feed-health.ts
+++ b/scripts/feed-health.ts
@@ -1,0 +1,624 @@
+#!/usr/bin/env bun
+
+/**
+ * Feed Health Report
+ *
+ * Direct-DB snapshot of feed content quality, duplicate detection, NPC post
+ * distribution, article health, group chat quality, and staleness.
+ * No server required — reads live DB state and flags problems instantly.
+ *
+ * Usage:
+ *   bun run report:feed
+ *   bun run report:feed -- --json
+ *   bun run report:feed -- --hours=6   (narrow window, default 24)
+ */
+
+import { parseArgs } from 'node:util';
+import { getRawDrizzle } from '@babylon/db';
+import { chats, messages, posts } from '@babylon/db/schema';
+import { getAllActors, getAllOrganizations } from '@babylon/engine';
+import { and, desc, gte, isNull, sql } from 'drizzle-orm';
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+const { values: args } = parseArgs({
+  options: {
+    json: { type: 'boolean', default: false },
+    hours: { type: 'string', default: '24' },
+  },
+  strict: false,
+});
+
+const outputJson = args.json ?? false;
+const windowHours = Math.max(1, Number.parseInt(args.hours ?? '24', 10));
+
+// ---------------------------------------------------------------------------
+// Thresholds
+// ---------------------------------------------------------------------------
+const STALE_NPC_POST_MIN = 30; // no NPC post in this many minutes → STALE
+const STALE_ORG_POST_MIN = 15; // no org post in this many minutes → STALE
+const ARTICLES_PER_HOUR_WARN = 6; // more than this per hour → flood
+const GROUP_MSG_PER_HOUR_WARN = 20; // more than this per chat/hour → flood
+const GROUP_MSG_MIN_CHARS = 20; // below this → too short
+const NPC_FLOOD_WARN = 6; // NPC posting more than this in window → flood
+const ORG_FLOOD_WARN = 10; // org posting more than this in window → flood
+const EXACT_DUPE_WINDOW_MIN = 60; // look for exact dupes within this window
+const FIRST_WORDS_DUPE_WINDOW_MIN = 30; // look for first-N-word dupes
+const FIRST_WORDS_N = 8; // words to compare for near-dupe check
+const SAME_AUTHOR_DUPE_WINDOW_MIN = 30; // same author near-dupe window
+
+// ---------------------------------------------------------------------------
+// Color helpers
+// ---------------------------------------------------------------------------
+const reset = '\x1b[0m';
+const bold = '\x1b[1m';
+const red = '\x1b[31m';
+const yellow = '\x1b[33m';
+const green = '\x1b[32m';
+const cyan = '\x1b[36m';
+const dim = '\x1b[2m';
+
+const OK = `${green}[OK]  ${reset}`;
+const WARN = `${yellow}[WARN]${reset}`;
+const ERR = `${red}[ERR] ${reset}`;
+
+function ago(d: Date): string {
+  const mins = Math.round((Date.now() - d.getTime()) / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  return `${Math.floor(mins / 60)}h${mins % 60}m ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Types for JSON output
+// ---------------------------------------------------------------------------
+interface FeedHealthReport {
+  generatedAt: string;
+  windowHours: number;
+  distribution: DistributionSection;
+  duplicates: DuplicateSection;
+  articles: ArticleSection;
+  groupChats: GroupChatSection;
+  staleness: StalenessSection;
+}
+
+interface DistributionSection {
+  totalPosts: number;
+  byType: Record<string, number>;
+  byCategory: Record<string, number>;
+  npcTopPosters: Array<{ id: string; count: number; flags: string[] }>;
+  orgTopPosters: Array<{ id: string; count: number; flags: string[] }>;
+}
+
+interface DuplicateSection {
+  exactDupes: Array<{ content: string; count: number; authors: string[] }>;
+  firstWordsDupes: Array<{
+    prefix: string;
+    count: number;
+    authors: string[];
+  }>;
+  sameAuthorNearDupes: Array<{
+    authorId: string;
+    content1: string;
+    content2: string;
+    windowMin: number;
+  }>;
+  warnings: number;
+}
+
+interface ArticleSection {
+  totalArticles: number;
+  hourlyBuckets: Array<{ hour: string; count: number; flags: string[] }>;
+  warnings: number;
+}
+
+interface GroupChatSection {
+  totalGroupChats: number;
+  recentMessages: number;
+  shortMessages: Array<{ chatId: string; senderId: string; content: string }>;
+  floodedChats: Array<{ chatId: string; msgsPerHour: number }>;
+  warnings: number;
+}
+
+interface StalenessSection {
+  lastNpcPostAt: string | null;
+  lastOrgPostAt: string | null;
+  lastArticleAt: string | null;
+  npcStale: boolean;
+  orgStale: boolean;
+  warnings: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function firstNWords(text: string, n: number): string {
+  return text
+    .trim()
+    .split(/\s+/)
+    .slice(0, n)
+    .join(' ')
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, '');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function run(): Promise<FeedHealthReport> {
+  const db = getRawDrizzle();
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - windowHours * 60 * 60 * 1000);
+  const exactDupeStart = new Date(
+    now.getTime() - EXACT_DUPE_WINDOW_MIN * 60 * 1000
+  );
+  const firstWordsDupeStart = new Date(
+    now.getTime() - FIRST_WORDS_DUPE_WINDOW_MIN * 60 * 1000
+  );
+  const sameAuthorDupeStart = new Date(
+    now.getTime() - SAME_AUTHOR_DUPE_WINDOW_MIN * 60 * 1000
+  );
+
+  // Load actor / org sets for categorization
+  const allActors = getAllActors();
+  const allOrgs = getAllOrganizations();
+  const npcIds = new Set(allActors.map((a) => a.id));
+  const orgIds = new Set(allOrgs.map((o) => o.id));
+
+  // -------------------------------------------------------------------------
+  // 1. Raw post query for window
+  // -------------------------------------------------------------------------
+  const rawPosts = await db
+    .select({
+      id: posts.id,
+      content: posts.content,
+      authorId: posts.authorId,
+      type: posts.type,
+      timestamp: posts.timestamp,
+      commentOnPostId: posts.commentOnPostId,
+      parentCommentId: posts.parentCommentId,
+    })
+    .from(posts)
+    .where(
+      and(
+        gte(posts.timestamp, windowStart),
+        isNull(posts.deletedAt),
+        isNull(posts.commentOnPostId),
+        isNull(posts.parentCommentId)
+      )
+    )
+    .orderBy(desc(posts.timestamp));
+
+  // -------------------------------------------------------------------------
+  // 2. Distribution
+  // -------------------------------------------------------------------------
+  const byType: Record<string, number> = {};
+  const byCategory: Record<string, number> = {
+    npc: 0,
+    org: 0,
+    user: 0,
+    agent: 0,
+    unknown: 0,
+  };
+  const postsByNpc: Record<string, number> = {};
+  const postsByOrg: Record<string, number> = {};
+
+  for (const p of rawPosts) {
+    byType[p.type] = (byType[p.type] ?? 0) + 1;
+    if (npcIds.has(p.authorId)) {
+      byCategory.npc++;
+      postsByNpc[p.authorId] = (postsByNpc[p.authorId] ?? 0) + 1;
+    } else if (orgIds.has(p.authorId)) {
+      byCategory.org++;
+      postsByOrg[p.authorId] = (postsByOrg[p.authorId] ?? 0) + 1;
+    } else {
+      byCategory.unknown++;
+    }
+  }
+
+  const npcTopPosters = Object.entries(postsByNpc)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([id, count]) => ({
+      id,
+      count,
+      flags: count > NPC_FLOOD_WARN ? ['FLOOD'] : [],
+    }));
+
+  const orgTopPosters = Object.entries(postsByOrg)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([id, count]) => ({
+      id,
+      count,
+      flags: count > ORG_FLOOD_WARN ? ['FLOOD'] : [],
+    }));
+
+  // -------------------------------------------------------------------------
+  // 3. Duplicate detection
+  // -------------------------------------------------------------------------
+
+  // 3a. Exact duplicate content in window
+  const recentForDupeCheck = rawPosts.filter(
+    (p) => p.timestamp >= exactDupeStart
+  );
+  const contentMap: Record<string, { count: number; authors: string[] }> = {};
+  for (const p of recentForDupeCheck) {
+    const key = p.content.trim().toLowerCase();
+    if (!contentMap[key]) {
+      contentMap[key] = { count: 0, authors: [] };
+    }
+    contentMap[key].count++;
+    if (!contentMap[key].authors.includes(p.authorId)) {
+      contentMap[key].authors.push(p.authorId);
+    }
+  }
+  const exactDupes = Object.entries(contentMap)
+    .filter(([, v]) => v.count > 1)
+    .map(([content, v]) => ({
+      content: content.slice(0, 80) + (content.length > 80 ? '…' : ''),
+      count: v.count,
+      authors: v.authors,
+    }));
+
+  // 3b. First-N-words near-dupes across different authors in short window
+  const recentForFirstWords = rawPosts.filter(
+    (p) => p.timestamp >= firstWordsDupeStart
+  );
+  const prefixMap: Record<string, { count: number; authors: string[] }> = {};
+  for (const p of recentForFirstWords) {
+    const prefix = firstNWords(p.content, FIRST_WORDS_N);
+    if (prefix.split(' ').length < 4) continue; // too short to be meaningful
+    if (!prefixMap[prefix]) {
+      prefixMap[prefix] = { count: 0, authors: [] };
+    }
+    prefixMap[prefix].count++;
+    if (!prefixMap[prefix].authors.includes(p.authorId)) {
+      prefixMap[prefix].authors.push(p.authorId);
+    }
+  }
+  const firstWordsDupes = Object.entries(prefixMap)
+    .filter(([, v]) => v.count > 1 && v.authors.length > 1)
+    .map(([prefix, v]) => ({ prefix, count: v.count, authors: v.authors }));
+
+  // 3c. Same-author near-dupes (first N words match, within time window)
+  const recentForSameAuthor = rawPosts.filter(
+    (p) => p.timestamp >= sameAuthorDupeStart
+  );
+  const authorPrefixMap: Record<
+    string,
+    Array<{ prefix: string; content: string }>
+  > = {};
+  for (const p of recentForSameAuthor) {
+    const prefix = firstNWords(p.content, FIRST_WORDS_N);
+    if (!authorPrefixMap[p.authorId]) {
+      authorPrefixMap[p.authorId] = [];
+    }
+    authorPrefixMap[p.authorId].push({ prefix, content: p.content });
+  }
+  const sameAuthorNearDupes: DuplicateSection['sameAuthorNearDupes'] = [];
+  for (const [authorId, items] of Object.entries(authorPrefixMap)) {
+    const seen = new Map<string, string>();
+    for (const item of items) {
+      if (seen.has(item.prefix)) {
+        sameAuthorNearDupes.push({
+          authorId,
+          content1: (seen.get(item.prefix) ?? '').slice(0, 80),
+          content2: item.content.slice(0, 80),
+          windowMin: SAME_AUTHOR_DUPE_WINDOW_MIN,
+        });
+      } else {
+        seen.set(item.prefix, item.content);
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 4. Article health (hourly buckets, last 6h capped at windowHours)
+  // -------------------------------------------------------------------------
+  const articleWindow = Math.min(windowHours, 6);
+  const articleWindowStart = new Date(
+    now.getTime() - articleWindow * 60 * 60 * 1000
+  );
+
+  const articlePosts = await db
+    .select({
+      timestamp: posts.timestamp,
+    })
+    .from(posts)
+    .where(
+      and(
+        gte(posts.timestamp, articleWindowStart),
+        isNull(posts.deletedAt),
+        sql`${posts.type} = 'article'`
+      )
+    )
+    .orderBy(desc(posts.timestamp));
+
+  const hourlyBuckets: ArticleSection['hourlyBuckets'] = [];
+  for (let h = 0; h < articleWindow; h++) {
+    const bucketStart = new Date(now.getTime() - (h + 1) * 60 * 60 * 1000);
+    const bucketEnd = new Date(now.getTime() - h * 60 * 60 * 1000);
+    const count = articlePosts.filter(
+      (p) => p.timestamp >= bucketStart && p.timestamp < bucketEnd
+    ).length;
+    hourlyBuckets.unshift({
+      hour: bucketStart.toISOString().slice(0, 13) + ':00',
+      count,
+      flags: count > ARTICLES_PER_HOUR_WARN ? ['FLOOD'] : [],
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // 5. Group chat quality
+  // -------------------------------------------------------------------------
+  const chatWindowStart = new Date(now.getTime() - 60 * 60 * 1000); // last 1h
+  const groupChatIds = await db
+    .select({ id: chats.id })
+    .from(chats)
+    .where(sql`${chats.isGroup} = true`);
+
+  const groupChatIdSet = new Set(groupChatIds.map((c) => c.id));
+  const totalGroupChats = groupChatIdSet.size;
+
+  let recentMessages = 0;
+  const shortMessages: GroupChatSection['shortMessages'] = [];
+  const msgsPerChat: Record<string, number> = {};
+
+  if (groupChatIdSet.size > 0) {
+    const recentMsgs = await db
+      .select({
+        chatId: messages.chatId,
+        senderId: messages.senderId,
+        content: messages.content,
+        createdAt: messages.createdAt,
+      })
+      .from(messages)
+      .where(gte(messages.createdAt, chatWindowStart))
+      .orderBy(desc(messages.createdAt));
+
+    for (const msg of recentMsgs) {
+      if (!groupChatIdSet.has(msg.chatId)) continue;
+      recentMessages++;
+      msgsPerChat[msg.chatId] = (msgsPerChat[msg.chatId] ?? 0) + 1;
+      if (msg.content.trim().length < GROUP_MSG_MIN_CHARS) {
+        shortMessages.push({
+          chatId: msg.chatId,
+          senderId: msg.senderId,
+          content: msg.content.trim(),
+        });
+      }
+    }
+  }
+
+  const floodedChats = Object.entries(msgsPerChat)
+    .filter(([, count]) => count > GROUP_MSG_PER_HOUR_WARN)
+    .map(([chatId, count]) => ({ chatId, msgsPerHour: count }));
+
+  // -------------------------------------------------------------------------
+  // 6. Staleness
+  // -------------------------------------------------------------------------
+  const allTopLevel = rawPosts; // already filtered to top-level in window
+
+  const lastNpcPost = allTopLevel.find((p) => npcIds.has(p.authorId));
+  const lastOrgPost = allTopLevel.find((p) => orgIds.has(p.authorId));
+
+  const lastArticle = rawPosts.find((p) => p.type === 'article');
+
+  const npcStaleMins = lastNpcPost
+    ? (now.getTime() - lastNpcPost.timestamp.getTime()) / 60000
+    : Number.POSITIVE_INFINITY;
+  const orgStaleMins = lastOrgPost
+    ? (now.getTime() - lastOrgPost.timestamp.getTime()) / 60000
+    : Number.POSITIVE_INFINITY;
+
+  const npcStale = npcStaleMins > STALE_NPC_POST_MIN;
+  const orgStale = orgStaleMins > STALE_ORG_POST_MIN;
+
+  // -------------------------------------------------------------------------
+  // Assemble report
+  // -------------------------------------------------------------------------
+  const report: FeedHealthReport = {
+    generatedAt: now.toISOString(),
+    windowHours,
+    distribution: {
+      totalPosts: rawPosts.length,
+      byType,
+      byCategory,
+      npcTopPosters,
+      orgTopPosters,
+    },
+    duplicates: {
+      exactDupes,
+      firstWordsDupes,
+      sameAuthorNearDupes,
+      warnings:
+        exactDupes.length + firstWordsDupes.length + sameAuthorNearDupes.length,
+    },
+    articles: {
+      totalArticles: articlePosts.length,
+      hourlyBuckets,
+      warnings: hourlyBuckets.filter((b) => b.flags.includes('FLOOD')).length,
+    },
+    groupChats: {
+      totalGroupChats,
+      recentMessages,
+      shortMessages: shortMessages.slice(0, 20),
+      floodedChats,
+      warnings: shortMessages.length + floodedChats.length,
+    },
+    staleness: {
+      lastNpcPostAt: lastNpcPost?.timestamp.toISOString() ?? null,
+      lastOrgPostAt: lastOrgPost?.timestamp.toISOString() ?? null,
+      lastArticleAt: lastArticle?.timestamp.toISOString() ?? null,
+      npcStale,
+      orgStale,
+      warnings: (npcStale ? 1 : 0) + (orgStale ? 1 : 0),
+    },
+  };
+
+  return report;
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable printer
+// ---------------------------------------------------------------------------
+function printReport(r: FeedHealthReport): void {
+  const line = `${dim}${'─'.repeat(70)}${reset}`;
+  console.log(
+    `\n${bold}${cyan}=== FEED HEALTH REPORT — ${r.generatedAt} ===${reset}`
+  );
+  console.log(`${dim}Window: last ${r.windowHours}h${reset}\n`);
+
+  // Distribution
+  console.log(`${bold}POST DISTRIBUTION${reset}`);
+  console.log(line);
+  const d = r.distribution;
+  console.log(`  Total top-level posts: ${bold}${d.totalPosts}${reset}`);
+  console.log('  By type:');
+  for (const [type, count] of Object.entries(d.byType).sort(
+    (a, b) => b[1] - a[1]
+  )) {
+    console.log(`    ${type.padEnd(22)} ${count}`);
+  }
+  console.log('  By author category:');
+  for (const [cat, count] of Object.entries(d.byCategory)) {
+    console.log(`    ${cat.padEnd(22)} ${count}`);
+  }
+  if (d.npcTopPosters.length > 0) {
+    console.log('  Top NPC posters:');
+    for (const p of d.npcTopPosters.slice(0, 5)) {
+      const flag =
+        p.flags.length > 0 ? ` ${yellow}[${p.flags.join(',')}]${reset}` : '';
+      console.log(`    ${p.id.padEnd(30)} ${p.count} posts${flag}`);
+    }
+  }
+  if (d.orgTopPosters.length > 0) {
+    console.log('  Top org posters:');
+    for (const p of d.orgTopPosters.slice(0, 5)) {
+      const flag =
+        p.flags.length > 0 ? ` ${yellow}[${p.flags.join(',')}]${reset}` : '';
+      console.log(`    ${p.id.padEnd(30)} ${p.count} posts${flag}`);
+    }
+  }
+
+  // Duplicates
+  console.log(`\n${bold}DUPLICATE DETECTION${reset}`);
+  console.log(line);
+  const dup = r.duplicates;
+  if (
+    dup.exactDupes.length === 0 &&
+    dup.firstWordsDupes.length === 0 &&
+    dup.sameAuthorNearDupes.length === 0
+  ) {
+    console.log(`  ${OK} No duplicates detected in window`);
+  }
+  for (const d of dup.exactDupes) {
+    console.log(
+      `  ${ERR} Exact dupe ×${d.count}: "${d.content}" (authors: ${d.authors.slice(0, 3).join(', ')})`
+    );
+  }
+  for (const d of dup.firstWordsDupes) {
+    console.log(
+      `  ${WARN} First-${FIRST_WORDS_N}-words dupe ×${d.count}: "${d.prefix}…" (authors: ${d.authors.slice(0, 3).join(', ')})`
+    );
+  }
+  for (const d of dup.sameAuthorNearDupes.slice(0, 5)) {
+    console.log(
+      `  ${WARN} Same-author near-dupe within ${d.windowMin}min: [${d.authorId}]`
+    );
+    console.log(`    A: "${d.content1}"`);
+    console.log(`    B: "${d.content2}"`);
+  }
+
+  // Articles
+  console.log(
+    `\n${bold}ARTICLE HEALTH (last ${Math.min(r.windowHours, 6)}h)${reset}`
+  );
+  console.log(line);
+  const art = r.articles;
+  console.log(`  Total articles: ${art.totalArticles}`);
+  for (const b of art.hourlyBuckets) {
+    const flag = b.flags.includes('FLOOD')
+      ? ` ${WARN} FLOOD > ${ARTICLES_PER_HOUR_WARN}/hr`
+      : '';
+    console.log(`  ${b.hour}  ${String(b.count).padStart(3)} articles${flag}`);
+  }
+  if (art.warnings === 0) {
+    console.log(`  ${OK} Article rate nominal`);
+  }
+
+  // Group chats
+  console.log(`\n${bold}GROUP CHAT QUALITY (last 1h)${reset}`);
+  console.log(line);
+  const gc = r.groupChats;
+  console.log(
+    `  Group chats: ${gc.totalGroupChats}   Messages (1h): ${gc.recentMessages}`
+  );
+  if (gc.floodedChats.length > 0) {
+    for (const f of gc.floodedChats) {
+      console.log(
+        `  ${WARN} Chat flood: ${f.chatId} — ${f.msgsPerHour} msgs/hr (>${GROUP_MSG_PER_HOUR_WARN})`
+      );
+    }
+  }
+  if (gc.shortMessages.length > 0) {
+    console.log(
+      `  ${WARN} ${gc.shortMessages.length} messages under ${GROUP_MSG_MIN_CHARS} chars:`
+    );
+    for (const m of gc.shortMessages.slice(0, 5)) {
+      console.log(`    [${m.senderId}] "${m.content}"`);
+    }
+  }
+  if (gc.warnings === 0) {
+    console.log(`  ${OK} Group chat quality nominal`);
+  }
+
+  // Staleness
+  console.log(`\n${bold}FEED STALENESS${reset}`);
+  console.log(line);
+  const s = r.staleness;
+  const npcLabel = s.lastNpcPostAt
+    ? ago(new Date(s.lastNpcPostAt))
+    : 'never (in window)';
+  const orgLabel = s.lastOrgPostAt
+    ? ago(new Date(s.lastOrgPostAt))
+    : 'never (in window)';
+  const artLabel = s.lastArticleAt
+    ? ago(new Date(s.lastArticleAt))
+    : 'none in window';
+
+  console.log(
+    `  ${s.npcStale ? WARN : OK} Last NPC post:     ${npcLabel}${s.npcStale ? ` ${yellow}(>${STALE_NPC_POST_MIN}min — cron may be down?)${reset}` : ''}`
+  );
+  console.log(
+    `  ${s.orgStale ? WARN : OK} Last org post:     ${orgLabel}${s.orgStale ? ` ${yellow}(>${STALE_ORG_POST_MIN}min — org-tick may be down?)${reset}` : ''}`
+  );
+  console.log(`  ${OK} Last article:      ${artLabel}`);
+
+  // Summary
+  const totalWarnings =
+    r.duplicates.warnings +
+    r.articles.warnings +
+    r.groupChats.warnings +
+    r.staleness.warnings;
+
+  console.log(`\n${bold}SUMMARY${reset}`);
+  console.log(line);
+  if (totalWarnings === 0) {
+    console.log(`  ${OK} Feed is healthy — no warnings\n`);
+  } else {
+    console.log(`  ${WARN} ${totalWarnings} warning(s) found — review above\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+const report = await run();
+
+if (outputJson) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  printReport(report);
+}


### PR DESCRIPTION
## Summary

**Mission**: QA Data feeds — make sure the data is good, make sure the feed NPC chat is good, make sure no duplicate posts, etc — feed should be good.

### Root causes fixed

1. **Arc event coverage was in-memory only** — `NewsArticlePacingEngine.arcEventCoverage` reset on every restart/cold start, causing duplicate articles for the same arc event after each deploy.

2. **BreakingArticleRateLimiter was in-memory** — breaking article timestamps were lost on restart, causing breaking-article bursts post-deploy.

3. **Cross-NPC topic dedup was per-process** — `TopicDiversityService` (singleton, per-agent) couldn't see what other NPCs posted in other processes. Two NPCs could post near-identical content in the same tick.

4. **Group chat had no message quality guards** — one-word fragments and near-duplicate messages within a chat window could be posted.

### Changes

| File | Change |
|------|--------|
| `packages/db/src/schema/narrative.ts` | New `arc_event_coverage` table |
| `packages/db/drizzle/migrations/0068_add_arc_event_coverage.sql` | DB migration |
| `packages/engine/src/services/event-generation-helpers.ts` | Replace `arcEventPacer` with DB reads/writes for arc coverage; `hasEventBeenCovered` and `markEventAsCovered` are now `async` DB-backed |
| `packages/engine/src/services/article-rate-limiter.ts` | `BreakingArticleRateLimiterService` now counts from DB (posts table) instead of in-memory timestamps; `tryReserveSlot`, `canGenerateArticle`, `getRemainingSlots` are now `async` |
| `packages/agents/src/autonomous/DirectExecutors.ts` | `executeDirectPost` queries last 20 recent posts, rejects if Jaccard similarity ≥ 0.5 with any NPC post in the past 10 min |
| `packages/engine/src/services/npc-group-dynamics-service.ts` | `postGroupMessages` rejects messages < 20 chars, < 3 words, or ≥ 0.5 Jaccard similarity to any message in the past 5 min in the same chat |
| `scripts/feed-health.ts` | New dev tool: `bun run report:feed` — post distribution, duplicate detection, article flood, group chat quality, feed staleness |
| `packages/testing/unit/feed-dedup.test.ts` | 24 new unit tests |
| `packages/testing/integration/feed-health.integration.test.ts` | 13 new integration tests |

### Dev tool

```bash
bun run report:feed           # human-readable with [OK]/[WARN] flags
bun run report:feed -- --json # machine-readable JSON
bun run report:feed -- --hours=6  # narrow window
```

## Test plan

- [x] `bun run check` — Biome format + lint, zero warnings
- [x] `bun run typecheck` — all packages pass
- [x] `bun run lint` — turbo lint, zero warnings
- [x] `bun test packages/testing/unit/feed-dedup.test.ts` — 24/24 pass
- [x] `bun test packages/testing/integration/feed-health.integration.test.ts` — 13/13 pass
- [ ] Run `bun run report:feed` against live DB after migration to verify health output
- [ ] Run `bun run db:migrate` to apply migration 0068

Made with [Cursor](https://cursor.com)