### PR TITLE
feat(web): gate Speed Insights with sampled RUM and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -304,6 +304,16 @@ SENTRY_PROJECT=
 NEXT_PUBLIC_SENTRY_RELEASE=""
 SENTRY_RELEASE=""
 
+# ============================================
+# VERCEL SPEED INSIGHTS (Optional)
+# ============================================
+# Client-side sampling for Web Vitals: percentage of sessions (0–100). Lower = fewer RUM datapoints.
+# Why: full-funnel RUM scales cost and noise; we keep vitals on high-signal routes + sample sessions.
+# High-signal routes are filtered in code (see apps/web/.../GatedSpeedInsights.tsx).
+# Full rationale, allowlist, migration (old 0–1 fractions), roadmap: docs/observability/speed-insights.md
+# Default when unset: 50 (50%).
+NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE=50
+
 # Sentry Service Hook webhook security (required if using /api/sentry/webhook)
 # Create a secret in Sentry Project Settings > Integrations > Internal Integrations > Webhooks
 SENTRY_WEBHOOK_SECRET=""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Documentation: Vercel Speed Insights (gated RUM)**
+  - **Why (docs)**: Sampling and route gating are operational choices; without written rationale, the next engineer disables “unused” env vars or removes `beforeSend` and accidentally restores 100% RUM volume or loses regressions on core surfaces.
+  - **Artifacts**: `docs/observability/speed-insights.md` (design, env semantics 0–100, default 50%, route allowlist, minimal-layout behavior, migration from legacy fractional env values, roadmap); `docs/observability/README.md` (index); `apps/web/README.md` (web app entry + link to observability docs); root `README.md` (Observability section + env table row).
+  - **Code**: `apps/web/src/components/observability/GatedSpeedInsights.tsx` (file-level and inline **why** comments); wired from `apps/web/src/app/layout.tsx` and `apps/web/src/components/layout/FullAppShellClient.tsx`; `.env.example` cross-links to the doc.
+
 ### Changed
 
 - **Markets trending screener — display formatting & org avatars**

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Babylon is a live social simulation where players trade on prediction markets al
 - [Testing](#testing)
 - [Simulation & Training](#simulation--training)
 - [Deployment](#deployment)
+- [Observability (web)](#observability-web)
 - [Contributing](#contributing)
 
 ---
@@ -161,8 +162,17 @@ See `.env.example` for the full annotated list. Key groups:
 | **Game** | `GAME_START`, `CRON_SECRET` | `GAME_START=true` enables auto-ticks |
 | **Social OAuth** | `DISCORD_CLIENT_ID/SECRET`, `TWITTER_CLIENT_ID/SECRET` | Optional; enables social login via Steward |
 | **Agents** | `BABYLON_A2A_API_KEY` | For external agents connecting via A2A protocol |
+| **Vercel RUM** | `NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE` | Optional — Web Vitals sampling **0–100** (% of sessions); unset defaults to **50**. Route allowlist + rationale: [docs/observability/speed-insights.md](docs/observability/speed-insights.md) |
 
 Run `bun run env:validate` to check required variables before starting.
+
+---
+
+## Observability (web)
+
+Vercel **Speed Insights** is enabled in production builds but **gated**: only selected high-traffic routes contribute vitals, **session sampling** reduces datapoint volume (default **50%** when the env var is omitted), and **minimal / embed** layout skips the component entirely. **Why:** RUM cost and dashboard noise scale with every page view; we keep signal on surfaces where Core Web Vitals correlate with product quality (feed, markets, wallet, etc.).
+
+Details, env migration notes, and roadmap: **[docs/observability/speed-insights.md](docs/observability/speed-insights.md)**.
 
 ---
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,28 @@
+# Babylon Web (`apps/web`)
+
+Next.js application: UI, API routes, SSE, auth wiring, and Vercel Analytics/Speed Insights.
+
+## Observability
+
+- **Vercel Speed Insights** (real-user Web Vitals) is wrapped in **`GatedSpeedInsights`**: route allowlist + session sampling + optional disable for minimal/embed layout.
+- **Why documented centrally:** Operators tune sampling without reading layout code; rationale for allowlists and defaults lives in one place.
+
+Full write-up (WHYs, env vars, route list, roadmap): [`docs/observability/speed-insights.md`](../../docs/observability/speed-insights.md).
+
+## Related docs
+
+| Topic | Location |
+|-------|----------|
+| Observability index | [`docs/observability/README.md`](../../docs/observability/README.md) |
+| Markets / terminal (example feature README) | [`src/app/markets/README.md`](./src/app/markets/README.md) |
+
+## Commands
+
+From repo root:
+
+```bash
+bun run dev:web    # This app only
+bun run build      # Production build (turbo)
+```
+
+See root [`README.md`](../../README.md) for full quality gates and monorepo commands.

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,13 +2,13 @@ import type { Metadata, Viewport } from 'next';
 import './globals.css';
 
 import { Analytics } from '@vercel/analytics/react';
-import { SpeedInsights } from '@vercel/speed-insights/next';
 import { headers } from 'next/headers';
 import { Suspense } from 'react';
 import { Toaster } from 'sonner';
 import { AchievementToastListener } from '@/components/achievements';
 import { FeedAuthBanner } from '@/components/auth/FeedAuthBanner';
 import { GlobalLoginModal } from '@/components/auth/GlobalLoginModal';
+import { GatedSpeedInsights } from '@/components/observability/GatedSpeedInsights';
 import { Providers } from '@/components/providers/Providers';
 import { BottomNav } from '@/components/shared/BottomNav';
 import { MobileHeader } from '@/components/shared/MobileHeader';
@@ -165,7 +165,7 @@ export default async function RootLayout({
           </div>
         </Providers>
         <Analytics />
-        <SpeedInsights />
+        <GatedSpeedInsights disabled={isMinimalLayout} />
       </body>
     </html>
   );

--- a/apps/web/src/components/layout/FullAppShellClient.tsx
+++ b/apps/web/src/components/layout/FullAppShellClient.tsx
@@ -1,10 +1,10 @@
 import { Analytics } from '@vercel/analytics/react';
-import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Suspense } from 'react';
 import { Toaster } from 'sonner';
 import { AchievementToastListener } from '@/components/achievements';
 import { FeedAuthBanner } from '@/components/auth/FeedAuthBanner';
 import { GlobalLoginModal } from '@/components/auth/GlobalLoginModal';
+import { GatedSpeedInsights } from '@/components/observability/GatedSpeedInsights';
 import { Providers } from '@/components/providers/Providers';
 import { BottomNav } from '@/components/shared/BottomNav';
 import { MobileHeader } from '@/components/shared/MobileHeader';
@@ -58,7 +58,7 @@ export function FullAppShellClient({
         </Suspense>
       </div>
       <Analytics />
-      <SpeedInsights />
+      <GatedSpeedInsights />
     </Providers>
   );
 }

--- a/apps/web/src/components/observability/GatedSpeedInsights.tsx
+++ b/apps/web/src/components/observability/GatedSpeedInsights.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+/**
+ * Gated Vercel Speed Insights (real-user Web Vitals).
+ *
+ * **Why not raw `<SpeedInsights />` in the root layout?** A global component reports
+ * from essentially every navigation. That inflates RUM cost and dilutes dashboards with
+ * admin/settings/builder traffic that is not representative of the core product shell.
+ *
+ * **Why `beforeSend` instead of mounting only on certain pages?** Once the SDK script
+ * is injected it typically stays for the SPA session; conditional mount alone does not
+ * guarantee zero events after cross-route navigation. Filtering events keeps behavior
+ * predictable and matches how we think about “which URLs matter for perf.”
+ *
+ * **Why `sampleRate`?** Vercel’s SDK supports client-side sampling. We expose it via
+ * `NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE` as **0–100** (percent) because operators
+ * reason in percentages, not 0–1 floats.
+ *
+ * **Why `disabled`?** Minimal / embed layouts (`x-minimal-layout`) are not comparable
+ * to the full app (different chrome and assets); skipping avoids biased vitals and cost.
+ *
+ * @see docs/observability/speed-insights.md — full rationale, env table, roadmap.
+ */
+import { SpeedInsights } from '@vercel/speed-insights/next';
+import { useCallback, useMemo } from 'react';
+
+/**
+ * Prefix allowlist for URLs whose vitals we keep.
+ * **Why a static list in code:** Explicit and reviewable in PRs; env-only lists are easy
+ * to mis-type and drop all telemetry silently. Change here + update the doc together.
+ */
+const TRACKED_ROUTE_PREFIXES = [
+  '/feed',
+  '/markets',
+  '/game',
+  '/wallet',
+  '/profile',
+  '/u/',
+  '/post/',
+  '/chats',
+  '/notifications',
+  '/leaderboard',
+  '/research',
+  '/ticker',
+  '/share/',
+  '/article/',
+  '/comment/',
+] as const;
+
+function shouldRecordPathname(pathname: string): boolean {
+  if (pathname === '/') {
+    return true;
+  }
+  for (const prefix of TRACKED_ROUTE_PREFIXES) {
+    // Match both `/feed` and `/feed/...` so dynamic segments stay included.
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Reads `NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE` as **0–100** (percent of sessions).
+ * **Why default 50:** Balance between catching regressions with enough samples and
+ * keeping RUM volume (and cost) bounded under traffic spikes; tune per environment in Vercel.
+ * **Why clamp:** Mis-set values must not produce invalid SDK input.
+ * @returns Fraction in [0, 1] for Vercel’s `sampleRate` prop.
+ */
+function parseSampleFractionFromEnvPercent(): number {
+  const raw = process.env.NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE;
+  if (raw === undefined || raw === '') {
+    return 0.5;
+  }
+  const percent = Number.parseFloat(raw);
+  if (!Number.isFinite(percent)) {
+    return 0.5;
+  }
+  const clamped = Math.min(100, Math.max(0, percent));
+  return clamped / 100;
+}
+
+type VitalEvent = {
+  type: 'vital';
+  url: string;
+  route?: string;
+};
+
+export function GatedSpeedInsights({
+  disabled = false,
+}: {
+  /** When true, do not mount Speed Insights (e.g. minimal embed layout). */
+  disabled?: boolean;
+}) {
+  const sampleRate = useMemo(() => parseSampleFractionFromEnvPercent(), []);
+
+  const beforeSend = useCallback((event: VitalEvent) => {
+    let pathname: string;
+    try {
+      pathname = new URL(event.url).pathname;
+    } catch {
+      // Malformed `event.url` should never take down the page; drop the event.
+      return false;
+    }
+    // Returning `false` drops the vital before it is sent — primary RUM cost control per route.
+    return shouldRecordPathname(pathname) ? event : false;
+  }, []);
+
+  if (disabled) {
+    return null;
+  }
+
+  return <SpeedInsights beforeSend={beforeSend} sampleRate={sampleRate} />;
+}

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,9 @@
+# Observability
+
+Client and server instrumentation for operating Babylon in production.
+
+| Doc | What it covers |
+|-----|----------------|
+| [Speed Insights (Vercel RUM)](./speed-insights.md) | Real-user Web Vitals: why we gate and sample, env vars, route list, roadmap |
+
+Related: error tracking and performance traces live in Sentry (see `.env.example`); product analytics in PostHog.

--- a/docs/observability/speed-insights.md
+++ b/docs/observability/speed-insights.md
@@ -1,0 +1,88 @@
+# Vercel Speed Insights (real user monitoring)
+
+Babylon uses [@vercel/speed-insights](https://vercel.com/docs/speed-insights) on the Next.js app (`apps/web`) to collect **Core Web Vitals** and related performance signals from real browsers.
+
+Instrumentation is implemented in **`GatedSpeedInsights`** (`apps/web/src/components/observability/GatedSpeedInsights.tsx`) and mounted from the root layout (and mirrored in the legacy full shell client for consistency).
+
+---
+
+## Why gate routes?
+
+**Problem:** With `<SpeedInsights />` in the root layout, **every navigation** can produce RUM datapoints. High-traffic apps pay for volume and noise: admin pages, settings, agent builders, and embeds rarely need the same perf regression signal as the main game surfaces.
+
+**Approach:** A `beforeSend` hook drops vitals whose URL pathname is **not** on an allowlist of high-signal routes (feed, markets, wallet, profiles, etc.). Product and engineering still see **LCP / INP / CLS** where UX and revenue matter most, without funding a complete census of every screen.
+
+**Caveat:** After the Speed Insights script loads (typically on a user’s first visit to an allowed route in a session), the script remains in the page. **Gating is event-level** (we discard disallowed routes), not “never download the SDK on other routes.” That is enough to cut **billable datapoints** materially while keeping implementation simple and reliable.
+
+---
+
+## Why sample (percentage)?
+
+**Problem:** Even on key routes, **100% sampling** multiplies events with traffic spikes (viral posts, bots, refresh-heavy trading UIs). Vercel bills Speed Insights on usage tiers tied to datapoint volume.
+
+**Approach:** We pass Vercel’s supported **`sampleRate`** (0–1 internally), driven by a single env var expressed as **0–100** so operators think in “percent of sessions,” not decimals.
+
+**Why default 50% when unset:** A single default has to balance **statistical usefulness** (enough samples to see regressions within days, not months) against **cost**. Fifty percent is a deliberate compromise: teams that need tighter monitoring can set `100`; cost-sensitive deploys can set `10` or `20` without code changes.
+
+**Why clamp 0–100:** Prevents misconfiguration (`200` or negative values) from producing invalid SDK input or surprising behavior. `0` effectively disables vitals reporting for sampled traffic (script may still load; see Vercel docs for edge behavior).
+
+---
+
+## Why disable on minimal layout?
+
+Some responses use the **`x-minimal-layout: 1`** header (embeds / stripped chrome). Those surfaces are not representative of the main app shell (different layout, fewer assets). **Why skip RUM there:** Avoid polluting aggregates with incomparable LCP/CLS and avoid paying for instrumentation on low-product-value views.
+
+---
+
+## Configuration
+
+| Variable | Meaning |
+|----------|---------|
+| `NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE` | Optional. **Integer or float from 0 to 100** = percentage of sessions that report vitals. **Unset → 50** (50%). |
+
+Examples:
+
+```bash
+# Default in code when variable is omitted: 50
+# Explicit examples:
+NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE=100   # full sampling on allowed routes
+NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE=25    # quarter of sessions
+NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE=0     # no vitals (maximum savings)
+```
+
+**Migration note:** If an older deployment used a **fraction** (e.g. `0.15` meaning “15%”), that value is now interpreted as **0.15%**. Update to **`15`** for fifteen percent.
+
+---
+
+## Allowed routes (high signal)
+
+The allowlist lives in code as `TRACKED_ROUTE_PREFIXES` plus the homepage `/`. **Why these:** They combine high **traffic**, **latency sensitivity** (trading, chat, feed), or **acquisition** (share links, articles).
+
+To add a route: edit `GatedSpeedInsights.tsx` and extend the list (prefer path **prefixes** so dynamic segments stay covered). Update this doc in the same PR so operators know what is measured.
+
+---
+
+## Local development
+
+Speed Insights **does not send production telemetry in development** (Vercel SDK behavior). You will still see the debug script path when running `next dev`; use a preview/production deploy to validate sampling.
+
+---
+
+## Roadmap
+
+Ordered by likely value vs. effort:
+
+1. **Env-driven route allowlist (optional)** — Why: Some teams want marketing-only or “checkout-only” measurement without redeploying. A `NEXT_PUBLIC_SPEED_INSIGHTS_ROUTES` comma-separated prefix list could override defaults; empty = use code defaults. **Risk:** Env mistakes silently drop all routes — needs validation logging in dev only.
+
+2. **Defer script injection until first allowed route** — Why: Fewer bytes and less third-party work on cold loads to settings-only flows. **Tradeoff:** First vitals on a deep-linked allowed page might be slightly delayed; must not break Next’s `SpeedInsights` expectations.
+
+3. **Dashboard alignment** — Why: If Vercel adds first-class sampling controls in the project UI, we should document precedence (env vs. dashboard) to avoid double-effective sampling confusion.
+
+4. **Correlation with Sentry / PostHog** — Why: Tie Web Vital regressions to release version or experiments. Depends on stable `release` and environment tags elsewhere in the stack.
+
+---
+
+## References
+
+- Vercel: [Speed Insights](https://vercel.com/docs/speed-insights)
+- Package: `@vercel/speed-insights` — `sampleRate`, `beforeSend` on `<SpeedInsights />` (see `node_modules/@vercel/speed-insights/dist/next/index.d.ts`)


### PR DESCRIPTION
Route allowlist and NEXT_PUBLIC_SPEED_INSIGHTS_SAMPLE_RATE (0–100, default 50) reduce Vercel RUM volume; minimal layout skips the component. Document rationale, env migration, and roadmap in docs/observability; link from root and apps/web READMEs and CHANGELOG.

Made-with: Cursor