### PR TITLE
docs: overhaul README for GitHub release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,399 +1,412 @@
 <div align="center">
 
-  <h1>🎮 Babylon</h1>
+# Babylon
 
-  <p><strong>A multiplayer prediction market game with autonomous AI agents and continuous RL training</strong></p>
-  
-  <p>
-    <a href="https://docs.babylon.market"><img src="https://img.shields.io/badge/docs-available-blue" alt="Documentation"></a>
-    <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.0-blue" alt="TypeScript"></a>
-    <a href="https://soliditylang.org/"><img src="https://img.shields.io/badge/Solidity-0.8-363636" alt="Solidity"></a>
-    <a href="https://arxiv.org/abs/2501.06781"><img src="https://img.shields.io/badge/arXiv-2501.06781-b31b1b.svg" alt="Paper" width=116 height=20></a>
-  </p>
+**A satirical prediction market game powered by autonomous AI agents**
+
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Bun](https://img.shields.io/badge/Bun-1.3+-fbf0df?logo=bun)](https://bun.sh)
+[![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+
 </div>
-
 
 ---
 
-A real-time prediction market game with autonomous NPCs, perpetual futures, and gamified social mechanics.
+Babylon is a live social simulation where players trade on prediction markets alongside cast of AI-powered NPCs. A continuous game engine generates satirical social posts, breaking news, market events, and world narratives every minute. Players and autonomous agents alike make bets on outcomes — which tech CEO will rug-pull next, which AI company will miss its timeline — using parody versions of real people and organizations.
 
-**NOTE**: This project is under active development. Expect incomplete features and moving interfaces.
+- **Social feed** — LLM-generated posts from 100+ NPCs (AIlon Musk, Sam AIltman, Mark Zuckerborg...) with distinct voices, relationships, and insider knowledge
+- **Prediction markets** — Binary outcome markets resolving on game events; NPCs trade with privileged signal, players infer from public clues
+- **Perpetuals** — Off-chain simulated perp markets on parody assets (TSLAI, OPENAGI, NVAIDAI, BTC...)
+- **Real-time SSE** — Feed, market prices, and chat update live without polling
+- **Autonomous agents** — ElizaOS-compatible agents connect via A2A/MCP and trade alongside NPCs
+- **Training pipeline** — RL/fine-tuning pipeline and ScamBench harness for agent evaluation
 
-## 📦 Installation
+> **Status:** Active development. The core game loop, auth, and feed generation are production-ready. The crypto/NFT stack is disabled. Training and agent frameworks are in active iteration.
 
-**Requirements:**
-- Node.js >= 18.0.0 (for Error cause support)
-- Bun >= 1.3.0
+---
+
+## Table of Contents
+
+- [Architecture](#architecture)
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Environment Variables](#environment-variables)
+- [Monorepo Structure](#monorepo-structure)
+- [Development](#development)
+- [Dev Tools](#dev-tools)
+- [Testing](#testing)
+- [Simulation & Training](#simulation--training)
+- [Deployment](#deployment)
+- [Contributing](#contributing)
+
+---
+
+## Architecture
+
+```
+apps/
+  web/          ← Next.js 16 app (UI, API routes, SSE, cron endpoints)
+  cli/          ← Bun CLI (db, game, agent commands)
+  mobile/       ← Capacitor mobile shell
+
+packages/
+  engine/       ← Game engine: ticks, feed/world generation, prompts, LLM client
+  core/         ← Domain: prediction markets, perpetuals, market utilities
+  db/           ← Drizzle ORM schema, migrations, DB client
+  api/          ← Auth middleware, user provisioning, API helpers
+  agents/       ← Autonomous agent logic, ElizaOS plugins, cron behavior
+  shared/       ← Types, constants, utilities shared across packages
+  a2a/          ← Agent-to-Agent protocol integration
+  mcp/          ← Model Context Protocol server
+  training/     ← RL pipeline, ScamBench harness, HF/W&B integration
+  pack-default/ ← Default NPC/organization content pack
+  examples/     ← Example agents, harness, local A2A server
+```
+
+**Data flow:** Cron → `game-tick` → `GameWorld` (hidden facts, events) → `FeedGenerator` (LLM posts per character) + `PredictionMarketService` + perps pricing → SSE broadcast → clients.
+
+**LLM inference:** Defaults to [ElizaCloud](https://elizacloud.ai) (`ELIZACLOUD_API_KEY`). Falls back to Groq → Anthropic → OpenAI.
+
+**Auth:** [Steward](https://steward.fi) — self-hostable JWT auth with social OAuth (Google, Discord, Twitter/X), magic links, and passkeys. Runs as a sibling Docker service in development.
+
+---
+
+## Prerequisites
+
+- **Bun** ≥ 1.3 — [install](https://bun.sh)
+- **Docker** — for Postgres, Redis, MinIO, and Steward auth
+- **LLM API key** — ElizaCloud (recommended), Groq, OpenAI, or Anthropic
+- **Sibling Steward repo** — required for local auth (see [Quick Start](#quick-start))
+
+---
+
+## Quick Start
+
+### 1. Clone and install
 
 ```bash
 git clone https://github.com/BabylonSocial/babylon.git
 cd babylon
 bun install
+```
 
-# Setup environment & database
+### 2. Set up Steward (auth service)
+
+Babylon uses [Steward](https://github.com/Steward-Fi/steward) for authentication. Clone it as a sibling directory:
+
+```bash
+cd ..
+git clone https://github.com/Steward-Fi/steward.git
+cd babylon
+```
+
+### 3. Configure environment
+
+```bash
 cp .env.example .env
-bun run db:push
 ```
 
----
-
-## 🚀 Quick Start
+Edit `.env` — the minimum required values:
 
 ```bash
-# 1. Install
-bun install
+# LLM inference (pick one)
+ELIZACLOUD_API_KEY=eliza_...        # recommended — multi-provider gateway
+# GROQ_API_KEY=gsk_...             # fast alternative
+# OPENAI_API_KEY=sk-...
 
-# 2. Configure environment
-cp .env.example .env
-# (Optional) Create .env.local for Next.js-only overrides
-# Edit .env (and optionally .env.local) with your Privy credentials + GROQ_API_KEY
+# Auth (Steward)
+STEWARD_JWT_SECRET=dev-jwt-secret-change-in-prod   # change in production
+STEWARD_TENANT_API_KEY=stw_...                      # from steward init
 
-# 3. Setup database
-bun run db:push
-bun run db:seed
-
-# 4. (Optional) Enable Agent0 Integration
-# Add to .env:
-# AGENT0_ENABLED=true
-# BASE_SEPOLIA_RPC_URL=...
-# BABYLON_GAME_PRIVATE_KEY=...
-# Then configure Agent0: babylon agent agent0-config
-
-# 5. Start development
-bun run dev   # ← Automatically starts web + game engine!
+# Cron
+CRON_SECRET=your-cron-secret
 ```
 
-Visit `http://localhost:3000` - everything runs and generates content automatically!
-
----
-
-### Development Modes
-
-**Default Mode** (Recommended):
-```bash
-bun run dev   # ← Web + Game Engine (both automatically!)
-```
-Runs web server plus the local cron simulator. Content is generated via cron endpoints every 60 seconds.
-
-**Web Only** (UI/API only, no local cron simulator):
-```bash
-bun run dev:web
-```
-Use if you're only working on frontend and don't need live cron-driven content.
-
-**Next.js Only** (Run Next directly):
-```bash
-bun run dev:next-only
-```
-Useful if you want to bypass Turbo and run the Next dev flow directly.
-
-### Real-Time Updates
-
-The application uses **Server-Sent Events (SSE)** for real-time updates (Vercel-compatible):
-- Feed updates (new posts)
-- Market price changes
-- Breaking news
-- Chat messages
-
-**For Production (Vercel):** Optionally set up Redis for cross-instance broadcasting:
-```bash
-# Add to Vercel environment variables
-UPSTASH_REDIS_REST_URL=https://your-redis-url.upstash.io
-UPSTASH_REDIS_REST_TOKEN=your-token
-```
-
----
-
-## 🚀 Development
+### 4. Start everything
 
 ```bash
-# Start dev server
 bun run dev
-
-# Build & test
-bun run build
-bun run typecheck
-bun run lint
-bun run test
 ```
 
-Visit `http://localhost:3000`
+This will:
+1. Start Docker services (Postgres on `:5433`, Redis on `:6380`, MinIO on `:9000`, Steward on `:3200`)
+2. Push the DB schema and seed initial data
+3. Start the Next.js dev server on `:3000`
+4. Start the local cron simulator (fires game ticks every 60s)
 
----
+Visit **http://localhost:3000** — the game engine begins generating content automatically.
 
-## 🤖 AI Assistants (Ruler)
-
-This repo uses **Ruler** to centralize AI coding instructions in `.ruler/**`.
+### 5. Initialize Steward tenant (first run only)
 
 ```bash
-# Install deps
-bun install
-
-# Generate local agent config files (gitignored)
-bun run ruler:apply
+bun run steward:init
 ```
 
-- Edit rules in `.ruler/**` only (generated files like `AGENTS.md`, `CLAUDE.md`, MCP configs should not be edited manually).
-- For OpenAI Codex CLI to pick up the project config/MCP, set `CODEX_HOME="$(pwd)/.codex"`.
+This provisions the Babylon tenant in your local Steward instance.
 
 ---
 
-## 🧪 Testing
+## Environment Variables
+
+See `.env.example` for the full annotated list. Key groups:
+
+| Group | Variables | Notes |
+|-------|-----------|-------|
+| **Database** | `DATABASE_URL`, `DIRECT_DATABASE_URL` | Postgres; local default on port 5433 |
+| **Auth (Steward)** | `STEWARD_JWT_SECRET`, `STEWARD_TENANT_API_KEY`, `NEXT_PUBLIC_STEWARD_API_URL`, `STEWARD_API_URL` | Required for login |
+| **LLM** | `ELIZACLOUD_API_KEY`, `GROQ_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` | At least one required for content generation |
+| **Cache** | `REDIS_URL`, `KV_REST_API_URL` | Optional locally; required for SSE in multi-instance deploys |
+| **Storage** | `BLOB_READ_WRITE_TOKEN` | Vercel Blob; MinIO used locally |
+| **Game** | `GAME_START`, `CRON_SECRET` | `GAME_START=true` enables auto-ticks |
+| **Social OAuth** | `DISCORD_CLIENT_ID/SECRET`, `TWITTER_CLIENT_ID/SECRET` | Optional; enables social login via Steward |
+| **Agents** | `BABYLON_A2A_API_KEY` | For external agents connecting via A2A protocol |
+
+Run `bun run env:validate` to check required variables before starting.
+
+---
+
+## Monorepo Structure
+
+### Apps
+
+| App | Description |
+|-----|-------------|
+| `apps/web` | Primary Next.js app — UI, API routes, SSE, Steward auth wiring |
+| `apps/cli` | `babylon` CLI — db migrations, game control, agent management |
+| `apps/mobile` | Capacitor mobile shell |
+| `apps/dag-visualizer` | Visual DAG explorer for game-tick data flow (port 4000) |
+
+### Packages
+
+| Package | Description |
+|---------|-------------|
+| `packages/engine` | Game engine: tick orchestration, `FeedGenerator`, `GameWorld`, `GameGenerator`, LLM client, prompts |
+| `packages/core` | Pure domain: prediction markets, perpetuals, pricing, CPMM |
+| `packages/db` | Drizzle ORM schema, migrations, lazy DB client |
+| `packages/api` | Steward JWT middleware, user provisioning, rate limiting, blob helpers |
+| `packages/agents` | Autonomous agent logic, ElizaOS plugins, `TopicDiversityService`, agent cron |
+| `packages/shared` | Shared types, content analysis utilities, Jaccard similarity, logging |
+| `packages/a2a` | Agent-to-Agent protocol integration (`@a2a-js/sdk`) |
+| `packages/mcp` | Model Context Protocol server for tool-using agents |
+| `packages/training` | RL pipeline, ScamBench harness (OpenClaw, Hermes, Eliza adapters), HF/W&B integration |
+| `packages/pack-default` | Default NPC and organization content pack (actors, orgs) |
+| `packages/sim` | Standalone simulation CLI |
+| `packages/testing` | Shared test utilities, integration helpers |
+| `packages/examples` | Example agents: TypeScript agent, LangGraph agent, local A2A server, training harness |
+
+---
+
+## Development
+
+### Commands
+
+| Command | What it does |
+|---------|-------------|
+| `bun run dev` | Start web + cron simulator + Docker services |
+| `bun run dev:web` | Web only (no cron simulator) |
+| `bun run check` | Biome format + lint (auto-fix) |
+| `bun run typecheck` | TypeScript across all packages |
+| `bun run lint` | Turbo lint (zero warnings) |
+| `bun run build` | Production build |
+| `bun run db:generate` | Generate Drizzle migration files |
+| `bun run db:migrate` | Apply migrations |
+| `bun run db:seed` | Seed initial game data |
+| `bun run db:studio` | Open Drizzle Studio (DB browser) |
+| `bun run env:validate` | Validate environment completeness |
+
+### Quality gates (run before every commit)
 
 ```bash
-bun run test:unit           # Unit tests
-bun run test:integration    # Integration tests
-bun run test:e2e           # E2E tests
-bun run contracts:test     # Smart contracts
+bun run check       # Biome format + lint (auto-fix)
+bun run typecheck   # TypeScript across all packages
+bun run lint        # Turbo lint (zero warnings required)
+bun run test:unit   # Unit tests
 ```
 
-To skip chain-dependent tests (e.g. in CI when Hardhat/localnet is not available), set `SKIP_CHAIN_TESTS=1`.
+### Docker services
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| Postgres | 5433 | Main database |
+| Redis | 6380 | Cache, sessions, SSE pubsub |
+| MinIO | 9000 / 9001 | S3-compatible storage (API / console) |
+| Steward | 3200 | Auth service |
+
+Start services manually: `docker compose up -d`
 
 ---
 
-## 🚢 Deploy to Vercel
+## Dev Tools
+
+The `scripts/` directory has several introspection tools for working on game content, prompts, and markets. All run against the live database without starting the server.
+
+### Context Inspector
+
+Inspect exactly what context an NPC or autonomous agent receives before an LLM call:
+
+```bash
+# Full rendered prompt for NPC trading decision
+bun run inspect:context -- --npc ailon-musk --type trading --raw
+
+# Section breakdown with token counts and ghost-variable detection
+bun run inspect:context -- --npc ailon-musk --type trading
+
+# Posting context (feed generation)
+bun run inspect:context -- --npc ailon-musk --type posting
+
+# Autonomous agent context (multi-step executor pipeline)
+bun run inspect:context -- --agent <userId> --raw
+
+# Aggregate stats across all NPCs
+bun run inspect:context -- --npc all --summary
+```
+
+### Market Reports
+
+```bash
+# Market diversity: topic clustering, entity over-representation, near-duplicates
+bun run report:markets
+bun run report:markets -- --verbose   # full question texts
+bun run report:markets -- --history 7 # trend over 7 days
+
+# Market realism: price stability, volatility, NPC trade sizing
+bun run report:realism
+
+# Training data quality
+bun run report:training-quality
+```
+
+### Prompt Diff
+
+Compare two versions of a prompt template rendered with the same live context:
+
+```bash
+bun scripts/prompt-diff.ts \
+  --old "git:HEAD~1:packages/engine/src/prompts/trading/npc-market-decisions.ts" \
+  --new packages/engine/src/prompts/trading/npc-market-decisions.ts
+```
+
+### Prompt Validation
+
+```bash
+# Run the static prompt pipeline validation suite (29 checks)
+bun run scripts/validate-prompts.ts
+```
+
+---
+
+## Testing
+
+```bash
+bun run test:unit           # Unit tests (pure logic, no DB)
+bun run test:integration    # Integration tests (requires DB + Redis)
+bun run test:e2e            # End-to-end (Playwright)
+```
+
+Integration tests require a running Postgres instance. The CI workflow starts one automatically; locally use `docker compose up -d postgres redis`.
+
+To skip chain-dependent tests: `SKIP_CHAIN_TESTS=1 bun run test:integration`
+
+---
+
+## Simulation & Training
+
+### Run a game simulation locally
+
+```bash
+# Core world simulation (generates narrative events)
+bun run sim:core
+
+# Full character simulation with content
+bun run sim:characters:local
+
+# Export simulation data
+bun run export:characters:local
+```
+
+### ScamBench / Agent Training
+
+The training pipeline evaluates agent reasoning quality via ScamBench — a benchmark where agents must detect manipulation tactics in prediction market contexts.
+
+Three agent framework adapters are supported:
+
+- **OpenClaw** — bootstrapped to `../external-sources/openclaw`
+- **Hermes** (NousResearch) — bootstrapped to `../external-sources/hermes-agent`
+- **ElizaOS** — native integration via `packages/agents`
+
+Bootstrap agent frameworks (run once):
+
+```bash
+bun run agent-frameworks:bootstrap
+# or skip with: BABYLON_SKIP_AGENT_FRAMEWORKS_BOOTSTRAP=1
+```
+
+The **training harness** in `packages/examples/harness` wires agents against the game engine for evaluation. See `packages/training/SCAMBENCH_RUNBOOK.md` for detailed setup.
+
+---
+
+## Deployment
+
+### Vercel
 
 ```bash
 npm i -g vercel
 vercel deploy --prod
 ```
 
-**Required Environment Variables:**
-
-- `DATABASE_URL` - PostgreSQL connection
-- `NEXT_PUBLIC_PRIVY_APP_ID` (or `PRIVY_APP_ID`) - Privy App ID
-- `PRIVY_APP_SECRET` - Privy backend secret
-- `CRON_SECRET` - Cron authentication
-- At least one LLM key: `GROQ_API_KEY` or `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`
-
-Validate your env files before running the app:
+**Required environment variables for production:**
 
 ```bash
-bun run env:validate
-# optional profiles:
-bun run env:validate:staging
+DATABASE_URL=postgresql://...
+DIRECT_DATABASE_URL=postgresql://...   # for migrations
+ELIZACLOUD_API_KEY=eliza_...           # or GROQ_API_KEY / OPENAI_API_KEY
+STEWARD_JWT_SECRET=<strong-random-secret>
+STEWARD_TENANT_API_KEY=stw_...
+NEXT_PUBLIC_STEWARD_API_URL=https://your-steward-instance.com
+CRON_SECRET=<strong-random-secret>
+REDIS_URL=rediss://...                 # required for SSE in multi-instance
+GAME_START=true
+```
+
+Validate env before deploying:
+
+```bash
 bun run env:validate:production
 ```
 
-Feature-specific requirements are validated conditionally (Agent0, SendGrid, NFT gating, on-chain perps).
-See `.env.example` for the full list.
+### Cron endpoints
+
+Vercel's cron system (or any scheduler) should hit these endpoints with `Authorization: Bearer $CRON_SECRET`:
+
+| Endpoint | Frequency | Purpose |
+|----------|-----------|---------|
+| `/api/cron/game-tick` | Every minute | Main game tick (feed, markets, events) |
+| `/api/cron/npc-tick` | Every minute | NPC trading decisions |
+| `/api/cron/agent-tick` | Every minute | Autonomous agent actions |
 
 ---
 
-## 🖼️ NFT Deployment (ProtoMonkeys)
+## AI Coding Config (Ruler)
 
-Deploy the ProtoMonkeys NFT collection for the Top 100 leaderboard rewards.
-
-### Local Development (Automatic)
-
-**NFT minting works automatically with `bun run dev`!** The dev startup:
-1. Deploys ProtoMonkeysNFT contract to local Hardhat
-2. Seeds the NFT collection (100 NFTs with placeholder metadata)
-3. Creates eligibility snapshots for all test users
+Agent instructions are centralized in `.ruler/` and generated into `CLAUDE.md` / `AGENTS.md`:
 
 ```bash
-bun run dev   # ← NFT minting ready out of the box!
+bun run ruler:apply   # regenerate AI config files from .ruler/
 ```
 
-Visit `http://localhost:3000/nft` to mint your NFT.
+Edit `.ruler/**` only — never edit `CLAUDE.md` or `AGENTS.md` directly.
 
-### Manual Local Setup (if needed)
-
-```bash
-# 1. Start local Hardhat node
-cd packages/contracts
-bun hardhat:node
-
-# 2. Deploy NFT contract (new terminal)
-NFT_SIGNER_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
-NFT_BASE_URI=http://localhost:3000/api/nft/metadata/ \
-forge script script/DeployProtoMonkeysNFT.s.sol:DeployProtoMonkeysNFTLocal \
-  --rpc-url http://localhost:8545 --broadcast
-
-# 3. Set the deployed address in .env
-NFT_CONTRACT_ADDRESS=<deployed_address>
-NEXT_PUBLIC_CHAIN_ID=31337
-NFT_CHAIN_ID=31337 # (legacy, optional) must match NEXT_PUBLIC_CHAIN_ID/CHAIN_ID
-NFT_SIGNER_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-
-# 4. Seed NFT collection and snapshots
-bun run scripts/seed-nft-collection.ts
-bun run scripts/seed-nft-snapshot-local.ts
-```
-
-### Environment Variables (Production)
-
-```bash
-# NFT Contract Configuration
-NFT_CONTRACT_ADDRESS=0x...          # Set after deployment
-NEXT_PUBLIC_CHAIN_ID=1              # 1 = Mainnet, 11155111 = Sepolia, 31337 = Local
-NFT_CHAIN_ID=1                      # (legacy, optional) must match NEXT_PUBLIC_CHAIN_ID/CHAIN_ID
-NFT_SIGNER_PRIVATE_KEY=0x...        # Backend signer private key (NEVER COMMIT)
-NFT_SIGNER_ADDRESS=0x...            # Public address of signer
-NFT_BASE_URI=https://babylon.market/api/nft/metadata/
-```
-
-Generate a signer keypair for production:
-```bash
-cast wallet new  # Save the private key securely!
-```
-
-### Sepolia Testnet
-
-```bash
-cd packages/contracts
-
-# Deploy to Sepolia
-forge script script/DeployProtoMonkeysNFT.s.sol:DeployProtoMonkeysNFT \
-  --rpc-url https://rpc.sepolia.org \
-  --broadcast --verify
-
-# Update environment
-NFT_CONTRACT_ADDRESS=<deployed_address>
-NEXT_PUBLIC_CHAIN_ID=11155111
-NFT_CHAIN_ID=11155111 # (legacy, optional) must match NEXT_PUBLIC_CHAIN_ID/CHAIN_ID
-```
-
-### Ethereum Mainnet
-
-```bash
-cd packages/contracts
-
-# Deploy to mainnet (requires ETH for gas)
-forge script script/DeployProtoMonkeysNFT.s.sol:DeployProtoMonkeysNFT \
-  --rpc-url https://eth.llamarpc.com \
-  --broadcast --verify
-
-# Update environment
-NFT_CONTRACT_ADDRESS=<deployed_address>
-NEXT_PUBLIC_CHAIN_ID=1
-NFT_CHAIN_ID=1 # (legacy, optional) must match NEXT_PUBLIC_CHAIN_ID/CHAIN_ID
-```
-
-### Post-Deployment Setup
-
-```bash
-# 1. Seed NFT collection with metadata (100 NFTs)
-bun run scripts/seed-nft-collection.ts
-
-# 2. Create eligibility snapshot from leaderboard (top 100 users)
-# This populates the nftSnapshot table for mint eligibility
-```
-
-### Contract Tests
-
-```bash
-cd packages/contracts
-forge test --match-contract ProtoMonkeysNFT -vvv
-```
-
-### Architecture
-
-| Component | Description |
-|-----------|-------------|
-| `ProtoMonkeysNFT.sol` | ERC-721 contract with ECDSA signature-gated minting |
-| `/api/nft/eligibility` | Check if user is in top 100 snapshot |
-| `/api/nft/mint/prepare` | Generate signed mint transaction |
-| `/api/nft/mint/confirm` | Verify on-chain mint, update database |
-| `/api/nft/metadata/[tokenId]` | ERC-721 metadata endpoint |
+For OpenAI Codex CLI: `CODEX_HOME="$(pwd)/.codex"`
 
 ---
 
-## 📚 Documentation
+## Contributing
 
-**[📖 Full Documentation →](https://docs.babylon.market)**
+1. Default branch is **`staging`** (not `main`)
+2. Run `bun run check && bun run typecheck` before committing
+3. Commit style: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:` prefix
+4. Domain logic belongs in `packages/` — `apps/web` is wiring only
+5. No `any`, no broad `try/catch`, no invented behavior
 
-- Smart Contracts: `bun run deploy:local|testnet`
-- RL Training: See `packages/training/README.md`
-- Game Control: `babylon game start|pause|status` (via CLI)
-- **Agent skills & LLM-facing docs**: We expose A2A and MCP; agents need an up-to-date reference.
-  - `bun run docs:generate` — Pulls vendor docs and regenerates skills packages.
-  - `bun run skills:generate` — Skills markdown only. `bun run skills:package` — Full package.
-
----
-
-## 📱 Farcaster Mini App Setup
-
-Babylon is configured as a **Farcaster Mini App** with automatic authentication. Users opening your app from any Farcaster client (e.g., Warpcast) are logged in automatically!
-
-### Prerequisites
-
-- Privy account with Farcaster enabled
-- Production deployment at `https://babylon.market`
-
-### Configuration Steps
-
-#### 1. Configure Privy Dashboard (10 min)
-
-Visit https://dashboard.privy.io/ and configure:
-
-**Enable Farcaster:**
-- Navigate to: **User management → Authentication → Socials**
-- Enable **Farcaster**
-
-**⚠️ CRITICAL: Add Allowed Domains:**
-- Navigate to: **Configuration → App settings → Domains**
-- Add these domains:
-  - ✅ `https://babylon.market` (your production domain)
-  - ⚠️ **`https://farcaster.xyz`** ← **REQUIRED for Mini Apps!**
-  - ✅ `http://localhost:3000` (for development)
-
-> **Why `https://farcaster.xyz`?** Required for iframe-in-iframe support that Farcaster Mini Apps use.
-
-**Set Callback URL:**
-- Add: `https://babylon.market/api/auth/farcaster/callback`
-
-#### 2. Verify Environment Variables
-
-Ensure these are set in production:
-
-```bash
-NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id
-PRIVY_APP_SECRET=your_privy_app_secret
-```
-
-#### 3. Deploy
-
-```bash
-vercel --prod
-```
-
-#### 4. Test in Farcaster
-
-Create a cast in a Farcaster client (e.g., Warpcast):
-```
-Check out Babylon! 🏛️
-
-https://babylon.market
-```
-
-Click to launch → Users are automatically logged in! ✨
-
-### How It Works
-
-1. **Mini App SDK** detects Farcaster context
-2. **Auto-login** triggers via Privy + `@farcaster/miniapp-sdk`
-3. User approves once
-4. **Instant authentication** - no forms or passwords!
-
-### Using Mini App Context in Code
-
-```typescript
-import { useFarcasterMiniApp } from '@/components/providers/FarcasterFrameProvider'
-
-function MyComponent() {
-  const { isMiniApp, fid, username } = useFarcasterMiniApp()
-
-  if (isMiniApp) {
-    return <div>Welcome from Farcaster, {username}!</div>
-  }
-
-  return <div>Welcome to Babylon!</div>
-}
-```
-
-### Key Resources
-
-- **Farcaster Mini Apps**: https://miniapps.farcaster.xyz/
-- **Privy Recipe**: https://docs.privy.io/recipes/farcaster/mini-apps
-- **Mini Apps SDK**: https://github.com/farcaster/miniapp-sdk
+See `CLAUDE.md` for the full coding standards and architecture rules.


### PR DESCRIPTION
## Summary

Complete rewrite of the README — the previous version was significantly outdated (referenced Privy, NFT deployment, Farcaster mini app Privy config, and crypto/wallet stack that have all been removed or disabled).

### What's removed
- Privy auth setup and configuration
- NFT deployment guide (ProtoMonkeys, Foundry scripts, Sepolia/mainnet deploy)
- Farcaster mini app (was Privy-dependent)
- `db:push` presented as the production migration story
- Any reference to on-chain perps as live

### What's added / corrected
- **Steward auth** — actual quick-start with sibling repo clone + `steward:init`
- **Docker services** — Postgres, Redis, MinIO, Steward with correct ports
- **ElizaCloud** as the recommended LLM inference provider
- **Full monorepo table** — all packages and apps with accurate descriptions
- **Dev tools section** — context inspector, market reports, prompt diff, validate-prompts
- **Simulation & training** — `sim:core`, `sim:characters:local`, ScamBench harness, OpenClaw/Hermes/ElizaOS adapters
- **Correct cron endpoints** — `/api/cron/game-tick`, `npc-tick`, `agent-tick`
- **Architecture diagram** — accurate data flow from game-tick through FeedGenerator to SSE
- **Contribution guide** — points to `CLAUDE.md` as single source of truth

## Test plan
- [ ] All commands in Quick Start work end-to-end on a clean checkout
- [ ] All script names match `package.json` entries
- [ ] Docker service ports match `docker-compose.yml`

Made with [Cursor](https://cursor.com)